### PR TITLE
Add vault settings screen with sliding selection and security enhancements

### DIFF
--- a/android/app/src/main/kotlin/com/ultraelectronica/locker/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ultraelectronica/locker/MainActivity.kt
@@ -7,6 +7,9 @@ import android.content.pm.PackageManager
 import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.Display
 import android.view.WindowManager
 import androidx.core.content.FileProvider
@@ -18,10 +21,28 @@ import java.io.File
 
 class MainActivity: FlutterFragmentActivity() {
     private val CHANNEL = "com.ultraelectronica.locker/autokill"
+    private val AUTO_KILL_PREFS = "locker_auto_kill"
+    private val AUTO_KILL_DELAY_KEY = "delay_seconds"
     private val MEDIA_SCANNER_CHANNEL = "com.example.vault/media_scanner"
+    private val SCREENSHOT_PROTECTION_CHANNEL = "com.ultraelectronica.locker/screenshot_protection"
     private val FLICK_CHANNEL = "com.ultraelectronica.locker/flick"
     private val FLICK_PACKAGE = "com.ultraelectronica.flick"
+    private val autoKillPreferences by lazy {
+        getSharedPreferences(AUTO_KILL_PREFS, MODE_PRIVATE)
+    }
+    private val autoKillHandler = Handler(Looper.getMainLooper())
+    private val autoKillRunnable = Runnable {
+        if (isAutoKillEnabled && !isFinishing && !isDestroyed) {
+            finishAndRemoveTask()
+        }
+    }
     private var isAutoKillEnabled = true
+    private var autoKillDelayMillis = 0L
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        autoKillDelayMillis = loadAutoKillDelayMillis()
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -30,9 +51,39 @@ class MainActivity: FlutterFragmentActivity() {
         enableHighFrameRate()
         
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
-            if (call.method == "setAutoKillEnabled") {
-                isAutoKillEnabled = call.arguments as Boolean
-                result.success(null)
+            when (call.method) {
+                "setAutoKillEnabled" -> {
+                    val enabled = call.arguments as? Boolean
+                    if (enabled == null) {
+                        result.error("INVALID_ARGUMENT", "Boolean flag is required", null)
+                    } else {
+                        setAutoKillEnabled(enabled)
+                        result.success(null)
+                    }
+                }
+                "setAutoKillDelaySeconds" -> {
+                    val seconds =
+                        (call.argument<Number>("seconds") ?: call.arguments as? Number)?.toInt()
+                    if (seconds == null || seconds < 0) {
+                        result.error("INVALID_ARGUMENT", "Non-negative delay is required", null)
+                    } else {
+                        setAutoKillDelaySeconds(seconds)
+                        result.success(null)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SCREENSHOT_PROTECTION_CHANNEL).setMethodCallHandler { call, result ->
+            if (call.method == "setScreenshotProtectionEnabled") {
+                val enabled = call.arguments as? Boolean
+                if (enabled == null) {
+                    result.error("INVALID_ARGUMENT", "Boolean flag is required", null)
+                } else {
+                    setScreenshotProtectionEnabled(enabled)
+                    result.success(null)
+                }
             } else {
                 result.notImplemented()
             }
@@ -164,6 +215,44 @@ class MainActivity: FlutterFragmentActivity() {
             result.error("SCAN_ERROR", "Failed to scan file: ${e.message}", null)
         }
     }
+
+    private fun setScreenshotProtectionEnabled(enabled: Boolean) {
+        if (enabled) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    private fun setAutoKillEnabled(enabled: Boolean) {
+        isAutoKillEnabled = enabled
+        if (!enabled) {
+            cancelAutoKill()
+        }
+    }
+
+    private fun setAutoKillDelaySeconds(seconds: Int) {
+        autoKillDelayMillis = seconds * 1000L
+        autoKillPreferences.edit().putInt(AUTO_KILL_DELAY_KEY, seconds).apply()
+    }
+
+    private fun loadAutoKillDelayMillis(): Long {
+        val seconds = autoKillPreferences.getInt(AUTO_KILL_DELAY_KEY, 0)
+        return seconds * 1000L
+    }
+
+    private fun cancelAutoKill() {
+        autoKillHandler.removeCallbacks(autoKillRunnable)
+    }
+
+    private fun scheduleAutoKill() {
+        cancelAutoKill()
+        if (autoKillDelayMillis <= 0L) {
+            finishAndRemoveTask()
+        } else {
+            autoKillHandler.postDelayed(autoKillRunnable, autoKillDelayMillis)
+        }
+    }
     
     private fun enableHighFrameRate() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -213,11 +302,20 @@ class MainActivity: FlutterFragmentActivity() {
         return windowManager.defaultDisplay.supportedModes[0]
     }
     
-    override fun onPause() {
-        super.onPause()
-        // Remove from recent apps when user leaves the app, ONLY if enabled
-        if (isAutoKillEnabled) {
-            finishAndRemoveTask()
+    override fun onStart() {
+        super.onStart()
+        cancelAutoKill()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        if (isAutoKillEnabled && !isChangingConfigurations) {
+            scheduleAutoKill()
         }
+    }
+
+    override fun onDestroy() {
+        cancelAutoKill()
+        super.onDestroy()
     }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'services/auto_kill_service.dart';
+import 'services/screenshot_protection_service.dart';
+import 'services/vault_service.dart';
 import 'themes/app_theme.dart';
 import 'providers/theme_provider.dart';
 import 'services/auth_service.dart';
@@ -9,22 +12,28 @@ import 'screens/unlock_screen.dart';
 import 'utils/frame_rate_optimizer.dart';
 import 'utils/performance_config.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  
+
   // Configure high frame rate support
   PerformanceConfig.configureHighFrameRate();
   PerformanceConfig.optimizeImageCache();
-  
+
   // Start frame rate monitoring
   FrameRateOptimizer().startMonitoring();
-  
+
   // Set preferred orientations and system UI
-  SystemChrome.setPreferredOrientations([
+  await SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,
   ]);
-  
+
+  final settings = await VaultService.instance.getSettings();
+  await AutoKillService.setDelaySeconds(settings.autoKillDelaySeconds);
+  await ScreenshotProtectionService.setEnabled(
+    settings.screenshotProtectionEnabled,
+  );
+
   runApp(const ProviderScope(child: LockerApp()));
 }
 

--- a/lib/screens/backup_file_selection_screen.dart
+++ b/lib/screens/backup_file_selection_screen.dart
@@ -1,0 +1,517 @@
+import 'package:flutter/material.dart';
+import '../models/vaulted_file.dart';
+import '../services/vault_service.dart';
+import '../themes/app_colors.dart';
+
+class BackupFileSelectionScreen extends StatefulWidget {
+  final List<VaultedFile> initialSelection;
+
+  const BackupFileSelectionScreen({
+    super.key,
+    this.initialSelection = const [],
+  });
+
+  @override
+  State<BackupFileSelectionScreen> createState() =>
+      _BackupFileSelectionScreenState();
+}
+
+class _BackupFileSelectionScreenState extends State<BackupFileSelectionScreen> {
+  final VaultService _vaultService = VaultService.instance;
+  final TextEditingController _searchController = TextEditingController();
+  final Map<String, GlobalKey> _tileKeys = {};
+
+  late final Future<List<VaultedFile>> _filesFuture;
+  late final Set<String> _selectedIds;
+  String _searchQuery = '';
+  bool _isSlidingSelection = false;
+  bool? _slidingSelectionValue;
+  final Set<String> _slidingTouchedIds = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _filesFuture = _vaultService.getAllFiles(isDecoy: false);
+    _selectedIds = widget.initialSelection.map((file) => file.id).toSet();
+    _searchController.addListener(_handleSearchChanged);
+  }
+
+  @override
+  void dispose() {
+    _searchController
+      ..removeListener(_handleSearchChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _handleSearchChanged() {
+    final nextQuery = _searchController.text.trim().toLowerCase();
+    if (nextQuery == _searchQuery) return;
+    setState(() => _searchQuery = nextQuery);
+  }
+
+  void _toggleSelection(String fileId) {
+    setState(() {
+      _setSelected(fileId, !_selectedIds.contains(fileId));
+    });
+  }
+
+  void _setSelected(String fileId, bool isSelected) {
+    if (isSelected) {
+      _selectedIds.add(fileId);
+    } else {
+      _selectedIds.remove(fileId);
+    }
+  }
+
+  GlobalKey _tileKeyFor(String fileId) {
+    return _tileKeys.putIfAbsent(fileId, GlobalKey.new);
+  }
+
+  void _startSlidingSelection(VaultedFile file) {
+    final shouldSelect = !_selectedIds.contains(file.id);
+
+    setState(() {
+      _isSlidingSelection = true;
+      _slidingSelectionValue = shouldSelect;
+      _slidingTouchedIds
+        ..clear()
+        ..add(file.id);
+      _setSelected(file.id, shouldSelect);
+    });
+  }
+
+  void _updateSlidingSelection(Offset globalPosition) {
+    if (!_isSlidingSelection || _slidingSelectionValue == null) return;
+
+    final fileId = _fileIdAt(globalPosition);
+    if (fileId == null || _slidingTouchedIds.contains(fileId)) return;
+
+    setState(() {
+      _slidingTouchedIds.add(fileId);
+      _setSelected(fileId, _slidingSelectionValue!);
+    });
+  }
+
+  void _stopSlidingSelection() {
+    if (!_isSlidingSelection) return;
+
+    setState(() {
+      _isSlidingSelection = false;
+      _slidingSelectionValue = null;
+      _slidingTouchedIds.clear();
+    });
+  }
+
+  String? _fileIdAt(Offset globalPosition) {
+    for (final entry in _tileKeys.entries) {
+      final context = entry.value.currentContext;
+      if (context == null) continue;
+
+      final renderObject = context.findRenderObject();
+      if (renderObject is! RenderBox || !renderObject.hasSize) continue;
+
+      final rect = renderObject.localToGlobal(Offset.zero) & renderObject.size;
+      if (rect.contains(globalPosition)) {
+        return entry.key;
+      }
+    }
+
+    return null;
+  }
+
+  void _toggleVisibleSelections(List<VaultedFile> visibleFiles) {
+    if (visibleFiles.isEmpty) return;
+
+    final visibleIds = visibleFiles.map((file) => file.id).toSet();
+    final allVisibleSelected = visibleIds.every(_selectedIds.contains);
+
+    setState(() {
+      if (allVisibleSelected) {
+        _selectedIds.removeAll(visibleIds);
+      } else {
+        _selectedIds.addAll(visibleIds);
+      }
+    });
+  }
+
+  void _applySelection(List<VaultedFile> files) {
+    final selectedFiles =
+        files.where((file) => _selectedIds.contains(file.id)).toList();
+    Navigator.of(context).pop(selectedFiles);
+  }
+
+  List<VaultedFile> _visibleFiles(List<VaultedFile> files) {
+    final filtered = _searchQuery.isEmpty
+        ? List<VaultedFile>.from(files)
+        : files
+            .where((file) =>
+                file.originalName.toLowerCase().contains(_searchQuery) ||
+                file.type.displayName.toLowerCase().contains(_searchQuery) ||
+                file.extension.toLowerCase().contains(_searchQuery))
+            .toList();
+
+    filtered.sort((a, b) => b.dateAdded.compareTo(a.dateAdded));
+    return filtered;
+  }
+
+  int _selectedCount(List<VaultedFile> files) {
+    return files.where((file) => _selectedIds.contains(file.id)).length;
+  }
+
+  IconData _iconForFile(VaultedFile file) {
+    switch (file.type) {
+      case VaultedFileType.image:
+        return Icons.image_outlined;
+      case VaultedFileType.video:
+        return Icons.videocam_outlined;
+      case VaultedFileType.song:
+        return Icons.music_note_outlined;
+      case VaultedFileType.document:
+        return Icons.description_outlined;
+      case VaultedFileType.other:
+        return Icons.insert_drive_file_outlined;
+    }
+  }
+
+  Color _colorForFile(VaultedFile file) {
+    switch (file.type) {
+      case VaultedFileType.image:
+        return context.accentColor;
+      case VaultedFileType.video:
+        return Colors.red;
+      case VaultedFileType.song:
+        return Colors.purple;
+      case VaultedFileType.document:
+        return Colors.orange;
+      case VaultedFileType.other:
+        return Colors.grey;
+    }
+  }
+
+  Widget _buildSearchField() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      child: TextField(
+        controller: _searchController,
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          color: context.textPrimary,
+        ),
+        decoration: InputDecoration(
+          hintText: 'Search files',
+          hintStyle: TextStyle(
+            fontFamily: 'ProductSans',
+            color: context.textTertiary,
+          ),
+          prefixIcon: Icon(Icons.search, color: context.textTertiary),
+          suffixIcon: _searchQuery.isEmpty
+              ? null
+              : IconButton(
+                  onPressed: _searchController.clear,
+                  icon: Icon(Icons.close, color: context.textTertiary),
+                ),
+          filled: true,
+          fillColor: context.backgroundSecondary,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(14),
+            borderSide: BorderSide.none,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFileTile(VaultedFile file) {
+    final isSelected = _selectedIds.contains(file.id);
+    final color = _colorForFile(file);
+
+    return Padding(
+      key: _tileKeyFor(file.id),
+      padding: const EdgeInsets.only(bottom: 8),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onLongPressStart: (_) => _startSlidingSelection(file),
+        onLongPressMoveUpdate: (details) =>
+            _updateSlidingSelection(details.globalPosition),
+        onLongPressEnd: (_) => _stopSlidingSelection(),
+        onLongPressCancel: _stopSlidingSelection,
+        child: Material(
+          color: isSelected
+              ? context.accentColor.withValues(alpha: 0.1)
+              : context.backgroundSecondary,
+          borderRadius: BorderRadius.circular(12),
+          child: InkWell(
+            onTap: () => _toggleSelection(file.id),
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      color: color.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Icon(_iconForFile(file), color: color),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          file.originalName,
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 15,
+                            fontWeight: FontWeight.w500,
+                            color: context.textPrimary,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${file.type.displayName} · ${file.formattedSize} · ${file.formattedDateAdded}',
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 12,
+                            color: context.textSecondary,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 150),
+                    width: 26,
+                    height: 26,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color:
+                          isSelected ? context.accentColor : Colors.transparent,
+                      border: Border.all(
+                        color: isSelected
+                            ? context.accentColor
+                            : context.textTertiary,
+                        width: 2,
+                      ),
+                    ),
+                    child: isSelected
+                        ? const Icon(Icons.check, size: 16, color: Colors.white)
+                        : null,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSelectionHint() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: Text(
+        'Tip: long-press and slide across files to select or clear several at once.',
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: 12,
+          color: context.textTertiary,
+        ),
+      ),
+    );
+  }
+
+  void _syncTileKeys(List<VaultedFile> visibleFiles) {
+    final visibleIds = visibleFiles.map((file) => file.id).toSet();
+    _tileKeys.removeWhere((fileId, _) => !visibleIds.contains(fileId));
+  }
+
+  Widget _buildVisibleFilesList(List<VaultedFile> visibleFiles) {
+    _syncTileKeys(visibleFiles);
+
+    return ListView.builder(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      itemCount: visibleFiles.length,
+      itemBuilder: (context, index) => _buildFileTile(visibleFiles[index]),
+    );
+  }
+
+  Widget _buildEmptyState({required String title, required String subtitle}) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.backup_outlined, size: 56, color: context.textTertiary),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: context.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              subtitle,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 14,
+                color: context.textTertiary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadedState(List<VaultedFile> files) {
+    final visibleFiles = _visibleFiles(files);
+    final selectedCount = _selectedCount(files);
+    final allVisibleSelected = visibleFiles.isNotEmpty &&
+        visibleFiles.every((file) => _selectedIds.contains(file.id));
+
+    if (files.isEmpty) {
+      return _buildEmptyState(
+        title: 'No files in vault',
+        subtitle: 'Hide files first, then come back to create a backup.',
+      );
+    }
+
+    return Column(
+      children: [
+        _buildSearchField(),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: Row(
+            children: [
+              Text(
+                '${visibleFiles.length} file${visibleFiles.length == 1 ? '' : 's'}',
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 13,
+                  color: context.textTertiary,
+                ),
+              ),
+              const Spacer(),
+              TextButton(
+                onPressed: visibleFiles.isEmpty
+                    ? null
+                    : () => _toggleVisibleSelections(visibleFiles),
+                child: Text(
+                    allVisibleSelected ? 'Clear visible' : 'Select visible'),
+              ),
+            ],
+          ),
+        ),
+        _buildSelectionHint(),
+        Expanded(
+          child: visibleFiles.isEmpty
+              ? _buildEmptyState(
+                  title: 'No matching files',
+                  subtitle: 'Try another name, type, or file extension.',
+                )
+              : _buildVisibleFilesList(visibleFiles),
+        ),
+        SafeArea(
+          top: false,
+          child: Container(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              border: Border(
+                top: BorderSide(
+                    color: context.borderColor.withValues(alpha: 0.5)),
+              ),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    selectedCount == 1
+                        ? '1 file selected'
+                        : '$selectedCount files selected',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: context.textPrimary,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed:
+                      selectedCount == 0 ? null : () => _applySelection(files),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: context.accentColor,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 20, vertical: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text('Use selected'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: AppBar(
+        title: Text(
+          'Select backup files',
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            fontWeight: FontWeight.w600,
+            color: context.textPrimary,
+          ),
+        ),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        elevation: 0,
+        iconTheme: IconThemeData(color: context.textPrimary),
+      ),
+      body: FutureBuilder<List<VaultedFile>>(
+        future: _filesFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+              child: CircularProgressIndicator(color: AppColors.accent),
+            );
+          }
+
+          if (snapshot.hasError) {
+            return _buildEmptyState(
+              title: 'Failed to load vault files',
+              subtitle: 'Try reopening this screen and run the backup again.',
+            );
+          }
+
+          return _buildLoadedState(snapshot.data ?? const []);
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/document_picker_screen.dart
+++ b/lib/screens/document_picker_screen.dart
@@ -172,6 +172,7 @@ class DocumentPickerScreen extends StatefulWidget {
 class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
   final List<DocumentFile> _documents = [];
   final Set<DocumentFile> _selectedDocuments = {};
+  final Map<String, GlobalKey> _tileKeys = {};
   bool _isLoading = true;
   String? _error;
   String _searchQuery = '';
@@ -179,6 +180,9 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
   final _searchController = TextEditingController();
   late String _currentFolder;
   final Map<String, List<DocumentFile>> _folderGroups = {};
+  bool _isSlidingSelection = false;
+  bool? _slidingSelectionValue;
+  final Set<String> _slidingTouchedDocumentPaths = {};
 
   String get _allItemsLabel => 'All ${widget.itemLabelPlural}';
 
@@ -214,9 +218,9 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
       if (!hasPermission) {
         setState(() {
           _isLoading = false;
-            _error = 'Storage permission is required to browse documents';
-          });
-          return;
+          _error = 'Storage permission is required to browse documents';
+        });
+        return;
       }
 
       final foundDocuments = <DocumentFile>[];
@@ -395,23 +399,116 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
 
   void _toggleSelection(DocumentFile doc) {
     setState(() {
-      if (_selectedDocuments.contains(doc)) {
-        _selectedDocuments.remove(doc);
-      } else {
-        if (widget.maxSelection > 0 &&
-            _selectedDocuments.length >= widget.maxSelection) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content:
-                  Text('Maximum ${widget.maxSelection} items can be selected'),
-              duration: const Duration(seconds: 1),
-            ),
-          );
-          return;
-        }
-        _selectedDocuments.add(doc);
-      }
+      _setSelected(doc, !_selectedDocuments.contains(doc));
     });
+  }
+
+  bool _setSelected(DocumentFile doc, bool isSelected,
+      {bool showLimitError = true}) {
+    if (isSelected) {
+      if (_selectedDocuments.contains(doc)) return true;
+
+      if (widget.maxSelection > 0 &&
+          _selectedDocuments.length >= widget.maxSelection) {
+        if (showLimitError) {
+          _showMaxSelectionMessage();
+        }
+        return false;
+      }
+
+      _selectedDocuments.add(doc);
+      return true;
+    }
+
+    _selectedDocuments.remove(doc);
+    return true;
+  }
+
+  void _showMaxSelectionMessage() {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text('Maximum ${widget.maxSelection} items can be selected'),
+          duration: const Duration(seconds: 1),
+        ),
+      );
+  }
+
+  GlobalKey _tileKeyFor(String documentPath) {
+    return _tileKeys.putIfAbsent(documentPath, GlobalKey.new);
+  }
+
+  void _startSlidingSelection(DocumentFile doc) {
+    final shouldSelect = !_selectedDocuments.contains(doc);
+    if (!_setSelected(doc, shouldSelect)) return;
+
+    setState(() {
+      _isSlidingSelection = true;
+      _slidingSelectionValue = shouldSelect;
+      _slidingTouchedDocumentPaths
+        ..clear()
+        ..add(doc.path);
+    });
+  }
+
+  void _updateSlidingSelection(Offset globalPosition) {
+    if (!_isSlidingSelection || _slidingSelectionValue == null) return;
+
+    final documentPath = _documentPathAt(globalPosition);
+    if (documentPath == null ||
+        _slidingTouchedDocumentPaths.contains(documentPath)) {
+      return;
+    }
+
+    final doc = _documentByPath(documentPath);
+    if (doc == null) return;
+
+    final applied =
+        _setSelected(doc, _slidingSelectionValue!, showLimitError: false);
+    if (!applied) {
+      _showMaxSelectionMessage();
+      _stopSlidingSelection();
+      return;
+    }
+
+    setState(() {
+      _slidingTouchedDocumentPaths.add(documentPath);
+    });
+  }
+
+  void _stopSlidingSelection() {
+    if (!_isSlidingSelection) return;
+
+    setState(() {
+      _isSlidingSelection = false;
+      _slidingSelectionValue = null;
+      _slidingTouchedDocumentPaths.clear();
+    });
+  }
+
+  DocumentFile? _documentByPath(String documentPath) {
+    for (final doc in _filteredDocuments) {
+      if (doc.path == documentPath) return doc;
+    }
+    return null;
+  }
+
+  String? _documentPathAt(Offset globalPosition) {
+    for (final entry in _tileKeys.entries) {
+      final context = entry.value.currentContext;
+      if (context == null) continue;
+
+      final renderObject = context.findRenderObject();
+      if (renderObject is! RenderBox || !renderObject.hasSize) continue;
+
+      final rect = renderObject.localToGlobal(Offset.zero) & renderObject.size;
+      if (rect.contains(globalPosition)) {
+        return entry.key;
+      }
+    }
+
+    return null;
   }
 
   void _selectAll() {
@@ -578,9 +675,9 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
                   child: Row(
                     children: [
                       Icon(
-                         folder == _allItemsLabel
-                             ? Icons.folder_special
-                             : Icons.folder,
+                        folder == _allItemsLabel
+                            ? Icons.folder_special
+                            : Icons.folder,
                         size: 18,
                         color: context.accentColor,
                       ),
@@ -754,6 +851,10 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
 
   Widget _buildDocumentList() {
     final docs = _filteredDocuments;
+    _tileKeys.removeWhere(
+      (documentPath, _) => !docs.any((doc) => doc.path == documentPath),
+    );
+
     return ListView.builder(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       itemCount: docs.length,
@@ -768,150 +869,159 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
     final selectionIndex = _selectedDocuments.toList().indexOf(doc);
 
     return Padding(
+      key: _tileKeyFor(doc.path),
       padding: const EdgeInsets.only(bottom: 8),
-      child: Material(
-        color: isSelected
-            ? context.accentColor.withValues(alpha: 0.1)
-            : context.backgroundSecondary,
-        borderRadius: BorderRadius.circular(12),
-        child: InkWell(
-          onTap: () => _toggleSelection(doc),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onLongPressStart: (_) => _startSlidingSelection(doc),
+        onLongPressMoveUpdate: (details) =>
+            _updateSlidingSelection(details.globalPosition),
+        onLongPressEnd: (_) => _stopSlidingSelection(),
+        onLongPressCancel: _stopSlidingSelection,
+        child: Material(
+          color: isSelected
+              ? context.accentColor.withValues(alpha: 0.1)
+              : context.backgroundSecondary,
           borderRadius: BorderRadius.circular(12),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Row(
-              children: [
-                // File type icon
-                Container(
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    color: doc.iconColor.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(10),
+          child: InkWell(
+            onTap: () => _toggleSelection(doc),
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  // File type icon
+                  Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      color: doc.iconColor.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Icon(
+                      doc.icon,
+                      color: doc.iconColor,
+                      size: 26,
+                    ),
                   ),
-                  child: Icon(
-                    doc.icon,
-                    color: doc.iconColor,
-                    size: 26,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                // File info
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        doc.name,
-                        style: TextStyle(
-                          fontFamily: 'ProductSans',
-                          fontSize: 15,
-                          fontWeight: FontWeight.w500,
-                          color: context.textPrimary,
+                  const SizedBox(width: 12),
+                  // File info
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          doc.name,
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 15,
+                            fontWeight: FontWeight.w500,
+                            color: context.textPrimary,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      const SizedBox(height: 4),
-                      Row(
-                        children: [
-                          Text(
-                            doc.formattedSize,
-                            style: TextStyle(
-                              fontFamily: 'ProductSans',
-                              fontSize: 12,
-                              color: context.textSecondary,
-                            ),
-                          ),
-                          Container(
-                            margin: const EdgeInsets.symmetric(horizontal: 8),
-                            width: 3,
-                            height: 3,
-                            decoration: BoxDecoration(
-                              color: context.textTertiary,
-                              shape: BoxShape.circle,
-                            ),
-                          ),
-                          Text(
-                            doc.formattedDate,
-                            style: TextStyle(
-                              fontFamily: 'ProductSans',
-                              fontSize: 12,
-                              color: context.textSecondary,
-                            ),
-                          ),
-                          Container(
-                            margin: const EdgeInsets.symmetric(horizontal: 8),
-                            width: 3,
-                            height: 3,
-                            decoration: BoxDecoration(
-                              color: context.textTertiary,
-                              shape: BoxShape.circle,
-                            ),
-                          ),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 6,
-                              vertical: 2,
-                            ),
-                            decoration: BoxDecoration(
-                              color: doc.iconColor.withValues(alpha: 0.15),
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                            child: Text(
-                              doc.extension.toUpperCase(),
+                        const SizedBox(height: 4),
+                        Row(
+                          children: [
+                            Text(
+                              doc.formattedSize,
                               style: TextStyle(
                                 fontFamily: 'ProductSans',
-                                fontSize: 10,
-                                fontWeight: FontWeight.w600,
-                                color: doc.iconColor,
+                                fontSize: 12,
+                                color: context.textSecondary,
                               ),
                             ),
-                          ),
-                        ],
-                      ),
-                    ],
+                            Container(
+                              margin: const EdgeInsets.symmetric(horizontal: 8),
+                              width: 3,
+                              height: 3,
+                              decoration: BoxDecoration(
+                                color: context.textTertiary,
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                            Text(
+                              doc.formattedDate,
+                              style: TextStyle(
+                                fontFamily: 'ProductSans',
+                                fontSize: 12,
+                                color: context.textSecondary,
+                              ),
+                            ),
+                            Container(
+                              margin: const EdgeInsets.symmetric(horizontal: 8),
+                              width: 3,
+                              height: 3,
+                              decoration: BoxDecoration(
+                                color: context.textTertiary,
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 6,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: doc.iconColor.withValues(alpha: 0.15),
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: Text(
+                                doc.extension.toUpperCase(),
+                                style: TextStyle(
+                                  fontFamily: 'ProductSans',
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w600,
+                                  color: doc.iconColor,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                const SizedBox(width: 8),
-                // Selection indicator
-                AnimatedContainer(
-                  duration: const Duration(milliseconds: 150),
-                  width: 28,
-                  height: 28,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: isSelected
-                        ? context.accentColor
-                        : Colors.white.withValues(alpha: 0.7),
-                    border: Border.all(
+                  const SizedBox(width: 8),
+                  // Selection indicator
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 150),
+                    width: 28,
+                    height: 28,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
                       color: isSelected
                           ? context.accentColor
-                          : Colors.grey.shade400,
-                      width: 2,
-                    ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.1),
-                        blurRadius: 2,
+                          : Colors.white.withValues(alpha: 0.7),
+                      border: Border.all(
+                        color: isSelected
+                            ? context.accentColor
+                            : Colors.grey.shade400,
+                        width: 2,
                       ),
-                    ],
-                  ),
-                  child: isSelected
-                      ? Center(
-                          child: Text(
-                            '${selectionIndex + 1}',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                              fontFamily: 'ProductSans',
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.1),
+                          blurRadius: 2,
+                        ),
+                      ],
+                    ),
+                    child: isSelected
+                        ? Center(
+                            child: Text(
+                              '${selectionIndex + 1}',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                                fontWeight: FontWeight.bold,
+                                fontFamily: 'ProductSans',
+                              ),
                             ),
-                          ),
-                        )
-                      : null,
-                ),
-              ],
+                          )
+                        : null,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -41,12 +41,17 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
   final FileImportService _importService = FileImportService.instance;
+  final Map<String, GlobalKey> _selectionTileKeys = {};
 
   bool _isImporting = false;
   int _importProgress = 0;
   int _importTotal = 0;
   bool _isSearching = false;
   final TextEditingController _searchController = TextEditingController();
+  bool _isSlidingSelection = false;
+  bool? _slidingSelectionValue;
+  String? _slidingTabKey;
+  final Set<String> _slidingTouchedTileKeys = {};
 
   @override
   void initState() {
@@ -391,6 +396,8 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
 
   Widget _buildFileGrid(
       VaultedFileType? filterType, AsyncValue<List<VaultedFile>> filesAsync) {
+    final tabKey = _tabKeyFor(filterType);
+
     return filesAsync.when(
       loading: () => Center(
         child: CircularProgressIndicator(
@@ -477,7 +484,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
             itemCount: files.length,
             itemBuilder: (context, index) => RepaintBoundary(
               key: ValueKey(files[index].id),
-              child: _buildFileItem(files[index]),
+              child: _buildFileItem(files[index], tabKey),
             ),
           ),
         );
@@ -485,10 +492,11 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
     );
   }
 
-  Widget _buildFileItem(VaultedFile file) {
+  Widget _buildFileItem(VaultedFile file, String tabKey) {
     final selectedFiles = ref.watch(selectedFilesProvider);
     final isSelectionMode = ref.watch(isSelectionModeProvider);
     final isSelected = selectedFiles.contains(file.id);
+    final tileKey = _selectionTileKey(tabKey, file.id);
 
     return GestureDetector(
       onTap: () {
@@ -498,15 +506,16 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
           _openFile(file);
         }
       },
-      onLongPress: () {
-        if (!isSelectionMode) {
-          _enterSelectionMode(file.id);
-        }
-      },
+      onLongPressStart: (_) => _startSlidingSelection(file.id, tabKey),
+      onLongPressMoveUpdate: (details) =>
+          _updateSlidingSelection(details.globalPosition),
+      onLongPressEnd: (_) => _stopSlidingSelection(),
+      onLongPressCancel: _stopSlidingSelection,
       child: Stack(
         fit: StackFit.expand,
         children: [
           Container(
+            key: _tileKeyFor(tileKey),
             decoration: BoxDecoration(
               color: context.backgroundSecondary,
               borderRadius: BorderRadius.circular(8),
@@ -660,6 +669,101 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
         ],
       ),
     );
+  }
+
+  String _tabKeyFor(VaultedFileType? filterType) {
+    if (filterType == null) return 'all';
+
+    switch (filterType) {
+      case VaultedFileType.image:
+        return 'images';
+      case VaultedFileType.video:
+        return 'videos';
+      case VaultedFileType.song:
+        return 'songs';
+      case VaultedFileType.document:
+        return 'documents';
+      case VaultedFileType.other:
+        return 'other';
+    }
+  }
+
+  String _selectionTileKey(String tabKey, String fileId) => '$tabKey::$fileId';
+
+  GlobalKey _tileKeyFor(String tileKey) {
+    return _selectionTileKeys.putIfAbsent(tileKey, GlobalKey.new);
+  }
+
+  void _startSlidingSelection(String fileId, String tabKey) {
+    final selectedFiles = ref.read(selectedFilesProvider);
+    final shouldSelect = !selectedFiles.contains(fileId);
+    final tileKey = _selectionTileKey(tabKey, fileId);
+
+    setState(() {
+      _isSlidingSelection = true;
+      _slidingSelectionValue = shouldSelect;
+      _slidingTabKey = tabKey;
+      _slidingTouchedTileKeys
+        ..clear()
+        ..add(tileKey);
+    });
+
+    _setSelection(fileId, shouldSelect, keepSelectionMode: true);
+  }
+
+  void _updateSlidingSelection(Offset globalPosition) {
+    if (!_isSlidingSelection || _slidingSelectionValue == null) return;
+
+    final tileKey = _tileKeyAt(globalPosition, _slidingTabKey);
+    if (tileKey == null || _slidingTouchedTileKeys.contains(tileKey)) return;
+
+    final separatorIndex = tileKey.indexOf('::');
+    if (separatorIndex == -1) return;
+
+    final fileId = tileKey.substring(separatorIndex + 2);
+
+    setState(() {
+      _slidingTouchedTileKeys.add(tileKey);
+    });
+
+    _setSelection(fileId, _slidingSelectionValue!, keepSelectionMode: true);
+  }
+
+  void _stopSlidingSelection() {
+    if (!_isSlidingSelection) return;
+
+    setState(() {
+      _isSlidingSelection = false;
+      _slidingSelectionValue = null;
+      _slidingTabKey = null;
+      _slidingTouchedTileKeys.clear();
+    });
+
+    final selectedFiles = ref.read(selectedFilesProvider);
+    if (selectedFiles.isEmpty) {
+      ref.read(isSelectionModeProvider.notifier).state = false;
+    }
+  }
+
+  String? _tileKeyAt(Offset globalPosition, String? tabKey) {
+    if (tabKey == null) return null;
+
+    for (final entry in _selectionTileKeys.entries) {
+      if (!entry.key.startsWith('$tabKey::')) continue;
+
+      final context = entry.value.currentContext;
+      if (context == null) continue;
+
+      final renderObject = context.findRenderObject();
+      if (renderObject is! RenderBox || !renderObject.hasSize) continue;
+
+      final rect = renderObject.localToGlobal(Offset.zero) & renderObject.size;
+      if (rect.contains(globalPosition)) {
+        return entry.key;
+      }
+    }
+
+    return null;
   }
 
   Widget _buildFileThumbnail(VaultedFile file) {
@@ -816,21 +920,22 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
 
   void _toggleSelection(String fileId) {
     final selectedFiles = ref.read(selectedFilesProvider);
-    if (selectedFiles.contains(fileId)) {
-      ref.read(selectedFilesProvider.notifier).state = Set.from(selectedFiles)
-        ..remove(fileId);
-      if (selectedFiles.length == 1) {
-        ref.read(isSelectionModeProvider.notifier).state = false;
-      }
-    } else {
-      ref.read(selectedFilesProvider.notifier).state = Set.from(selectedFiles)
-        ..add(fileId);
-    }
+    _setSelection(fileId, !selectedFiles.contains(fileId));
   }
 
-  void _enterSelectionMode(String fileId) {
-    ref.read(isSelectionModeProvider.notifier).state = true;
-    ref.read(selectedFilesProvider.notifier).state = {fileId};
+  void _setSelection(String fileId, bool isSelected,
+      {bool keepSelectionMode = false}) {
+    final selectedFiles = Set<String>.from(ref.read(selectedFilesProvider));
+
+    if (isSelected) {
+      selectedFiles.add(fileId);
+    } else {
+      selectedFiles.remove(fileId);
+    }
+
+    ref.read(selectedFilesProvider.notifier).state = selectedFiles;
+    ref.read(isSelectionModeProvider.notifier).state =
+        keepSelectionMode || selectedFiles.isNotEmpty;
   }
 
   void _exitSelectionMode() {

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -9,14 +9,11 @@ import 'package:path_provider/path_provider.dart';
 import '../models/vaulted_file.dart';
 import '../models/album.dart';
 import '../providers/vault_providers.dart';
-import '../services/auth_service.dart';
 import '../services/auto_kill_service.dart';
 import '../services/file_import_service.dart';
-import '../services/vault_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 import '../utils/responsive_utils.dart';
-import '../providers/theme_provider.dart';
 import '../widgets/office_conversion_confirm_dialog.dart';
 import 'albums_screen.dart';
 import 'favorites_screen.dart';
@@ -29,9 +26,7 @@ import 'media_picker_screen.dart';
 import 'document_picker_screen.dart';
 import 'package:photo_manager/photo_manager.dart' hide AlbumType;
 import 'camera_screen.dart';
-import 'local_backup_screen.dart';
-import 'change_security_screen.dart';
-import 'accent_color_picker_screen.dart';
+import 'vault_settings_screen.dart';
 import '../widgets/operation_progress_sheet.dart';
 
 /// Gallery vault screen - main screen after authentication
@@ -44,10 +39,6 @@ class GalleryVaultScreen extends ConsumerStatefulWidget {
 
 class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
     with SingleTickerProviderStateMixin {
-  static const List<int> _lockoutAttemptOptions = [3, 5, 7, 10];
-  static const List<int> _lockoutDurationOptions = [30, 60, 300, 900];
-  static const List<int> _wipeAttemptOptions = [10, 15, 20, 30];
-
   late TabController _tabController;
   final FileImportService _importService = FileImportService.instance;
 
@@ -200,7 +191,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
                 );
                 break;
               case 'settings':
-                _showSettingsSheet();
+                _openSettingsScreen();
                 break;
               case 'refresh':
                 ref.read(vaultNotifierProvider.notifier).refresh();
@@ -1603,7 +1594,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
                         title: 'Security Settings',
                         onTap: () {
                           Navigator.pop(context);
-                          _showSettingsSheet();
+                          _openSettingsScreen();
                         },
                       ),
                       _buildDrawerItem(
@@ -2439,494 +2430,12 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
     }
   }
 
-  void _showSettingsSheet() {
-    showModalBottomSheet(
-      context: context,
-      backgroundColor: Colors.transparent,
-      isScrollControlled: true,
-      builder: (context) => Container(
-        constraints: BoxConstraints(
-          maxHeight: MediaQuery.of(context).size.height * 0.85,
-        ),
-        decoration: BoxDecoration(
-          color: context.backgroundColor,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-        ),
-        child: Consumer(
-          builder: (context, ref, _) {
-            final settingsAsync = ref.watch(vaultSettingsProvider);
-            return SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    margin: const EdgeInsets.only(top: 12),
-                    width: 40,
-                    height: 4,
-                    decoration: BoxDecoration(
-                      color: context.borderColor,
-                      borderRadius: BorderRadius.circular(2),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(20),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Security Settings',
-                          style: TextStyle(
-                            fontSize: 20,
-                            fontWeight: FontWeight.bold,
-                            color: context.textPrimary,
-                            fontFamily: 'ProductSans',
-                          ),
-                        ),
-                        const SizedBox(height: 16),
-                        ListTile(
-                          leading: Icon(Icons.security_outlined,
-                              color: context.accentColor),
-                          title: const Text('Change Security',
-                              style: TextStyle(fontFamily: 'ProductSans')),
-                          subtitle: Text('Change password, PIN, or biometric',
-                              style: TextStyle(
-                                  fontFamily: 'ProductSans',
-                                  fontSize: 12,
-                                  color: context.textTertiary)),
-                          onTap: () {
-                            Navigator.pop(context);
-                            Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) =>
-                                        const ChangeSecurityScreen()));
-                          },
-                          contentPadding: EdgeInsets.zero,
-                        ),
-                        ListTile(
-                          leading: Icon(Icons.backup_outlined,
-                              color: context.accentColor),
-                          title: const Text('Local backup',
-                              style: TextStyle(fontFamily: 'ProductSans')),
-                          subtitle: Text('Save vault as ZIP to a folder',
-                              style: TextStyle(
-                                  fontFamily: 'ProductSans',
-                                  fontSize: 12,
-                                  color: context.textTertiary)),
-                          onTap: () {
-                            Navigator.pop(context);
-                            Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) =>
-                                        const LocalBackupScreen()));
-                          },
-                          contentPadding: EdgeInsets.zero,
-                        ),
-                        const SizedBox(height: 16),
-                        _buildThemeToggle(context, ref),
-                        const SizedBox(height: 8),
-                        _buildAccentColorOption(context, ref),
-                        const SizedBox(height: 16),
-                        settingsAsync.when(
-                          loading: () =>
-                              const Center(child: CircularProgressIndicator()),
-                          error: (_, __) =>
-                              const Text('Failed to load settings'),
-                          data: (settings) => Column(
-                            children: [
-                              SwitchListTile(
-                                title: const Text('Encrypt New Files',
-                                    style:
-                                        TextStyle(fontFamily: 'ProductSans')),
-                                subtitle: Text(
-                                    'AES-256 encryption for all new imports',
-                                    style: TextStyle(
-                                        fontFamily: 'ProductSans',
-                                        fontSize: 12,
-                                        color: context.textTertiary)),
-                                value: settings.encryptionEnabled,
-                                onChanged: (value) async {
-                                  await _saveVaultSettings(
-                                    settings.copyWith(
-                                      encryptionEnabled: value,
-                                    ),
-                                  );
-                                },
-                                activeThumbColor: context.accentColor,
-                                contentPadding: EdgeInsets.zero,
-                              ),
-                              SwitchListTile(
-                                title: const Text('Secure Delete',
-                                    style:
-                                        TextStyle(fontFamily: 'ProductSans')),
-                                subtitle: Text(
-                                    'Overwrite files before deletion',
-                                    style: TextStyle(
-                                        fontFamily: 'ProductSans',
-                                        fontSize: 12,
-                                        color: context.textTertiary)),
-                                value: settings.secureDelete,
-                                onChanged: (value) async {
-                                  await _saveVaultSettings(
-                                    settings.copyWith(
-                                      secureDelete: value,
-                                    ),
-                                  );
-                                },
-                                activeThumbColor: context.accentColor,
-                                contentPadding: EdgeInsets.zero,
-                              ),
-                              SwitchListTile(
-                                title: const Text('Compress Media',
-                                    style:
-                                        TextStyle(fontFamily: 'ProductSans')),
-                                subtitle: Text(
-                                    'Reduce file size for images and videos',
-                                    style: TextStyle(
-                                        fontFamily: 'ProductSans',
-                                        fontSize: 12,
-                                        color: context.textTertiary)),
-                                value: settings.compressionEnabled,
-                                onChanged: (value) async {
-                                  await _saveVaultSettings(
-                                    settings.copyWith(
-                                      compressionEnabled: value,
-                                    ),
-                                  );
-                                },
-                                activeThumbColor: context.accentColor,
-                                contentPadding: EdgeInsets.zero,
-                              ),
-                              const SizedBox(height: 8),
-                              Divider(color: context.borderColor),
-                              const SizedBox(height: 8),
-                              SwitchListTile(
-                                title: const Text(
-                                  'Failed Unlock Protection',
-                                  style: TextStyle(fontFamily: 'ProductSans'),
-                                ),
-                                subtitle: Text(
-                                  'Adds a cooldown after repeated wrong PIN, password, or biometric attempts',
-                                  style: TextStyle(
-                                    fontFamily: 'ProductSans',
-                                    fontSize: 12,
-                                    color: context.textTertiary,
-                                  ),
-                                ),
-                                value: settings.failedUnlockProtectionEnabled,
-                                onChanged: (value) async {
-                                  await _toggleFailedUnlockProtection(
-                                    settings,
-                                    value,
-                                  );
-                                },
-                                activeThumbColor: context.accentColor,
-                                contentPadding: EdgeInsets.zero,
-                              ),
-                              if (settings.failedUnlockProtectionEnabled) ...[
-                                _buildSecurityOptionDropdown(
-                                  title: 'Attempts Before Cooldown',
-                                  subtitle:
-                                      'How many failed unlocks are allowed before access is paused',
-                                  value:
-                                      settings.maxFailedAttemptsBeforeLockout,
-                                  options: _lockoutAttemptOptions,
-                                  labelBuilder: (value) => value.toString(),
-                                  onChanged: (value) async {
-                                    if (value == null) return;
-                                    await _saveUnlockProtectionSettings(
-                                      settings.copyWith(
-                                        maxFailedAttemptsBeforeLockout: value,
-                                      ),
-                                    );
-                                  },
-                                ),
-                                _buildSecurityOptionDropdown(
-                                  title: 'Cooldown Timer',
-                                  subtitle:
-                                      'How long unlock stays disabled after the cooldown threshold is hit',
-                                  value: settings.lockoutDurationSeconds,
-                                  options: _lockoutDurationOptions,
-                                  labelBuilder: _lockoutDurationLabel,
-                                  onChanged: (value) async {
-                                    if (value == null) return;
-                                    await _saveUnlockProtectionSettings(
-                                      settings.copyWith(
-                                        lockoutDurationSeconds: value,
-                                      ),
-                                    );
-                                  },
-                                ),
-                                SwitchListTile(
-                                  title: const Text(
-                                    'Wipe Vault At Hard Limit',
-                                    style: TextStyle(fontFamily: 'ProductSans'),
-                                  ),
-                                  subtitle: Text(
-                                    'Permanently erases real and decoy vault files after too many failed unlocks',
-                                    style: TextStyle(
-                                      fontFamily: 'ProductSans',
-                                      fontSize: 12,
-                                      color: context.textTertiary,
-                                    ),
-                                  ),
-                                  value: settings.wipeVaultOnMaxFailedAttempts,
-                                  onChanged: (value) async {
-                                    await _toggleVaultWipeProtection(
-                                      settings,
-                                      value,
-                                    );
-                                  },
-                                  activeThumbColor: AppColors.error,
-                                  contentPadding: EdgeInsets.zero,
-                                ),
-                                if (settings.wipeVaultOnMaxFailedAttempts) ...[
-                                  _buildSecurityOptionDropdown(
-                                    title: 'Attempts Before Wipe',
-                                    subtitle:
-                                        'Locker erases all vault files when this failed-attempt total is reached',
-                                    value: settings.maxFailedAttemptsBeforeWipe,
-                                    options: _wipeAttemptOptions,
-                                    labelBuilder: (value) => value.toString(),
-                                    onChanged: (value) async {
-                                      if (value == null) return;
-                                      await _saveUnlockProtectionSettings(
-                                        settings.copyWith(
-                                          maxFailedAttemptsBeforeWipe: value,
-                                        ),
-                                      );
-                                    },
-                                  ),
-                                  Container(
-                                    width: double.infinity,
-                                    margin: const EdgeInsets.only(top: 8),
-                                    padding: const EdgeInsets.all(12),
-                                    decoration: BoxDecoration(
-                                      color: AppColors.error
-                                          .withValues(alpha: 0.08),
-                                      borderRadius: BorderRadius.circular(12),
-                                      border: Border.all(
-                                        color: AppColors.error
-                                            .withValues(alpha: 0.18),
-                                      ),
-                                    ),
-                                    child: Text(
-                                      'Warning: wiping the vault is permanent and cannot be undone.',
-                                      style: TextStyle(
-                                        fontFamily: 'ProductSans',
-                                        fontSize: 12,
-                                        color: AppColors.error,
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ],
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  SizedBox(height: MediaQuery.of(context).padding.bottom),
-                ],
-              ),
-            );
-          },
-        ),
+  void _openSettingsScreen() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const VaultSettingsScreen(),
       ),
-    );
-  }
-
-  Future<void> _saveVaultSettings(VaultSettings settings) async {
-    await ref.read(vaultServiceProvider).updateSettings(settings);
-    ref.invalidate(vaultSettingsProvider);
-  }
-
-  Future<void> _saveUnlockProtectionSettings(VaultSettings settings) async {
-    await _saveVaultSettings(settings);
-    await AuthService().resetUnlockAttempts();
-  }
-
-  Future<void> _toggleFailedUnlockProtection(
-    VaultSettings settings,
-    bool enabled,
-  ) async {
-    await _saveUnlockProtectionSettings(
-      settings.copyWith(failedUnlockProtectionEnabled: enabled),
-    );
-  }
-
-  Future<void> _toggleVaultWipeProtection(
-    VaultSettings settings,
-    bool enabled,
-  ) async {
-    if (enabled) {
-      final confirmed = await _confirmDangerousWipeProtection();
-      if (confirmed != true) return;
-    }
-
-    await _saveUnlockProtectionSettings(
-      settings.copyWith(wipeVaultOnMaxFailedAttempts: enabled),
-    );
-  }
-
-  Future<bool?> _confirmDangerousWipeProtection() {
-    return showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: Theme.of(dialogContext).scaffoldBackgroundColor,
-        title: const Text(
-          'Enable Vault Wipe?',
-          style: TextStyle(fontFamily: 'ProductSans'),
-        ),
-        content: const Text(
-          'When the failed-attempt limit is reached, Locker will permanently erase the real and decoy vault files on this device. This cannot be undone.',
-          style: TextStyle(fontFamily: 'ProductSans'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            child: const Text('Enable'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSecurityOptionDropdown({
-    required String title,
-    required String subtitle,
-    required int value,
-    required List<int> options,
-    required String Function(int value) labelBuilder,
-    required ValueChanged<int?> onChanged,
-  }) {
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      title: Text(
-        title,
-        style: const TextStyle(fontFamily: 'ProductSans'),
-      ),
-      subtitle: Text(
-        subtitle,
-        style: TextStyle(
-          fontFamily: 'ProductSans',
-          fontSize: 12,
-          color: context.textTertiary,
-        ),
-      ),
-      trailing: DropdownButtonHideUnderline(
-        child: DropdownButton<int>(
-          value: value,
-          borderRadius: BorderRadius.circular(12),
-          items: options
-              .map(
-                (option) => DropdownMenuItem<int>(
-                  value: option,
-                  child: Text(
-                    labelBuilder(option),
-                    style: const TextStyle(fontFamily: 'ProductSans'),
-                  ),
-                ),
-              )
-              .toList(),
-          onChanged: onChanged,
-        ),
-      ),
-    );
-  }
-
-  String _lockoutDurationLabel(int seconds) {
-    if (seconds < 60) {
-      return '${seconds}s';
-    }
-
-    final minutes = seconds ~/ 60;
-    return minutes == 1 ? '1 min' : '$minutes min';
-  }
-
-  Widget _buildThemeToggle(BuildContext context, WidgetRef ref) {
-    final isDarkMode = ref.watch(isDarkModeProvider);
-
-    return SwitchListTile(
-      title: const Text(
-        'Dark Mode',
-        style: TextStyle(fontFamily: 'ProductSans'),
-      ),
-      subtitle: Text(
-        isDarkMode ? 'Eye-friendly dark theme' : 'Clean light theme',
-        style: TextStyle(
-          fontFamily: 'ProductSans',
-          fontSize: 12,
-          color: context.textTertiary,
-        ),
-      ),
-      secondary: Icon(
-        isDarkMode ? Icons.dark_mode : Icons.light_mode,
-        color: context.accentColor,
-      ),
-      value: isDarkMode,
-      onChanged: (value) {
-        ref.read(themeModeProvider.notifier).toggleTheme();
-      },
-      activeThumbColor: context.accentColor,
-      contentPadding: EdgeInsets.zero,
-    );
-  }
-
-  Widget _buildAccentColorOption(BuildContext context, WidgetRef ref) {
-    final accentColor = ref.watch(accentColorProvider);
-
-    return ListTile(
-      leading: Container(
-        width: 32,
-        height: 32,
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              accentColor.getColor(
-                  context.isDarkMode ? Brightness.dark : Brightness.light),
-              accentColor.getVariantColor(
-                  context.isDarkMode ? Brightness.dark : Brightness.light),
-            ],
-          ),
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.2)
-                : Colors.black.withValues(alpha: 0.1),
-            width: 1.5,
-          ),
-        ),
-      ),
-      title: const Text(
-        'Accent Color',
-        style: TextStyle(fontFamily: 'ProductSans'),
-      ),
-      subtitle: Text(
-        accentColor.name,
-        style: TextStyle(
-          fontFamily: 'ProductSans',
-          fontSize: 12,
-          color: context.textTertiary,
-        ),
-      ),
-      trailing: const Icon(Icons.chevron_right),
-      onTap: () {
-        Navigator.pop(context);
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const AccentColorPickerScreen(),
-          ),
-        );
-      },
-      contentPadding: EdgeInsets.zero,
     );
   }
 

--- a/lib/screens/local_backup_screen.dart
+++ b/lib/screens/local_backup_screen.dart
@@ -2,9 +2,11 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
+import '../models/vaulted_file.dart';
 import '../services/backup_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
+import 'backup_file_selection_screen.dart';
 import 'folder_picker_screen.dart';
 
 /// One save target: label and a way to get its path (or null).
@@ -26,6 +28,8 @@ class LocalBackupScreen extends ConsumerStatefulWidget {
 class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
   final BackupService _backupService = BackupService.instance;
   bool _isBackingUp = false;
+  bool _backupSelectedFilesOnly = false;
+  List<VaultedFile> _selectedFiles = const [];
 
   static List<SaveLocation> get _saveLocations => [
         SaveLocation(
@@ -50,7 +54,46 @@ class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
         ),
       ];
 
+  Future<void> _chooseFilesForBackup() async {
+    final selectedFiles = await Navigator.of(context).push<List<VaultedFile>>(
+      MaterialPageRoute(
+        builder: (context) => BackupFileSelectionScreen(
+          initialSelection: _selectedFiles,
+        ),
+      ),
+    );
+
+    if (!mounted || selectedFiles == null) return;
+
+    setState(() {
+      _backupSelectedFilesOnly = true;
+      _selectedFiles = selectedFiles;
+    });
+  }
+
+  Future<bool> _ensureSelectedFiles() async {
+    if (!_backupSelectedFilesOnly) return true;
+    if (_selectedFiles.isNotEmpty) return true;
+
+    await _chooseFilesForBackup();
+    if (_selectedFiles.isNotEmpty) return true;
+
+    ToastUtils.showError('Select at least one file to backup');
+    return false;
+  }
+
+  String _selectedFilesSubtitle() {
+    if (_selectedFiles.isEmpty) {
+      return 'No files selected';
+    }
+    if (_selectedFiles.length == 1) {
+      return _selectedFiles.first.originalName;
+    }
+    return '${_selectedFiles.length} files selected';
+  }
+
   Future<void> _runBackupToPath(String destinationDirPath) async {
+    if (!await _ensureSelectedFiles()) return;
     if (_isBackingUp) return;
     setState(() => _isBackingUp = true);
 
@@ -79,7 +122,10 @@ class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
       ),
     );
 
-    final result = await _backupService.createBackup(destinationDirPath);
+    final result = await _backupService.createBackup(
+      destinationDirPath,
+      files: _backupSelectedFilesOnly ? _selectedFiles : null,
+    );
 
     if (mounted) Navigator.of(context).pop();
 
@@ -126,6 +172,64 @@ class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
           : ListView(
               padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
               children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: Text(
+                    'Files to include',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 14,
+                      color: context.textTertiary,
+                    ),
+                  ),
+                ),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    ChoiceChip(
+                      label: const Text('All files'),
+                      selected: !_backupSelectedFilesOnly,
+                      onSelected: (_) {
+                        setState(() => _backupSelectedFilesOnly = false);
+                      },
+                    ),
+                    ChoiceChip(
+                      label: const Text('Selected files'),
+                      selected: _backupSelectedFilesOnly,
+                      onSelected: (_) {
+                        setState(() => _backupSelectedFilesOnly = true);
+                      },
+                    ),
+                  ],
+                ),
+                if (_backupSelectedFilesOnly)
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: Icon(Icons.library_books_outlined,
+                        color: context.accentColor),
+                    title: Text(
+                      'Choose files',
+                      style: TextStyle(
+                        fontFamily: 'ProductSans',
+                        fontWeight: FontWeight.w500,
+                        color: context.textPrimary,
+                      ),
+                    ),
+                    subtitle: Text(
+                      _selectedFilesSubtitle(),
+                      style: TextStyle(
+                        fontFamily: 'ProductSans',
+                        fontSize: 12,
+                        color: context.textTertiary,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    trailing:
+                        Icon(Icons.chevron_right, color: context.textTertiary),
+                    onTap: _chooseFilesForBackup,
+                  ),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 12),
                   child: Text(

--- a/lib/screens/media_picker_screen.dart
+++ b/lib/screens/media_picker_screen.dart
@@ -33,11 +33,15 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
   AssetPathEntity? _currentAlbum;
   List<AssetEntity> _assets = [];
   final Set<AssetEntity> _selectedAssets = {};
+  final Map<String, GlobalKey> _tileKeys = {};
   bool _isLoading = true;
   int _currentPage = 0;
   static const int _pageSize = 80;
   bool _hasMoreToLoad = true;
   final ScrollController _scrollController = ScrollController();
+  bool _isSlidingSelection = false;
+  bool? _slidingSelectionValue;
+  final Set<String> _slidingTouchedAssetIds = {};
 
   @override
   void initState() {
@@ -147,23 +151,113 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
 
   void _toggleSelection(AssetEntity asset) {
     setState(() {
-      if (_selectedAssets.contains(asset)) {
-        _selectedAssets.remove(asset);
-      } else {
-        if (widget.maxSelection > 0 &&
-            _selectedAssets.length >= widget.maxSelection) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content:
-                  Text('Maximum ${widget.maxSelection} items can be selected'),
-              duration: const Duration(seconds: 1),
-            ),
-          );
-          return;
-        }
-        _selectedAssets.add(asset);
-      }
+      _setSelected(asset, !_selectedAssets.contains(asset));
     });
+  }
+
+  bool _setSelected(AssetEntity asset, bool isSelected,
+      {bool showLimitError = true}) {
+    if (isSelected) {
+      if (_selectedAssets.contains(asset)) return true;
+
+      if (widget.maxSelection > 0 &&
+          _selectedAssets.length >= widget.maxSelection) {
+        if (showLimitError) {
+          _showMaxSelectionMessage();
+        }
+        return false;
+      }
+
+      _selectedAssets.add(asset);
+      return true;
+    }
+
+    _selectedAssets.remove(asset);
+    return true;
+  }
+
+  void _showMaxSelectionMessage() {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text('Maximum ${widget.maxSelection} items can be selected'),
+          duration: const Duration(seconds: 1),
+        ),
+      );
+  }
+
+  GlobalKey _tileKeyFor(String assetId) {
+    return _tileKeys.putIfAbsent(assetId, GlobalKey.new);
+  }
+
+  void _startSlidingSelection(AssetEntity asset) {
+    final shouldSelect = !_selectedAssets.contains(asset);
+    if (!_setSelected(asset, shouldSelect)) return;
+
+    setState(() {
+      _isSlidingSelection = true;
+      _slidingSelectionValue = shouldSelect;
+      _slidingTouchedAssetIds
+        ..clear()
+        ..add(asset.id);
+    });
+  }
+
+  void _updateSlidingSelection(Offset globalPosition) {
+    if (!_isSlidingSelection || _slidingSelectionValue == null) return;
+
+    final assetId = _assetIdAt(globalPosition);
+    if (assetId == null || _slidingTouchedAssetIds.contains(assetId)) return;
+
+    final asset = _assetById(assetId);
+    if (asset == null) return;
+
+    final applied =
+        _setSelected(asset, _slidingSelectionValue!, showLimitError: false);
+    if (!applied) {
+      _showMaxSelectionMessage();
+      _stopSlidingSelection();
+      return;
+    }
+
+    setState(() {
+      _slidingTouchedAssetIds.add(assetId);
+    });
+  }
+
+  void _stopSlidingSelection() {
+    if (!_isSlidingSelection) return;
+
+    setState(() {
+      _isSlidingSelection = false;
+      _slidingSelectionValue = null;
+      _slidingTouchedAssetIds.clear();
+    });
+  }
+
+  AssetEntity? _assetById(String assetId) {
+    for (final asset in _assets) {
+      if (asset.id == assetId) return asset;
+    }
+    return null;
+  }
+
+  String? _assetIdAt(Offset globalPosition) {
+    for (final entry in _tileKeys.entries) {
+      final context = entry.value.currentContext;
+      if (context == null) continue;
+
+      final renderObject = context.findRenderObject();
+      if (renderObject is! RenderBox || !renderObject.hasSize) continue;
+
+      final rect = renderObject.localToGlobal(Offset.zero) & renderObject.size;
+      if (rect.contains(globalPosition)) {
+        return entry.key;
+      }
+    }
+
+    return null;
   }
 
   void _selectAll() {
@@ -310,6 +404,10 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
   }
 
   Widget _buildMediaGrid() {
+    _tileKeys.removeWhere(
+      (assetId, _) => !_assets.any((asset) => asset.id == assetId),
+    );
+
     return GridView.builder(
       controller: _scrollController,
       padding: const EdgeInsets.all(2),
@@ -341,8 +439,14 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
     final selectionIndex = _selectedAssets.toList().indexOf(asset);
 
     return GestureDetector(
+      onLongPressStart: (_) => _startSlidingSelection(asset),
+      onLongPressMoveUpdate: (details) =>
+          _updateSlidingSelection(details.globalPosition),
+      onLongPressEnd: (_) => _stopSlidingSelection(),
+      onLongPressCancel: _stopSlidingSelection,
       onTap: () => _toggleSelection(asset),
       child: Stack(
+        key: _tileKeyFor(asset.id),
         fit: StackFit.expand,
         children: [
           // Thumbnail

--- a/lib/screens/vault_settings_screen.dart
+++ b/lib/screens/vault_settings_screen.dart
@@ -1,0 +1,582 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/theme_provider.dart';
+import '../providers/vault_providers.dart';
+import '../services/auth_service.dart';
+import '../services/auto_kill_service.dart';
+import '../services/screenshot_protection_service.dart';
+import '../services/vault_service.dart';
+import '../themes/app_colors.dart';
+import 'accent_color_picker_screen.dart';
+import 'change_security_screen.dart';
+import 'local_backup_screen.dart';
+
+class VaultSettingsScreen extends ConsumerStatefulWidget {
+  const VaultSettingsScreen({super.key});
+
+  @override
+  ConsumerState<VaultSettingsScreen> createState() =>
+      _VaultSettingsScreenState();
+}
+
+class _VaultSettingsScreenState extends ConsumerState<VaultSettingsScreen> {
+  static const List<int> _autoKillDelayOptions = [0, 5, 10, 30, 60];
+  static const List<int> _lockoutAttemptOptions = [3, 5, 7, 10];
+  static const List<int> _lockoutDurationOptions = [30, 60, 300, 900];
+  static const List<int> _wipeAttemptOptions = [10, 15, 20, 30];
+
+  @override
+  Widget build(BuildContext context) {
+    final settingsAsync = ref.watch(vaultSettingsProvider);
+
+    return Scaffold(
+      backgroundColor: context.backgroundColor,
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: context.textPrimary),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Settings',
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            color: context.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+      ),
+      body: settingsAsync.when(
+        loading: () => Center(
+          child: CircularProgressIndicator(color: context.accentColor),
+        ),
+        error: (_, __) => Center(
+          child: Text(
+            'Failed to load settings',
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              color: context.textPrimary,
+            ),
+          ),
+        ),
+        data: (settings) {
+          final autoKillSupported = AutoKillService.isSupported;
+          final screenshotProtectionSupported =
+              ScreenshotProtectionService.isSupported;
+
+          return ListView(
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+            children: [
+              _buildSectionTitle(context, 'Security'),
+              ListTile(
+                leading:
+                    Icon(Icons.security_outlined, color: context.accentColor),
+                title: const Text(
+                  'Change Security',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  'Change password, PIN, or biometric',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const ChangeSecurityScreen(),
+                    ),
+                  );
+                },
+                contentPadding: EdgeInsets.zero,
+              ),
+              SwitchListTile(
+                title: const Text(
+                  'Encrypt New Files',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  'AES-256 encryption for all new imports',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                value: settings.encryptionEnabled,
+                onChanged: (value) async {
+                  await _saveVaultSettings(
+                    settings.copyWith(encryptionEnabled: value),
+                  );
+                },
+                activeThumbColor: context.accentColor,
+                contentPadding: EdgeInsets.zero,
+              ),
+              SwitchListTile(
+                title: const Text(
+                  'Secure Delete',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  'Overwrite files before deletion',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                value: settings.secureDelete,
+                onChanged: (value) async {
+                  await _saveVaultSettings(
+                    settings.copyWith(secureDelete: value),
+                  );
+                },
+                activeThumbColor: context.accentColor,
+                contentPadding: EdgeInsets.zero,
+              ),
+              SwitchListTile(
+                title: const Text(
+                  'In-App Screenshot Protection',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  screenshotProtectionSupported
+                      ? 'Blocks screenshots and app previews while Locker is open'
+                      : 'Available on supported Android devices',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                value: settings.screenshotProtectionEnabled,
+                onChanged: screenshotProtectionSupported
+                    ? (value) async {
+                        await _saveVaultSettings(
+                          settings.copyWith(
+                            screenshotProtectionEnabled: value,
+                          ),
+                        );
+                      }
+                    : null,
+                activeThumbColor: context.accentColor,
+                contentPadding: EdgeInsets.zero,
+              ),
+              _buildSecurityOptionDropdown(
+                context: context,
+                title: 'Auto-Kill Delay',
+                subtitle: autoKillSupported
+                    ? 'How long Locker waits after going to the background before it closes itself'
+                    : 'Available on supported Android devices',
+                value: settings.autoKillDelaySeconds,
+                options: _autoKillDelayOptions,
+                labelBuilder: _autoKillDelayLabel,
+                enabled: autoKillSupported,
+                onChanged: (value) async {
+                  if (value == null) return;
+                  await _saveVaultSettings(
+                    settings.copyWith(autoKillDelaySeconds: value),
+                  );
+                },
+              ),
+              const SizedBox(height: 20),
+              Divider(color: context.borderColor),
+              const SizedBox(height: 20),
+              _buildSectionTitle(context, 'Appearance'),
+              _buildThemeToggle(context, ref),
+              _buildAccentColorOption(context, ref),
+              const SizedBox(height: 20),
+              Divider(color: context.borderColor),
+              const SizedBox(height: 20),
+              _buildSectionTitle(context, 'Storage'),
+              ListTile(
+                leading:
+                    Icon(Icons.backup_outlined, color: context.accentColor),
+                title: const Text(
+                  'Local Backup',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  'Save vault as ZIP to a folder',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const LocalBackupScreen(),
+                    ),
+                  );
+                },
+                contentPadding: EdgeInsets.zero,
+              ),
+              SwitchListTile(
+                title: const Text(
+                  'Compress Media',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  'Reduce file size for images and videos',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                value: settings.compressionEnabled,
+                onChanged: (value) async {
+                  await _saveVaultSettings(
+                    settings.copyWith(compressionEnabled: value),
+                  );
+                },
+                activeThumbColor: context.accentColor,
+                contentPadding: EdgeInsets.zero,
+              ),
+              const SizedBox(height: 20),
+              Divider(color: context.borderColor),
+              const SizedBox(height: 20),
+              _buildSectionTitle(context, 'Unlock Protection'),
+              SwitchListTile(
+                title: const Text(
+                  'Failed Unlock Protection',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  'Adds a cooldown after repeated wrong PIN, password, or biometric attempts',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                value: settings.failedUnlockProtectionEnabled,
+                onChanged: (value) async {
+                  await _toggleFailedUnlockProtection(settings, value);
+                },
+                activeThumbColor: context.accentColor,
+                contentPadding: EdgeInsets.zero,
+              ),
+              if (settings.failedUnlockProtectionEnabled) ...[
+                _buildSecurityOptionDropdown(
+                  context: context,
+                  title: 'Attempts Before Cooldown',
+                  subtitle:
+                      'How many failed unlocks are allowed before access is paused',
+                  value: settings.maxFailedAttemptsBeforeLockout,
+                  options: _lockoutAttemptOptions,
+                  labelBuilder: (value) => value.toString(),
+                  onChanged: (value) async {
+                    if (value == null) return;
+                    await _saveUnlockProtectionSettings(
+                      settings.copyWith(maxFailedAttemptsBeforeLockout: value),
+                    );
+                  },
+                ),
+                _buildSecurityOptionDropdown(
+                  context: context,
+                  title: 'Cooldown Timer',
+                  subtitle:
+                      'How long unlock stays disabled after the cooldown threshold is hit',
+                  value: settings.lockoutDurationSeconds,
+                  options: _lockoutDurationOptions,
+                  labelBuilder: _lockoutDurationLabel,
+                  onChanged: (value) async {
+                    if (value == null) return;
+                    await _saveUnlockProtectionSettings(
+                      settings.copyWith(lockoutDurationSeconds: value),
+                    );
+                  },
+                ),
+                SwitchListTile(
+                  title: const Text(
+                    'Wipe Vault At Hard Limit',
+                    style: TextStyle(fontFamily: 'ProductSans'),
+                  ),
+                  subtitle: Text(
+                    'Permanently erases real and decoy vault files after too many failed unlocks',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 12,
+                      color: context.textTertiary,
+                    ),
+                  ),
+                  value: settings.wipeVaultOnMaxFailedAttempts,
+                  onChanged: (value) async {
+                    await _toggleVaultWipeProtection(settings, value);
+                  },
+                  activeThumbColor: AppColors.error,
+                  contentPadding: EdgeInsets.zero,
+                ),
+                if (settings.wipeVaultOnMaxFailedAttempts) ...[
+                  _buildSecurityOptionDropdown(
+                    context: context,
+                    title: 'Attempts Before Wipe',
+                    subtitle:
+                        'Locker erases all vault files when this failed-attempt total is reached',
+                    value: settings.maxFailedAttemptsBeforeWipe,
+                    options: _wipeAttemptOptions,
+                    labelBuilder: (value) => value.toString(),
+                    onChanged: (value) async {
+                      if (value == null) return;
+                      await _saveUnlockProtectionSettings(
+                        settings.copyWith(maxFailedAttemptsBeforeWipe: value),
+                      );
+                    },
+                  ),
+                  Container(
+                    width: double.infinity,
+                    margin: const EdgeInsets.only(top: 8),
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: AppColors.error.withValues(alpha: 0.08),
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: AppColors.error.withValues(alpha: 0.18),
+                      ),
+                    ),
+                    child: Text(
+                      'Warning: wiping the vault is permanent and cannot be undone.',
+                      style: TextStyle(
+                        fontFamily: 'ProductSans',
+                        fontSize: 12,
+                        color: AppColors.error,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        title,
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: 18,
+          fontWeight: FontWeight.w600,
+          color: context.textPrimary,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _saveVaultSettings(VaultSettings settings) async {
+    await ref.read(vaultServiceProvider).updateSettings(settings);
+    await AutoKillService.setDelaySeconds(settings.autoKillDelaySeconds);
+    await ScreenshotProtectionService.setEnabled(
+      settings.screenshotProtectionEnabled,
+    );
+    ref.invalidate(vaultSettingsProvider);
+  }
+
+  Future<void> _saveUnlockProtectionSettings(VaultSettings settings) async {
+    await _saveVaultSettings(settings);
+    await AuthService().resetUnlockAttempts();
+  }
+
+  Future<void> _toggleFailedUnlockProtection(
+    VaultSettings settings,
+    bool enabled,
+  ) async {
+    await _saveUnlockProtectionSettings(
+      settings.copyWith(failedUnlockProtectionEnabled: enabled),
+    );
+  }
+
+  Future<void> _toggleVaultWipeProtection(
+    VaultSettings settings,
+    bool enabled,
+  ) async {
+    if (enabled) {
+      final confirmed = await _confirmDangerousWipeProtection();
+      if (confirmed != true) return;
+    }
+
+    await _saveUnlockProtectionSettings(
+      settings.copyWith(wipeVaultOnMaxFailedAttempts: enabled),
+    );
+  }
+
+  Future<bool?> _confirmDangerousWipeProtection() {
+    return showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: Theme.of(dialogContext).scaffoldBackgroundColor,
+        title: const Text(
+          'Enable Vault Wipe?',
+          style: TextStyle(fontFamily: 'ProductSans'),
+        ),
+        content: const Text(
+          'When the failed-attempt limit is reached, Locker will permanently erase the real and decoy vault files on this device. This cannot be undone.',
+          style: TextStyle(fontFamily: 'ProductSans'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Enable'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSecurityOptionDropdown({
+    required BuildContext context,
+    required String title,
+    required String subtitle,
+    required int value,
+    required List<int> options,
+    required String Function(int value) labelBuilder,
+    bool enabled = true,
+    required ValueChanged<int?> onChanged,
+  }) {
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(
+        title,
+        style: const TextStyle(fontFamily: 'ProductSans'),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: 12,
+          color: context.textTertiary,
+        ),
+      ),
+      trailing: DropdownButtonHideUnderline(
+        child: DropdownButton<int>(
+          value: value,
+          borderRadius: BorderRadius.circular(12),
+          items: options
+              .map(
+                (option) => DropdownMenuItem<int>(
+                  value: option,
+                  child: Text(
+                    labelBuilder(option),
+                    style: const TextStyle(fontFamily: 'ProductSans'),
+                  ),
+                ),
+              )
+              .toList(),
+          onChanged: enabled ? onChanged : null,
+        ),
+      ),
+    );
+  }
+
+  String _lockoutDurationLabel(int seconds) {
+    if (seconds < 60) {
+      return '${seconds}s';
+    }
+
+    final minutes = seconds ~/ 60;
+    return minutes == 1 ? '1 min' : '$minutes min';
+  }
+
+  String _autoKillDelayLabel(int seconds) {
+    if (seconds == 0) return 'Instant';
+    return _lockoutDurationLabel(seconds);
+  }
+
+  Widget _buildThemeToggle(BuildContext context, WidgetRef ref) {
+    final isDarkMode = ref.watch(isDarkModeProvider);
+
+    return SwitchListTile(
+      title: const Text(
+        'Dark Mode',
+        style: TextStyle(fontFamily: 'ProductSans'),
+      ),
+      subtitle: Text(
+        isDarkMode ? 'Eye-friendly dark theme' : 'Clean light theme',
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: 12,
+          color: context.textTertiary,
+        ),
+      ),
+      secondary: Icon(
+        isDarkMode ? Icons.dark_mode : Icons.light_mode,
+        color: context.accentColor,
+      ),
+      value: isDarkMode,
+      onChanged: (_) {
+        ref.read(themeModeProvider.notifier).toggleTheme();
+      },
+      activeThumbColor: context.accentColor,
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+
+  Widget _buildAccentColorOption(BuildContext context, WidgetRef ref) {
+    final accentColor = ref.watch(accentColorProvider);
+
+    return ListTile(
+      leading: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              accentColor.getColor(
+                context.isDarkMode ? Brightness.dark : Brightness.light,
+              ),
+              accentColor.getVariantColor(
+                context.isDarkMode ? Brightness.dark : Brightness.light,
+              ),
+            ],
+          ),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: context.isDarkMode
+                ? Colors.white.withValues(alpha: 0.2)
+                : Colors.black.withValues(alpha: 0.1),
+            width: 1.5,
+          ),
+        ),
+      ),
+      title: const Text(
+        'Accent Color',
+        style: TextStyle(fontFamily: 'ProductSans'),
+      ),
+      subtitle: Text(
+        accentColor.name,
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: 12,
+          color: context.textTertiary,
+        ),
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const AccentColorPickerScreen(),
+          ),
+        );
+      },
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+}

--- a/lib/services/auto_kill_service.dart
+++ b/lib/services/auto_kill_service.dart
@@ -5,15 +5,33 @@ class AutoKillService {
   static const MethodChannel _channel =
       MethodChannel('com.ultraelectronica.locker/autokill');
 
+  static bool get isSupported =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
   /// Set whether the auto-kill feature (killing app on pause) is enabled.
   /// Set to [false] before requesting permissions or launching external intents.
   /// Set back to [true] immediately after the interaction is complete or the app resumes.
   static Future<void> setEnabled(bool enabled) async {
+    if (!isSupported) return;
+
     try {
       await _channel.invokeMethod('setAutoKillEnabled', enabled);
       debugPrint('[AutoKill] Set enabled: $enabled');
     } on PlatformException catch (e) {
       debugPrint('[AutoKill] Failed to set enabled: $e');
+    }
+  }
+
+  static Future<void> setDelaySeconds(int seconds) async {
+    if (!isSupported) return;
+
+    try {
+      await _channel.invokeMethod('setAutoKillDelaySeconds', {
+        'seconds': seconds,
+      });
+      debugPrint('[AutoKill] Set delay seconds: $seconds');
+    } on PlatformException catch (e) {
+      debugPrint('[AutoKill] Failed to set delay: $e');
     }
   }
 

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -50,17 +50,21 @@ class BackupService {
     return '$_zipPrefix${const Uuid().v4().replaceAll('-', '')}$_zipSuffix';
   }
 
-  /// ZIPs all real vault files (decrypted) into [destinationDirPath] with a random name.
+  /// ZIPs real vault files (decrypted) into [destinationDirPath] with a random name.
   Future<BackupResult> createBackup(
     String destinationDirPath, {
+    List<VaultedFile>? files,
     void Function(int current, int total)? onProgress,
   }) async {
     try {
-      final files = await _vaultService.getAllFiles(isDecoy: false);
-      if (files.isEmpty) {
-        return const BackupResult(
+      final filesToBackup =
+          files ?? await _vaultService.getAllFiles(isDecoy: false);
+      if (filesToBackup.isEmpty) {
+        return BackupResult(
           success: false,
-          error: 'No files in vault to backup',
+          error: files == null
+              ? 'No files in vault to backup'
+              : 'No files selected for backup',
         );
       }
 
@@ -74,11 +78,11 @@ class BackupService {
         final zipPath = '$destinationDirPath/${generateRandomZipName()}';
         encoder.create(zipPath);
 
-        final total = files.length;
+        final total = filesToBackup.length;
         int current = 0;
         final usedNames = <String, int>{};
 
-        for (final file in files) {
+        for (final file in filesToBackup) {
           final subdir = _subdirForType(file.type);
           final dir = Directory('${workDir.path}/$subdir');
           if (!await dir.exists()) await dir.create(recursive: true);

--- a/lib/services/screenshot_protection_service.dart
+++ b/lib/services/screenshot_protection_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class ScreenshotProtectionService {
+  ScreenshotProtectionService._();
+
+  static const MethodChannel _channel =
+      MethodChannel('com.ultraelectronica.locker/screenshot_protection');
+
+  static bool get isSupported =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+
+  static Future<void> setEnabled(bool enabled) async {
+    if (!isSupported) return;
+
+    try {
+      await _channel.invokeMethod('setScreenshotProtectionEnabled', enabled);
+      debugPrint('[ScreenshotProtection] Set enabled: $enabled');
+    } on PlatformException catch (e) {
+      debugPrint('[ScreenshotProtection] Failed to set enabled: $e');
+    }
+  }
+}

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -1363,6 +1363,8 @@ class FileToVault {
 class VaultSettings {
   final bool encryptionEnabled;
   final bool secureDelete;
+  final bool screenshotProtectionEnabled;
+  final int autoKillDelaySeconds;
   final SortOption defaultSort;
   final bool showHiddenFiles;
   final bool autoBackup;
@@ -1379,6 +1381,8 @@ class VaultSettings {
   const VaultSettings({
     this.encryptionEnabled = false,
     this.secureDelete = true,
+    this.screenshotProtectionEnabled = false,
+    this.autoKillDelaySeconds = 0,
     this.defaultSort = SortOption.dateAddedNewest,
     this.showHiddenFiles = false,
     this.autoBackup = false,
@@ -1396,6 +1400,8 @@ class VaultSettings {
   VaultSettings copyWith({
     bool? encryptionEnabled,
     bool? secureDelete,
+    bool? screenshotProtectionEnabled,
+    int? autoKillDelaySeconds,
     SortOption? defaultSort,
     bool? showHiddenFiles,
     bool? autoBackup,
@@ -1412,6 +1418,9 @@ class VaultSettings {
     return VaultSettings(
       encryptionEnabled: encryptionEnabled ?? this.encryptionEnabled,
       secureDelete: secureDelete ?? this.secureDelete,
+      screenshotProtectionEnabled:
+          screenshotProtectionEnabled ?? this.screenshotProtectionEnabled,
+      autoKillDelaySeconds: autoKillDelaySeconds ?? this.autoKillDelaySeconds,
       defaultSort: defaultSort ?? this.defaultSort,
       showHiddenFiles: showHiddenFiles ?? this.showHiddenFiles,
       autoBackup: autoBackup ?? this.autoBackup,
@@ -1435,6 +1444,8 @@ class VaultSettings {
   Map<String, dynamic> toJson() => {
         'encryptionEnabled': encryptionEnabled,
         'secureDelete': secureDelete,
+        'screenshotProtectionEnabled': screenshotProtectionEnabled,
+        'autoKillDelaySeconds': autoKillDelaySeconds,
         'defaultSort': defaultSort.name,
         'showHiddenFiles': showHiddenFiles,
         'autoBackup': autoBackup,
@@ -1453,6 +1464,9 @@ class VaultSettings {
     return VaultSettings(
       encryptionEnabled: json['encryptionEnabled'] as bool? ?? false,
       secureDelete: json['secureDelete'] as bool? ?? true,
+      screenshotProtectionEnabled:
+          json['screenshotProtectionEnabled'] as bool? ?? false,
+      autoKillDelaySeconds: json['autoKillDelaySeconds'] as int? ?? 0,
       defaultSort: SortOption.values.firstWhere(
         (s) => s.name == (json['defaultSort'] as String? ?? 'dateAddedNewest'),
         orElse: () => SortOption.dateAddedNewest,


### PR DESCRIPTION
# Summary

Adds a dedicated vault settings screen, sliding selection for multi-file selection, and security enhancements including auto-kill and screenshot protection.

# Changes

## UI Enhancements

- Introduce sliding selection feature for multi-file selection in gallery vault and media picker
- Refactor `GalleryVaultScreen` with tab-specific selection keys
- Refactor selection management with new methods for toggling and updating selections
- Introduce tile key management for better asset tracking during sliding selection

## Settings

- Add `VaultSettingsScreen` with options for security, appearance, and storage settings
- Replace settings sheet with navigation to vault settings screen
- Add functionality for changing security settings and toggling encryption/secure delete features
- Enhance Local Backup Screen to allow selection of specific files for backup
- Add optional file selection support in `BackupService`

## Security

- Implement auto-kill functionality with configurable delay
- Add screenshot protection toggle
- Update method channel handling for auto-kill and screenshot protection settings
- Add `isSupported` checks for platform feature compatibility
- Implement `setDelaySeconds` method for configuring auto-kill delay
- Update `VaultSettings` to include screenshot protection and auto-kill delay options
