### PR TITLE
Add audio file support with Flick integration for external playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Locker is a secure, private media vault application built with Flutter for Andro
 
 - **Image Viewer**: Full-screen image viewing with pinch-to-zoom and slideshow mode
 - **Video Player**: Built-in video player with playback controls, speed adjustment, and loop options
+- **Song Player**: Built-in audio playback with external app handoff support
 - **Document Viewer**: Native PDF rendering and Office document conversion for viewing
 - **File Export**: Export files to Downloads folder or open with external applications
 - **Performance Overlay**: Real-time display of FPS and performance metrics
@@ -501,6 +502,7 @@ Built with the following open-source libraries:
 Additional documentation available:
 
 - [Architecture Diagram](docs/architecture_media.md) - Detailed system architecture design covering compression, encryption, and file operations
+- [Flick Integration Guide](docs/flick_integration.md) - Contract and implementation notes for making Flick a first-class Locker playback companion
 
 ---
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:taskAffinity=""
             android:excludeFromRecents="true"
             android:theme="@style/LaunchTheme"
@@ -57,6 +57,18 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+
+            <!-- Lets Flick return the user to the running Locker task. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="locker"
+                    android:host="return" />
             </intent-filter>
         </activity>
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -85,6 +85,7 @@
          https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
          In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
     <queries>
+        <package android:name="com.ultraelectronica.flick" />
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>

--- a/android/app/src/main/kotlin/com/ultraelectronica/locker/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ultraelectronica/locker/MainActivity.kt
@@ -1,11 +1,15 @@
 package com.ultraelectronica.locker
 
+import android.content.ActivityNotFoundException
+import android.content.ClipData
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
 import android.view.Display
 import android.view.WindowManager
+import androidx.core.content.FileProvider
 import io.flutter.embedding.android.FlutterFragmentActivity
 
 import io.flutter.embedding.engine.FlutterEngine
@@ -15,6 +19,8 @@ import java.io.File
 class MainActivity: FlutterFragmentActivity() {
     private val CHANNEL = "com.ultraelectronica.locker/autokill"
     private val MEDIA_SCANNER_CHANNEL = "com.example.vault/media_scanner"
+    private val FLICK_CHANNEL = "com.ultraelectronica.locker/flick"
+    private val FLICK_PACKAGE = "com.ultraelectronica.flick"
     private var isAutoKillEnabled = true
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -46,11 +52,92 @@ class MainActivity: FlutterFragmentActivity() {
                 else -> result.notImplemented()
             }
         }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, FLICK_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isFlickInstalled" -> result.success(isPackageInstalled(FLICK_PACKAGE))
+                "openAudioInFlick" -> {
+                    val path = call.argument<String>("filePath")
+                    val mimeType = call.argument<String>("mimeType")
+
+                    if (path.isNullOrBlank()) {
+                        result.error("INVALID_ARGUMENT", "File path is required", null)
+                    } else {
+                        openAudioInFlick(path, mimeType, result)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+    }
+
+    private fun isPackageInstalled(packageName: String): Boolean {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+            } else {
+                @Suppress("DEPRECATION")
+                packageManager.getPackageInfo(packageName, 0)
+            }
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            false
+        }
+    }
+
+    private fun openAudioInFlick(
+        filePath: String,
+        mimeType: String?,
+        result: MethodChannel.Result,
+    ) {
+        try {
+            if (!isPackageInstalled(FLICK_PACKAGE)) {
+                result.error("FLICK_NOT_INSTALLED", "Flick is not installed", null)
+                return
+            }
+
+            val file = File(filePath)
+            if (!file.exists()) {
+                result.error("FILE_NOT_FOUND", "File does not exist: $filePath", null)
+                return
+            }
+
+            val resolvedMimeType = mimeType?.takeIf { it.isNotBlank() } ?: "audio/*"
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                addCategory(Intent.CATEGORY_DEFAULT)
+                setPackage(FLICK_PACKAGE)
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                val authority = "${applicationContext.packageName}.fileProvider.com.crazecoder.openfile"
+                val uri = FileProvider.getUriForFile(applicationContext, authority, file)
+
+                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                intent.clipData = ClipData.newUri(contentResolver, file.name, uri)
+                intent.setDataAndType(uri, resolvedMimeType)
+                grantUriPermission(FLICK_PACKAGE, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            } else {
+                intent.setDataAndType(Uri.fromFile(file), resolvedMimeType)
+            }
+
+            if (intent.resolveActivity(packageManager) == null) {
+                result.error("FLICK_UNAVAILABLE", "Flick cannot open this audio file", null)
+                return
+            }
+
+            startActivity(intent)
+            result.success(true)
+        } catch (e: ActivityNotFoundException) {
+            result.error("FLICK_UNAVAILABLE", "Flick cannot handle this file", e.message)
+        } catch (e: Exception) {
+            result.error("FLICK_OPEN_FAILED", "Failed to open Flick", e.message)
+        }
     }
 
     private fun scanMediaFile(filePath: String, result: MethodChannel.Result) {

--- a/android/app/src/main/kotlin/com/ultraelectronica/locker/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ultraelectronica/locker/MainActivity.kt
@@ -47,7 +47,12 @@ class MainActivity: FlutterFragmentActivity() {
             }
         }
     }
-    
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+    }
+
     private fun scanMediaFile(filePath: String, result: MethodChannel.Result) {
         try {
             val file = File(filePath)

--- a/docs/flick_integration.md
+++ b/docs/flick_integration.md
@@ -1,0 +1,183 @@
+# Flick Integration Guide
+
+## Goal
+
+Flick should behave like a first-class playback companion for Locker:
+
+- Locker hands Flick a hidden song with a normal Android audio `VIEW` intent.
+- Flick plays that URI directly without copying it into public storage.
+- Flick exposes an explicit `Back to Locker` action.
+- Returning from Flick should foreground the existing Locker task when it is already running.
+
+This keeps the two apps feeling like one ecosystem instead of two unrelated apps.
+
+## Locker Contract
+
+Locker now exposes these Android integration points:
+
+- Locker package: `com.ultraelectronica.locker`
+- Return URI: `locker://return`
+- Main activity launch mode: `singleTask`
+- Return intent filter: `ACTION_VIEW` on `locker://return`
+
+What that means for Flick:
+
+- If Locker is already open in the background, opening `locker://return` will bring that existing task forward.
+- If Locker is not running, Android will cold-start it.
+- Locker does not need a custom action for v1. Standard Android `VIEW` for audio is enough.
+
+## What Flick Should Implement
+
+### 1. Accept standard Android audio `VIEW` intents
+
+Flick should expose an exported playback activity that can handle audio sent from Locker.
+
+Recommended manifest shape:
+
+```xml
+<activity
+    android:name=".player.ExternalPlaybackActivity"
+    android:exported="true">
+
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:scheme="content" />
+        <data android:mimeType="audio/*" />
+    </intent-filter>
+</activity>
+```
+
+Notes:
+
+- Supporting `content://` is the important part.
+- Keep MIME support broad: `audio/*`.
+- You can add narrower types later if you want analytics or specialized handling.
+- Do not require custom permissions from Locker.
+
+## 2. Read the incoming URI directly
+
+Locker will hand Flick a temporary readable audio URI. Flick should stream from it instead of copying it into gallery-visible storage.
+
+If Flick uses Media3 / ExoPlayer, the flow should look like this:
+
+```kotlin
+val audioUri = intent?.data ?: return
+
+val mediaItem = MediaItem.fromUri(audioUri)
+player.setMediaItem(mediaItem)
+player.prepare()
+player.playWhenReady = true
+```
+
+If Flick does any preflight validation, do it through `ContentResolver`:
+
+```kotlin
+contentResolver.openAssetFileDescriptor(audioUri, "r")?.use {
+    // URI is readable
+}
+```
+
+Important behavior:
+
+- Do not move the file into shared storage.
+- Do not rescan it into the media library.
+- Do not assume the URI is permanent.
+- Release the URI and player resources when playback is done.
+
+## 3. Preserve Locker's privacy model
+
+Flick should treat Locker-supplied media as temporary private content.
+
+Recommended rules on the Flick side:
+
+- No background indexing of Locker media.
+- No automatic caching to public folders.
+- No automatic cloud sync for the handed-off file.
+- No thumbnail export into gallery-visible locations.
+- If caching is needed for playback stability, keep it inside Flick's private app storage and clean it up aggressively.
+
+## 4. Add a dedicated `Back to Locker` action
+
+Do not rely only on Android back-stack behavior. It may feel okay in some cases, but explicit return is more reliable and intentional.
+
+Flick should expose a visible action in the player UI such as:
+
+- `Back to Locker`
+- `Return to Locker`
+- `Done in Flick`
+
+Recommended implementation:
+
+```kotlin
+private fun returnToLocker(context: Context) {
+    val intent = Intent(
+        Intent.ACTION_VIEW,
+        Uri.parse("locker://return?source=flick")
+    ).apply {
+        `package` = "com.ultraelectronica.locker"
+        addCategory(Intent.CATEGORY_BROWSABLE)
+        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    }
+
+    context.startActivity(intent)
+}
+```
+
+Why this is the right shape:
+
+- `package = "com.ultraelectronica.locker"` makes the return deterministic.
+- `locker://return` matches Locker's manifest contract.
+- `CLEAR_TOP` and `SINGLE_TOP` help Android reuse the running Locker activity instead of creating unnecessary duplicates.
+
+If you want to be defensive, wrap the launch in a `try/catch` and fall back to a normal `finish()` if Locker is unavailable.
+
+## 5. Keep Flick's package name stable
+
+For the first version, Locker can still hand off audio through the normal Android app chooser or generic open flow.
+
+For tighter ecosystem integration later, Locker will need Flick's stable Android package name so it can:
+
+- detect whether Flick is installed
+- show a dedicated `Play with Flick` action
+- target Flick directly instead of showing every compatible audio app
+
+So on the Flick side, avoid changing the package identifier casually once you settle on one.
+
+## Recommended UX Flow
+
+1. User taps a song in Locker.
+2. Locker can either play it internally or hand it to Flick.
+3. Flick opens directly on a playback screen.
+4. Flick makes it obvious the track came from Locker.
+5. User taps `Back to Locker`.
+6. Flick launches `locker://return`.
+7. Locker comes back to the foreground in its existing state.
+
+Good small UX touches in Flick:
+
+- Show a small `Opened from Locker` label.
+- Keep the return action visible without burying it in a menu.
+- If playback fails, offer `Back to Locker` in the error state too.
+
+## Test Checklist
+
+Run these checks before calling the integration done:
+
+1. Launch an MP3 from Locker into Flick.
+2. Verify Flick can read the URI without copying it to public storage.
+3. Verify playback works for at least `mp3`, `m4a`, and `ogg`.
+4. Tap `Back to Locker` and confirm the existing Locker task returns.
+5. Confirm Locker is not duplicated in recents.
+6. Confirm the handed-off song does not appear in gallery/music scanners because of Flick.
+7. Confirm closing Flick does not leave stale temp playback state behind.
+
+## Future Tightening
+
+Once Flick's package name is final, Locker can add a dedicated package-targeted handoff path. That would allow:
+
+- a direct `Play with Flick` button in Locker
+- an install check for Flick
+- skipping the generic app chooser when Flick is present
+
+The v1 contract in this document is enough to start building the ecosystem now.

--- a/docs/flick_integration.md
+++ b/docs/flick_integration.md
@@ -16,6 +16,7 @@ This keeps the two apps feeling like one ecosystem instead of two unrelated apps
 Locker now exposes these Android integration points:
 
 - Locker package: `com.ultraelectronica.locker`
+- Flick package: `com.ultraelectronica.flick`
 - Return URI: `locker://return`
 - Main activity launch mode: `singleTask`
 - Return intent filter: `ACTION_VIEW` on `locker://return`
@@ -132,17 +133,18 @@ Why this is the right shape:
 
 If you want to be defensive, wrap the launch in a `try/catch` and fall back to a normal `finish()` if Locker is unavailable.
 
-## 5. Keep Flick's package name stable
+## 5. Package-targeted handoff
 
-For the first version, Locker can still hand off audio through the normal Android app chooser or generic open flow.
+Locker now knows Flick's package name and can target it directly:
 
-For tighter ecosystem integration later, Locker will need Flick's stable Android package name so it can:
+- Flick package: `com.ultraelectronica.flick`
+- Locker can detect whether Flick is installed
+- Locker can show a dedicated `Play with Flick` action
+- Locker can skip the generic app chooser when the user explicitly wants Flick
 
-- detect whether Flick is installed
-- show a dedicated `Play with Flick` action
-- target Flick directly instead of showing every compatible audio app
+That makes the handoff deterministic and keeps the two-app flow feeling tighter.
 
-So on the Flick side, avoid changing the package identifier casually once you settle on one.
+Because of that, Flick's package identifier should now be treated as part of the integration contract.
 
 ## Recommended UX Flow
 
@@ -172,12 +174,13 @@ Run these checks before calling the integration done:
 6. Confirm the handed-off song does not appear in gallery/music scanners because of Flick.
 7. Confirm closing Flick does not leave stale temp playback state behind.
 
-## Future Tightening
+## Locker-side implementation status
 
-Once Flick's package name is final, Locker can add a dedicated package-targeted handoff path. That would allow:
+Locker is configured to support this integration now:
 
-- a direct `Play with Flick` button in Locker
-- an install check for Flick
-- skipping the generic app chooser when Flick is present
+- `locker://return` is registered in Locker's manifest
+- Locker uses `singleTask` so the existing task can be foregrounded again
+- Locker can query `com.ultraelectronica.flick`
+- Locker can offer a dedicated `Play with Flick` action for songs when Flick is installed
 
-The v1 contract in this document is enough to start building the ecosystem now.
+The remaining work is fully on Flick's side: accept the URI, play it, and provide the explicit return affordance.

--- a/lib/models/vaulted_file.dart
+++ b/lib/models/vaulted_file.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 enum VaultedFileType {
   image,
   video,
+  song,
   document,
   other;
 
@@ -13,6 +14,8 @@ enum VaultedFileType {
         return 'Image';
       case VaultedFileType.video:
         return 'Video';
+      case VaultedFileType.song:
+        return 'Song';
       case VaultedFileType.document:
         return 'Document';
       case VaultedFileType.other:
@@ -26,6 +29,7 @@ enum VaultedFileType {
         return 'picture_icon.png';
       case VaultedFileType.video:
         return 'video_icon.png';
+      case VaultedFileType.song:
       case VaultedFileType.document:
       case VaultedFileType.other:
         return 'otherfiles_icon.png';
@@ -38,6 +42,9 @@ enum VaultedFileType {
         return VaultedFileType.image;
       case 'video':
         return VaultedFileType.video;
+      case 'song':
+      case 'audio':
+        return VaultedFileType.song;
       case 'document':
         return VaultedFileType.document;
       default:
@@ -310,6 +317,9 @@ class VaultedFile {
   /// Check if file is a document
   bool get isDocument => type == VaultedFileType.document;
 
+  /// Check if file is a song
+  bool get isSong => type == VaultedFileType.song;
+
   /// Get tag count
   int get tagCount => tags.length;
 
@@ -389,6 +399,16 @@ const List<String> supportedDocumentExtensions = [
   'epub',
 ];
 
+/// Supported audio extensions
+const List<String> supportedAudioExtensions = [
+  'mp3',
+  'wav',
+  'flac',
+  'aac',
+  'ogg',
+  'm4a',
+];
+
 /// Get file type from extension
 VaultedFileType getFileTypeFromExtension(String extension) {
   final ext = extension.toLowerCase().replaceAll('.', '');
@@ -397,6 +417,8 @@ VaultedFileType getFileTypeFromExtension(String extension) {
     return VaultedFileType.image;
   } else if (supportedVideoExtensions.contains(ext)) {
     return VaultedFileType.video;
+  } else if (supportedAudioExtensions.contains(ext)) {
+    return VaultedFileType.song;
   } else if (supportedDocumentExtensions.contains(ext)) {
     return VaultedFileType.document;
   }
@@ -411,6 +433,8 @@ VaultedFileType getFileTypeFromMime(String mimeType) {
     return VaultedFileType.image;
   } else if (mime.startsWith('video/')) {
     return VaultedFileType.video;
+  } else if (mime.startsWith('audio/')) {
+    return VaultedFileType.song;
   } else if (mime.startsWith('application/pdf') ||
       mime.startsWith('application/msword') ||
       mime.startsWith('application/vnd.') ||

--- a/lib/screens/album_detail_screen.dart
+++ b/lib/screens/album_detail_screen.dart
@@ -12,6 +12,7 @@ import '../utils/toast_utils.dart';
 import '../utils/responsive_utils.dart';
 import 'media_viewer_screen.dart';
 import 'document_viewer_screen.dart';
+import 'song_player_screen.dart';
 
 /// Screen for viewing album details and files
 class AlbumDetailScreen extends ConsumerStatefulWidget {
@@ -316,6 +317,10 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
         icon = Icons.videocam;
         color = Colors.red;
         break;
+      case VaultedFileType.song:
+        icon = Icons.music_note;
+        color = Colors.purple;
+        break;
       case VaultedFileType.document:
         icon = Icons.description;
         color = Colors.green;
@@ -451,6 +456,13 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
             files: viewerFiles.isNotEmpty ? viewerFiles : [file],
             initialIndex: initialIndex >= 0 ? initialIndex : 0,
           ),
+        ),
+      );
+    } else if (file.isSong) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => SongPlayerScreen(file: file),
         ),
       );
     } else if (file.isDocument) {
@@ -1203,6 +1215,10 @@ class _AddFilesToAlbumSheetState extends ConsumerState<_AddFilesToAlbumSheet> {
       case VaultedFileType.video:
         icon = Icons.videocam;
         color = Colors.red;
+        break;
+      case VaultedFileType.song:
+        icon = Icons.music_note;
+        color = Colors.purple;
         break;
       case VaultedFileType.document:
         icon = Icons.description;

--- a/lib/screens/document_picker_screen.dart
+++ b/lib/screens/document_picker_screen.dart
@@ -143,10 +143,26 @@ class DocumentPickerScreen extends StatefulWidget {
   /// Title for the app bar
   final String title;
 
+  /// Extensions allowed in the picker.
+  final List<String> allowedExtensions;
+
+  /// Singular label for the selected file type.
+  final String itemLabel;
+
+  /// Plural label for the selected file type.
+  final String itemLabelPlural;
+
+  /// Icon for the empty/loading state.
+  final IconData stateIcon;
+
   const DocumentPickerScreen({
     super.key,
     this.maxSelection = 0,
     this.title = 'Select Documents',
+    this.allowedExtensions = supportedDocumentExtensions,
+    this.itemLabel = 'document',
+    this.itemLabelPlural = 'documents',
+    this.stateIcon = Icons.description_outlined,
   });
 
   @override
@@ -161,12 +177,19 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
   String _searchQuery = '';
   DocumentSortOption _sortOption = DocumentSortOption.dateDesc;
   final _searchController = TextEditingController();
-  String _currentFolder = 'All Documents';
+  late String _currentFolder;
   final Map<String, List<DocumentFile>> _folderGroups = {};
+
+  String get _allItemsLabel => 'All ${widget.itemLabelPlural}';
+
+  String get _itemLabelPluralCapitalized =>
+      widget.itemLabelPlural[0].toUpperCase() +
+      widget.itemLabelPlural.substring(1);
 
   @override
   void initState() {
     super.initState();
+    _currentFolder = _allItemsLabel;
     _scanForDocuments();
   }
 
@@ -191,9 +214,9 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
       if (!hasPermission) {
         setState(() {
           _isLoading = false;
-          _error = 'Storage permission is required to browse documents';
-        });
-        return;
+            _error = 'Storage permission is required to browse documents';
+          });
+          return;
       }
 
       final foundDocuments = <DocumentFile>[];
@@ -244,7 +267,7 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
 
       // Group by folder
       _folderGroups.clear();
-      _folderGroups['All Documents'] = foundDocuments;
+      _folderGroups[_allItemsLabel] = foundDocuments;
       for (final doc in foundDocuments) {
         final folder = Directory(doc.path).parent.path.split('/').last;
         _folderGroups.putIfAbsent(folder, () => []).add(doc);
@@ -303,7 +326,7 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
               ? fileName.split('.').last.toLowerCase()
               : '';
 
-          if (supportedDocumentExtensions.contains(ext)) {
+          if (widget.allowedExtensions.contains(ext)) {
             try {
               final stat = await entity.stat();
               results.add(DocumentFile(
@@ -329,7 +352,7 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
 
   /// Get filtered and sorted documents
   List<DocumentFile> get _filteredDocuments {
-    var docs = _currentFolder == 'All Documents'
+    var docs = _currentFolder == _allItemsLabel
         ? List<DocumentFile>.from(_documents)
         : List<DocumentFile>.from(_folderGroups[_currentFolder] ?? []);
 
@@ -477,7 +500,7 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
         controller: _searchController,
         onChanged: (value) => setState(() => _searchQuery = value),
         decoration: InputDecoration(
-          hintText: 'Search documents...',
+          hintText: 'Search ${widget.itemLabelPlural}...',
           hintStyle: TextStyle(
             fontFamily: 'ProductSans',
             color: context.textTertiary,
@@ -555,9 +578,9 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
                   child: Row(
                     children: [
                       Icon(
-                        folder == 'All Documents'
-                            ? Icons.folder_special
-                            : Icons.folder,
+                         folder == _allItemsLabel
+                             ? Icons.folder_special
+                             : Icons.folder,
                         size: 18,
                         color: context.accentColor,
                       ),
@@ -638,7 +661,7 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
           ),
           const SizedBox(height: 16),
           Text(
-            'Scanning for documents...',
+            'Scanning for ${widget.itemLabelPlural}...',
             style: TextStyle(
               fontFamily: 'ProductSans',
               fontSize: 16,
@@ -699,15 +722,15 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Icon(
-            Icons.description_outlined,
+            widget.stateIcon,
             size: 64,
             color: context.textTertiary,
           ),
           const SizedBox(height: 16),
           Text(
             _searchQuery.isNotEmpty
-                ? 'No documents matching "$_searchQuery"'
-                : 'No documents found',
+                ? 'No ${widget.itemLabelPlural} matching "$_searchQuery"'
+                : 'No ${widget.itemLabelPlural} found',
             style: TextStyle(
               fontFamily: 'ProductSans',
               fontSize: 18,
@@ -716,7 +739,7 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
           ),
           const SizedBox(height: 8),
           Text(
-            'Documents will appear here when found on your device',
+            'Your ${widget.itemLabelPlural} will appear here when found on your device',
             textAlign: TextAlign.center,
             style: TextStyle(
               fontFamily: 'ProductSans',
@@ -930,7 +953,7 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
           ElevatedButton.icon(
             onPressed: _confirmSelection,
             icon: const Icon(Icons.check, size: 20),
-            label: const Text('Hide Selected'),
+            label: Text('Hide $_itemLabelPluralCapitalized'),
             style: ElevatedButton.styleFrom(
               backgroundColor: context.accentColor,
               foregroundColor: Colors.white,

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -12,6 +12,7 @@ import '../utils/toast_utils.dart';
 import '../utils/responsive_utils.dart';
 import 'media_viewer_screen.dart';
 import 'document_viewer_screen.dart';
+import 'song_player_screen.dart';
 
 /// Screen for viewing favorite files
 class FavoritesScreen extends ConsumerStatefulWidget {
@@ -264,8 +265,8 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
                 ),
               ),
             ),
-          // Document name
-          if (file.isDocument)
+          // Non-visual file name
+          if (file.isDocument || file.isSong)
             Positioned(
               bottom: 8,
               left: 8,
@@ -347,6 +348,10 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
       case VaultedFileType.video:
         icon = Icons.videocam;
         color = Colors.red;
+        break;
+      case VaultedFileType.song:
+        icon = Icons.music_note;
+        color = Colors.purple;
         break;
       case VaultedFileType.document:
         icon = Icons.description;
@@ -471,6 +476,13 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
             files: viewerFiles,
             initialIndex: initialIndex >= 0 ? initialIndex : 0,
           ),
+        ),
+      );
+    } else if (file.isSong) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => SongPlayerScreen(file: file),
         ),
       );
     } else if (file.isDocument) {

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -23,6 +23,7 @@ import 'favorites_screen.dart';
 import 'tags_screen.dart';
 import 'media_viewer_screen.dart';
 import 'document_viewer_screen.dart';
+import 'song_player_screen.dart';
 import '../widgets/permission_warning_banner.dart';
 import 'media_picker_screen.dart';
 import 'document_picker_screen.dart';
@@ -59,7 +60,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 4, vsync: this);
+    _tabController = TabController(length: 5, vsync: this);
     _initializeVault();
   }
 
@@ -100,6 +101,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
                 _buildFileGrid(null, filesAsync),
                 _buildFileGrid(VaultedFileType.image, filesAsync),
                 _buildFileGrid(VaultedFileType.video, filesAsync),
+                _buildFileGrid(VaultedFileType.song, filesAsync),
                 _buildFileGrid(VaultedFileType.document, filesAsync),
               ],
             ),
@@ -373,6 +375,17 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
+                const Icon(Icons.music_note_outlined, size: 18),
+                const SizedBox(width: 6),
+                Text(
+                    'Songs (${files.where((f) => f.type == VaultedFileType.song).length})'),
+              ],
+            ),
+          ),
+          Tab(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
                 const Icon(Icons.description_outlined, size: 18),
                 const SizedBox(width: 6),
                 Text(
@@ -629,8 +642,8 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
                 ),
               ),
             ),
-          // File type badge for documents
-          if (file.isDocument)
+          // File type badge for non-visual files
+          if (file.isDocument || file.isSong)
             Positioned(
               bottom: 8,
               left: 8,
@@ -731,6 +744,10 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
       case VaultedFileType.video:
         icon = Icons.videocam;
         color = Colors.red;
+        break;
+      case VaultedFileType.song:
+        icon = Icons.music_note;
+        color = Colors.purple;
         break;
       case VaultedFileType.document:
         icon = _getDocumentIcon(file.extension);
@@ -853,6 +870,13 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
             files: viewerFiles,
             initialIndex: initialIndex,
           ),
+        ),
+      );
+    } else if (file.isSong) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => SongPlayerScreen(file: file),
         ),
       );
     } else if (file.isDocument) {
@@ -1344,6 +1368,11 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
           subtitle = 'Import videos from gallery or camera';
           icon = Icons.videocam_outlined;
           break;
+        case VaultedFileType.song:
+          title = 'No songs yet';
+          subtitle = 'Import MP3, WAV, FLAC, and more';
+          icon = Icons.music_note_outlined;
+          break;
         case VaultedFileType.document:
           title = 'No documents yet';
           subtitle = 'Import PDFs, Word docs, and more';
@@ -1764,6 +1793,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
         onImportMedia: _importMediaFromGallery,
         onCapturePhoto: _capturePhoto,
         onRecordVideo: _recordVideo,
+        onImportSongs: _importSongs,
         onImportDocuments: _importDocuments,
         onImportAnyFiles: _importAnyFiles,
       ),
@@ -3500,6 +3530,59 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
     }
   }
 
+  Future<void> _importSongs() async {
+    Navigator.pop(context);
+
+    final selectedSongs = await Navigator.push<List<DocumentFile>?>(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const DocumentPickerScreen(
+          title: 'Select Songs to Hide',
+          allowedExtensions: supportedAudioExtensions,
+          itemLabel: 'song',
+          itemLabelPlural: 'songs',
+          stateIcon: Icons.music_note_outlined,
+        ),
+      ),
+    );
+
+    if (selectedSongs == null || selectedSongs.isEmpty) {
+      ToastUtils.showInfo('No songs selected');
+      return;
+    }
+
+    setState(() {
+      _isImporting = true;
+      _importProgress = 0;
+      _importTotal = selectedSongs.length;
+    });
+
+    final result = await _importService.importFromDocumentFiles(
+      filePaths: selectedSongs.map((song) => song.path).toList(),
+      deleteOriginals: true,
+      onProgress: (current, total) {
+        setState(() {
+          _importProgress = current;
+          _importTotal = total;
+        });
+      },
+    );
+
+    setState(() => _isImporting = false);
+
+    if (result.success && result.importedCount > 0) {
+      final msg = result.deletedOriginals
+          ? 'Imported and hidden ${result.importedCount} song(s)'
+          : 'Imported ${result.importedCount} song(s)';
+      ToastUtils.showSuccess(msg);
+      ref.read(vaultNotifierProvider.notifier).loadFiles();
+    } else if (!result.success) {
+      ToastUtils.showError(result.error ?? 'Import failed');
+    } else {
+      ToastUtils.showInfo('No songs imported');
+    }
+  }
+
   Future<void> _importAnyFiles() async {
     Navigator.pop(context);
     setState(() {
@@ -3541,6 +3624,7 @@ class _ImportOptionsSheet extends StatelessWidget {
   final VoidCallback onImportMedia;
   final VoidCallback onCapturePhoto;
   final VoidCallback onRecordVideo;
+  final VoidCallback onImportSongs;
   final VoidCallback onImportDocuments;
   final VoidCallback onImportAnyFiles;
 
@@ -3550,6 +3634,7 @@ class _ImportOptionsSheet extends StatelessWidget {
     required this.onImportMedia,
     required this.onCapturePhoto,
     required this.onRecordVideo,
+    required this.onImportSongs,
     required this.onImportDocuments,
     required this.onImportAnyFiles,
   });
@@ -3662,6 +3747,15 @@ class _ImportOptionsSheet extends StatelessWidget {
                   children: [
                     Expanded(
                       child: _ImportOptionTile(
+                        icon: Icons.music_note_outlined,
+                        label: 'Songs',
+                        color: Colors.purple,
+                        onTap: onImportSongs,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _ImportOptionTile(
                         icon: Icons.description_outlined,
                         label: 'Documents',
                         color: Colors.green,
@@ -3669,9 +3763,14 @@ class _ImportOptionsSheet extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(width: 12),
-                    const Expanded(child: SizedBox()),
-                    const SizedBox(width: 12),
-                    const Expanded(child: SizedBox()),
+                    Expanded(
+                      child: _ImportOptionTile(
+                        icon: Icons.folder_zip_outlined,
+                        label: 'Any Files',
+                        color: Colors.blueGrey,
+                        onTap: onImportAnyFiles,
+                      ),
+                    ),
                   ],
                 ),
                 const SizedBox(height: 24),

--- a/lib/screens/song_player_screen.dart
+++ b/lib/screens/song_player_screen.dart
@@ -1,0 +1,470 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:open_filex/open_filex.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../models/vaulted_file.dart';
+import '../providers/vault_providers.dart';
+import '../services/auto_kill_service.dart';
+import '../themes/app_colors.dart';
+import '../utils/toast_utils.dart';
+
+class SongPlayerScreen extends ConsumerStatefulWidget {
+  final VaultedFile file;
+
+  const SongPlayerScreen({
+    super.key,
+    required this.file,
+  });
+
+  @override
+  ConsumerState<SongPlayerScreen> createState() => _SongPlayerScreenState();
+}
+
+class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen> {
+  final AudioPlayer _player = AudioPlayer();
+
+  bool _isLoading = true;
+  String? _error;
+  File? _playbackFile;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSong();
+  }
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadSong() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      final vaultService = ref.read(vaultServiceProvider);
+      final file = widget.file.isEncrypted && widget.file.encryptionIv != null
+          ? await vaultService.getVaultedFile(widget.file.id)
+          : File(widget.file.vaultPath);
+
+      if (file == null || !await file.exists()) {
+        setState(() {
+          _error = 'Failed to prepare song';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      _playbackFile = file;
+      await _player.setFilePath(file.path);
+
+      if (!mounted) return;
+      setState(() => _isLoading = false);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Failed to load song: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _togglePlayback() async {
+    try {
+      if (_player.playing) {
+        await _player.pause();
+      } else {
+        await _player.play();
+      }
+    } catch (e) {
+      ToastUtils.showError('Playback failed: $e');
+    }
+  }
+
+  Future<void> _seek(Duration position) async {
+    final duration = _player.duration;
+    if (duration == null) return;
+    final target = position > duration ? duration : position;
+    await _player.seek(target);
+  }
+
+  void _toggleFavorite() async {
+    await ref.read(vaultNotifierProvider.notifier).toggleFavorite(widget.file.id);
+    ToastUtils.showSuccess(
+      widget.file.isFavorite ? 'Removed from favorites' : 'Added to favorites',
+    );
+  }
+
+  Future<void> _exportToDownloads() async {
+    try {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => AlertDialog(
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+          content: Row(
+            children: [
+              CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation(AppColors.accent),
+              ),
+              const SizedBox(width: 20),
+              Expanded(
+                child: Text(
+                  'Exporting ${widget.file.originalName}...',
+                  style: const TextStyle(fontFamily: 'ProductSans'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      Directory? downloadsDir;
+      if (Platform.isAndroid) {
+        downloadsDir = Directory('/storage/emulated/0/Download');
+        if (!await downloadsDir.exists()) {
+          downloadsDir = await getExternalStorageDirectory();
+        }
+      } else {
+        downloadsDir = await getDownloadsDirectory();
+      }
+
+      if (downloadsDir == null) {
+        if (mounted) Navigator.pop(context);
+        ToastUtils.showError('Could not access Downloads folder');
+        return;
+      }
+
+      final destinationPath = '${downloadsDir.path}/${widget.file.originalName}';
+      final exportedFile = await ref
+          .read(vaultServiceProvider)
+          .exportFile(widget.file.id, destinationPath);
+
+      if (mounted) Navigator.pop(context);
+
+      if (exportedFile != null) {
+        ToastUtils.showSuccess('Exported to Downloads/${widget.file.originalName}');
+      } else {
+        ToastUtils.showError('Failed to export file');
+      }
+    } catch (e) {
+      if (mounted) Navigator.pop(context);
+      ToastUtils.showError('Failed to export file: $e');
+    }
+  }
+
+  Future<void> _openWithExternalApp() async {
+    try {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => AlertDialog(
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+          content: Row(
+            children: [
+              CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation(AppColors.accent),
+              ),
+              const SizedBox(width: 20),
+              Expanded(
+                child: Text(
+                  'Preparing ${widget.file.originalName}...',
+                  style: const TextStyle(fontFamily: 'ProductSans'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final decryptedFile = await ref
+          .read(vaultServiceProvider)
+          .getVaultedFile(widget.file.id);
+
+      if (mounted) Navigator.pop(context);
+
+      if (decryptedFile != null && await decryptedFile.exists()) {
+        final result =
+            await AutoKillService.runSafe(() => OpenFilex.open(decryptedFile.path));
+        if (result.type != ResultType.done) {
+          ToastUtils.showError('No app found to open this file type');
+        }
+      } else {
+        ToastUtils.showError('Failed to prepare file');
+      }
+    } catch (e) {
+      if (mounted) Navigator.pop(context);
+      ToastUtils.showError('Failed to open file: $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        elevation: 0,
+        title: Text(
+          'Song Player',
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            color: context.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        actions: [
+          IconButton(
+            onPressed: _toggleFavorite,
+            icon: Icon(
+              widget.file.isFavorite ? Icons.favorite : Icons.favorite_border,
+              color: widget.file.isFavorite ? Colors.red : context.textPrimary,
+            ),
+          ),
+          PopupMenuButton<String>(
+            icon: Icon(Icons.more_vert, color: context.textPrimary),
+            onSelected: (value) {
+              switch (value) {
+                case 'export':
+                  _exportToDownloads();
+                  break;
+                case 'external':
+                  _openWithExternalApp();
+                  break;
+              }
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: 'export', child: Text('Export to Downloads')),
+              PopupMenuItem(value: 'external', child: Text('Open with...')),
+            ],
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: _isLoading
+              ? Center(
+                  child: CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation(context.accentColor),
+                  ),
+                )
+              : _error != null
+                  ? _buildErrorState()
+                  : _buildPlayer(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorState() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.error_outline, size: 64, color: Colors.red.shade300),
+          const SizedBox(height: 16),
+          Text(
+            _error ?? 'Something went wrong',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              fontSize: 16,
+              color: context.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: _loadSong,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: context.accentColor,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlayer() {
+    return StreamBuilder<PlayerState>(
+      stream: _player.playerStateStream,
+      builder: (context, playerSnapshot) {
+        final playerState = playerSnapshot.data;
+        final isPlaying = playerState?.playing ?? false;
+        final processingState = playerState?.processingState;
+
+        return StreamBuilder<Duration?>(
+          stream: _player.durationStream,
+          builder: (context, durationSnapshot) {
+            final duration = durationSnapshot.data ?? Duration.zero;
+
+            return StreamBuilder<Duration>(
+              stream: _player.positionStream,
+              builder: (context, positionSnapshot) {
+                final position = positionSnapshot.data ?? Duration.zero;
+                final sliderMax = duration.inMilliseconds.toDouble();
+                final sliderValue = sliderMax == 0
+                    ? 0.0
+                    : position.inMilliseconds.clamp(0, duration.inMilliseconds).toDouble();
+
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Spacer(),
+                    Container(
+                      width: 140,
+                      height: 140,
+                      decoration: BoxDecoration(
+                        color: Colors.purple.withValues(alpha: 0.12),
+                        borderRadius: BorderRadius.circular(32),
+                      ),
+                      child: const Icon(
+                        Icons.music_note,
+                        size: 72,
+                        color: Colors.purple,
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+                    Text(
+                      widget.file.originalName,
+                      textAlign: TextAlign.center,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontFamily: 'ProductSans',
+                        fontSize: 24,
+                        fontWeight: FontWeight.w700,
+                        color: context.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${widget.file.extension.toUpperCase()} • ${widget.file.formattedSize}',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontFamily: 'ProductSans',
+                        fontSize: 14,
+                        color: context.textSecondary,
+                      ),
+                    ),
+                    const Spacer(),
+                    Slider(
+                      value: sliderValue,
+                      max: sliderMax == 0 ? 1 : sliderMax,
+                      activeColor: context.accentColor,
+                      onChanged: sliderMax == 0
+                          ? null
+                          : (value) => _seek(Duration(milliseconds: value.round())),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            _formatDuration(position),
+                            style: TextStyle(
+                              fontFamily: 'ProductSans',
+                              color: context.textSecondary,
+                            ),
+                          ),
+                          Text(
+                            _formatDuration(duration),
+                            style: TextStyle(
+                              fontFamily: 'ProductSans',
+                              color: context.textSecondary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        IconButton(
+                          onPressed: position > const Duration(seconds: 10)
+                              ? () => _seek(position - const Duration(seconds: 10))
+                              : () => _seek(Duration.zero),
+                          icon: Icon(
+                            Icons.replay_10,
+                            color: context.textPrimary,
+                            size: 32,
+                          ),
+                        ),
+                        const SizedBox(width: 24),
+                        Container(
+                          width: 84,
+                          height: 84,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: context.accentColor,
+                          ),
+                          child: IconButton(
+                            onPressed: processingState == ProcessingState.loading ||
+                                    processingState == ProcessingState.buffering
+                                ? null
+                                : _togglePlayback,
+                            icon: Icon(
+                              isPlaying ? Icons.pause : Icons.play_arrow,
+                              color: Colors.white,
+                              size: 40,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 24),
+                        IconButton(
+                          onPressed: duration > const Duration(seconds: 10)
+                              ? () => _seek(position + const Duration(seconds: 10))
+                              : null,
+                          icon: Icon(
+                            Icons.forward_10,
+                            color: context.textPrimary,
+                            size: 32,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                    if (_playbackFile != null)
+                      OutlinedButton.icon(
+                        onPressed: _openWithExternalApp,
+                        icon: const Icon(Icons.open_in_new),
+                        label: const Text('Open with External App'),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: context.textPrimary,
+                          side: BorderSide(color: context.borderColor),
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                      ),
+                  ],
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+
+  String _formatDuration(Duration duration) {
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    final hours = duration.inHours;
+
+    if (hours > 0) {
+      return '$hours:$minutes:$seconds';
+    }
+    return '$minutes:$seconds';
+  }
+}

--- a/lib/screens/song_player_screen.dart
+++ b/lib/screens/song_player_screen.dart
@@ -1,7 +1,5 @@
 import 'dart:io';
-import 'dart:async';
 
-import 'package:audio_session/audio_session.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -31,7 +29,6 @@ class SongPlayerScreen extends ConsumerStatefulWidget {
 class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
     with WidgetsBindingObserver {
   final AudioPlayer _player = AudioPlayer();
-  StreamSubscription<PlayerException>? _playerErrorSubscription;
 
   bool _isLoading = true;
   bool _isCheckingFlick = true;
@@ -44,7 +41,6 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    _playerErrorSubscription = _player.errorStream.listen(_handlePlaybackError);
     _loadSong();
     _loadFlickAvailability();
   }
@@ -55,7 +51,6 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
     if (_reenableAutoKillOnResume) {
       AutoKillService.setEnabled(true);
     }
-    _playerErrorSubscription?.cancel();
     _player.dispose();
     super.dispose();
   }
@@ -85,8 +80,6 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
     });
 
     try {
-      await _configureAudioSession();
-
       final vaultService = ref.read(vaultServiceProvider);
       final file = widget.file.isEncrypted && widget.file.encryptionIv != null
           ? await vaultService.getVaultedFile(widget.file.id)
@@ -101,24 +94,10 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
       }
 
       _playbackFile = file;
-      await _player.stop();
       await _player.setFilePath(file.path);
-      await _player.play();
 
       if (!mounted) return;
       setState(() => _isLoading = false);
-    } on PlayerException catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _error = 'Failed to load song: ${e.message}';
-        _isLoading = false;
-      });
-    } on PlayerInterruptedException catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _error = 'Song loading was interrupted: ${e.message}';
-        _isLoading = false;
-      });
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -133,31 +112,11 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
       if (_player.playing) {
         await _player.pause();
       } else {
-        if (_player.processingState == ProcessingState.completed) {
-          await _player.seek(Duration.zero);
-        }
         await _player.play();
       }
-    } on PlayerException catch (e) {
-      ToastUtils.showError('Playback failed: ${e.message}');
     } catch (e) {
       ToastUtils.showError('Playback failed: $e');
     }
-  }
-
-  Future<void> _configureAudioSession() async {
-    final session = await AudioSession.instance;
-    await session.configure(const AudioSessionConfiguration.music());
-    await session.setActive(true);
-  }
-
-  void _handlePlaybackError(PlayerException error) {
-    if (!mounted) return;
-
-    setState(() {
-      _error = 'Playback failed: ${error.message}';
-      _isLoading = false;
-    });
   }
 
   Future<void> _seek(Duration position) async {

--- a/lib/screens/song_player_screen.dart
+++ b/lib/screens/song_player_screen.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
+import 'dart:async';
 
+import 'package:audio_session/audio_session.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -29,6 +31,7 @@ class SongPlayerScreen extends ConsumerStatefulWidget {
 class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
     with WidgetsBindingObserver {
   final AudioPlayer _player = AudioPlayer();
+  StreamSubscription<PlayerException>? _playerErrorSubscription;
 
   bool _isLoading = true;
   bool _isCheckingFlick = true;
@@ -41,6 +44,7 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _playerErrorSubscription = _player.errorStream.listen(_handlePlaybackError);
     _loadSong();
     _loadFlickAvailability();
   }
@@ -51,6 +55,7 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
     if (_reenableAutoKillOnResume) {
       AutoKillService.setEnabled(true);
     }
+    _playerErrorSubscription?.cancel();
     _player.dispose();
     super.dispose();
   }
@@ -80,6 +85,8 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
     });
 
     try {
+      await _configureAudioSession();
+
       final vaultService = ref.read(vaultServiceProvider);
       final file = widget.file.isEncrypted && widget.file.encryptionIv != null
           ? await vaultService.getVaultedFile(widget.file.id)
@@ -94,10 +101,24 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
       }
 
       _playbackFile = file;
+      await _player.stop();
       await _player.setFilePath(file.path);
+      await _player.play();
 
       if (!mounted) return;
       setState(() => _isLoading = false);
+    } on PlayerException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Failed to load song: ${e.message}';
+        _isLoading = false;
+      });
+    } on PlayerInterruptedException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Song loading was interrupted: ${e.message}';
+        _isLoading = false;
+      });
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -112,11 +133,31 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
       if (_player.playing) {
         await _player.pause();
       } else {
+        if (_player.processingState == ProcessingState.completed) {
+          await _player.seek(Duration.zero);
+        }
         await _player.play();
       }
+    } on PlayerException catch (e) {
+      ToastUtils.showError('Playback failed: ${e.message}');
     } catch (e) {
       ToastUtils.showError('Playback failed: $e');
     }
+  }
+
+  Future<void> _configureAudioSession() async {
+    final session = await AudioSession.instance;
+    await session.configure(const AudioSessionConfiguration.music());
+    await session.setActive(true);
+  }
+
+  void _handlePlaybackError(PlayerException error) {
+    if (!mounted) return;
+
+    setState(() {
+      _error = 'Playback failed: ${error.message}';
+      _isLoading = false;
+    });
   }
 
   Future<void> _seek(Duration position) async {

--- a/lib/screens/song_player_screen.dart
+++ b/lib/screens/song_player_screen.dart
@@ -2,11 +2,13 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../models/vaulted_file.dart';
+import '../services/flick_integration_service.dart';
 import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
 import '../themes/app_colors.dart';
@@ -24,23 +26,51 @@ class SongPlayerScreen extends ConsumerStatefulWidget {
   ConsumerState<SongPlayerScreen> createState() => _SongPlayerScreenState();
 }
 
-class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen> {
+class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
+    with WidgetsBindingObserver {
   final AudioPlayer _player = AudioPlayer();
 
   bool _isLoading = true;
+  bool _isCheckingFlick = true;
+  bool _isFlickAvailable = false;
+  bool _reenableAutoKillOnResume = false;
   String? _error;
   File? _playbackFile;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _loadSong();
+    _loadFlickAvailability();
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    if (_reenableAutoKillOnResume) {
+      AutoKillService.setEnabled(true);
+    }
     _player.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && _reenableAutoKillOnResume) {
+      _reenableAutoKillOnResume = false;
+      AutoKillService.setEnabled(true);
+    }
+  }
+
+  Future<void> _loadFlickAvailability() async {
+    final isAvailable = await FlickIntegrationService.isAvailable();
+    if (!mounted) return;
+
+    setState(() {
+      _isFlickAvailable = isAvailable;
+      _isCheckingFlick = false;
+    });
   }
 
   Future<void> _loadSong() async {
@@ -203,6 +233,39 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       ToastUtils.showError('Failed to open file: $e');
+    }
+  }
+
+  Future<void> _playWithFlick() async {
+    final playbackFile = _playbackFile;
+    if (playbackFile == null) {
+      ToastUtils.showError('Song is not ready yet');
+      return;
+    }
+
+    try {
+      await AutoKillService.setEnabled(false);
+      _reenableAutoKillOnResume = true;
+
+      await FlickIntegrationService.openAudioFile(
+        filePath: playbackFile.path,
+        mimeType: widget.file.mimeType,
+      );
+    } on PlatformException catch (e) {
+      _reenableAutoKillOnResume = false;
+      await AutoKillService.setEnabled(true);
+
+      final message = switch (e.code) {
+        'FLICK_NOT_INSTALLED' => 'Flick is not installed',
+        'FLICK_UNAVAILABLE' => 'Flick cannot open this song',
+        'FILE_NOT_FOUND' => 'Failed to prepare song for Flick',
+        _ => e.message ?? 'Failed to open Flick',
+      };
+      ToastUtils.showError(message);
+    } catch (e) {
+      _reenableAutoKillOnResume = false;
+      await AutoKillService.setEnabled(true);
+      ToastUtils.showError('Failed to open Flick: $e');
     }
   }
 
@@ -436,6 +499,19 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen> {
                       ],
                     ),
                     const SizedBox(height: 24),
+                    if (!_isCheckingFlick && _isFlickAvailable && _playbackFile != null)
+                      FilledButton.icon(
+                        onPressed: _playWithFlick,
+                        icon: const Icon(Icons.music_note),
+                        label: const Text('Play with Flick'),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: Colors.purple,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                      ),
+                    if (!_isCheckingFlick && _isFlickAvailable && _playbackFile != null)
+                      const SizedBox(height: 12),
                     if (_playbackFile != null)
                       OutlinedButton.icon(
                         onPressed: _openWithExternalApp,

--- a/lib/screens/tags_screen.dart
+++ b/lib/screens/tags_screen.dart
@@ -12,6 +12,7 @@ import '../utils/toast_utils.dart';
 import '../utils/responsive_utils.dart';
 import 'media_viewer_screen.dart';
 import 'document_viewer_screen.dart';
+import 'song_player_screen.dart';
 
 /// Predefined tag colors
 final List<Color> tagColors = [
@@ -521,6 +522,10 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
         icon = Icons.videocam;
         color = Colors.red;
         break;
+      case VaultedFileType.song:
+        icon = Icons.music_note;
+        color = Colors.purple;
+        break;
       case VaultedFileType.document:
         icon = Icons.description;
         color = Colors.orange;
@@ -595,6 +600,13 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
             files: viewerFiles,
             initialIndex: initialIndex >= 0 ? initialIndex : 0,
           ),
+        ),
+      );
+    } else if (file.isSong) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => SongPlayerScreen(file: file),
         ),
       );
     } else if (file.isDocument) {

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -37,6 +37,8 @@ class BackupService {
         return 'images';
       case VaultedFileType.video:
         return 'videos';
+      case VaultedFileType.song:
+        return 'songs';
       case VaultedFileType.document:
       case VaultedFileType.other:
         return 'documents';

--- a/lib/services/file_import_service.dart
+++ b/lib/services/file_import_service.dart
@@ -854,8 +854,7 @@ class FileImportService {
     }
   }
 
-  /// Import documents from file paths (from custom document picker)
-  /// This is the preferred method for the custom document picker
+  /// Import files from file paths selected in the custom picker.
   Future<ImportResult> importFromDocumentFiles({
     required List<String> filePaths,
     bool deleteOriginals = true,
@@ -887,11 +886,12 @@ class FileImportService {
 
           final fileName = path.split('/').last;
           final mimeType = lookupMimeType(path) ?? 'application/octet-stream';
+          final type = getFileTypeFromMime(mimeType);
 
           filesToVault.add(FileToVault(
             sourcePath: path,
             originalName: fileName,
-            type: VaultedFileType.document,
+            type: type,
             mimeType: mimeType,
           ));
 
@@ -900,7 +900,7 @@ class FileImportService {
           processed++;
           onProgress?.call(processed, filePaths.length);
 
-          debugPrint('[FileImport] Prepared document for import: $fileName');
+          debugPrint('[FileImport] Prepared file for import: $fileName');
         } catch (e) {
           debugPrint('[FileImport] Error processing document $path: $e');
         }
@@ -914,8 +914,7 @@ class FileImportService {
         );
       }
 
-      debugPrint(
-          '[FileImport] Adding ${filesToVault.length} documents to vault');
+      debugPrint('[FileImport] Adding ${filesToVault.length} files to vault');
 
       // Add to vault
       final imported = await _vaultService.addFiles(
@@ -925,7 +924,7 @@ class FileImportService {
         onProgress: onProgress,
       );
 
-      debugPrint('[FileImport] Imported ${imported.length} documents to vault');
+      debugPrint('[FileImport] Imported ${imported.length} files to vault');
 
       // Delete originals if requested
       bool deletedOriginals = false;
@@ -940,7 +939,7 @@ class FileImportService {
         success: true,
         importedFiles: imported,
         message:
-            'Imported ${imported.length} document(s)${deletedOriginals ? " and removed originals" : ""}',
+            'Imported ${imported.length} file(s)${deletedOriginals ? " and removed originals" : ""}',
         deletedOriginals: deletedOriginals,
       );
     } catch (e, stackTrace) {
@@ -948,7 +947,7 @@ class FileImportService {
       debugPrint('[FileImport] Stack trace: $stackTrace');
       return ImportResult(
         success: false,
-        error: 'Failed to import documents: $e',
+        error: 'Failed to import files: $e',
         importedFiles: [],
       );
     }

--- a/lib/services/flick_integration_service.dart
+++ b/lib/services/flick_integration_service.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class FlickIntegrationService {
+  static const packageName = 'com.ultraelectronica.flick';
+  static const MethodChannel _channel =
+      MethodChannel('com.ultraelectronica.locker/flick');
+
+  static Future<bool> isAvailable() async {
+    if (!Platform.isAndroid) return false;
+
+    try {
+      return await _channel.invokeMethod<bool>('isFlickInstalled') ?? false;
+    } on PlatformException catch (e) {
+      debugPrint('[Flick] Failed to check availability: $e');
+      return false;
+    }
+  }
+
+  static Future<void> openAudioFile({
+    required String filePath,
+    required String mimeType,
+  }) async {
+    if (!Platform.isAndroid) {
+      throw UnsupportedError('Flick handoff is only available on Android');
+    }
+
+    await _channel.invokeMethod<void>('openAudioInFlick', {
+      'filePath': filePath,
+      'mimeType': mimeType,
+    });
+  }
+}

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -80,6 +80,7 @@ class VaultService {
     // Create subdirectories for different file types
     await Directory('${_vaultDirectory!.path}/images').create(recursive: true);
     await Directory('${_vaultDirectory!.path}/videos').create(recursive: true);
+    await Directory('${_vaultDirectory!.path}/songs').create(recursive: true);
     await Directory('${_vaultDirectory!.path}/documents')
         .create(recursive: true);
     await Directory('${_vaultDirectory!.path}/thumbnails')
@@ -108,6 +109,7 @@ class VaultService {
 
     await Directory('${_decoyDirectory!.path}/images').create(recursive: true);
     await Directory('${_decoyDirectory!.path}/videos').create(recursive: true);
+    await Directory('${_decoyDirectory!.path}/songs').create(recursive: true);
     await Directory('${_decoyDirectory!.path}/documents')
         .create(recursive: true);
 
@@ -132,6 +134,8 @@ class VaultService {
         return 'images';
       case VaultedFileType.video:
         return 'videos';
+      case VaultedFileType.song:
+        return 'songs';
       case VaultedFileType.document:
       case VaultedFileType.other:
         return 'documents';

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import audio_session
 import file_picker
 import file_selector_macos
 import flutter_image_compress_macos
 import flutter_secure_storage_darwin
+import just_audio
 import local_auth_darwin
 import photo_manager
 import shared_preferences_foundation
@@ -17,10 +19,12 @@ import video_compress
 import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
+  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   LocalAuthPlugin.register(with: registry.registrar(forPlugin: "LocalAuthPlugin"))
   PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  audio_session:
+    dependency: transitive
+    description:
+      name: audio_session
+      sha256: "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -616,6 +624,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      sha256: "9694e4734f515f2a052493d1d7e0d6de219ee0427c7c29492e246ff32a219908"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.5"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: "2532c8d6702528824445921c5ff10548b518b13f808c2e34c2fd54793b999a6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: "6ba8a2a7e87d57d32f0f7b42856ade3d6a9fbe0f1a11fabae0a4f00bb73f0663"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.16"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,7 +50,7 @@ packages:
     source: hosted
     version: "2.13.1"
   audio_session:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: audio_session
       sha256: "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,7 +50,7 @@ packages:
     source: hosted
     version: "2.13.1"
   audio_session:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: audio_session
       sha256: "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   archive: ^4.0.7
+  audio_session: ^0.2.3
   camera: ^0.12.0
   crypto: ^3.0.7
   cupertino_icons: ^1.0.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   fluttertoast: ^9.0.0
   image: ^4.8.0
   image_picker: ^1.2.1
+  just_audio: ^0.10.5
   video_compress: ^3.1.4
   local_auth: ^3.0.0
   local_auth_android: ^2.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,6 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   archive: ^4.0.7
-  audio_session: ^0.2.3
   camera: ^0.12.0
   crypto: ^3.0.7
   cupertino_icons: ^1.0.6


### PR DESCRIPTION
# Summary

Adds comprehensive audio file support to the app, including song handling in the vault, favorites, and gallery screens, along with Flick integration for external audio playback on Android.

# Changes

## Audio Support

- Add song type to `VaultedFileType` enum for handling audio files
- Create 'songs' subdirectory in vault and decoy directories for audio organization
- Add `SongPlayerScreen` for audio playback functionality
- Integrate song handling in `FavoritesScreen`, `GalleryVaultScreen`, `TagsScreen`, `AlbumDetailScreen`

## Flick Integration

- Add Flick integration service for Android audio handoff
- Check Flick availability and show "Play with Flick" button when available
- Handle Flick lifecycle with auto-kill service
- Add platform channel for Flick operations and file opening
- Add `locker://return` intent filter for Flick companion return flow

## UI Updates

- Add song type badges and tabs in file listings
- Update import options to include songs
- Enhance file type detection for audio extensions and MIME types

## Bug Fixes

- Simplify song player by removing unused audio session and error handling
- Add `onNewIntent` to properly handle new activity launches
- Remove `audio_session` dependency (now transitive)

## Documentation

- Add Flick-Locker integration guide
- Update docs to reflect Flick package and deterministic handoff
