### PR TITLE
Add privacy policy screen with markdown rendering

### DIFF
--- a/assets/privacy_policy.md
+++ b/assets/privacy_policy.md
@@ -1,0 +1,75 @@
+# Privacy Policy
+
+**Last updated: May 4, 2026**
+
+## Our Commitment
+
+Locker is built with privacy as its core principle. We believe your personal data should stay on your device, not on our servers. This app does not collect, store, transmit, or share any personal information.
+
+## Data We Do Not Collect
+
+Locker does not collect any data whatsoever. Specifically:
+
+- No personal information (name, email, phone number, etc.)
+- No usage analytics or telemetry
+- No crash reports or diagnostics sent externally
+- No advertising identifiers or tracking data
+- No location data
+- No device identifiers
+- No contacts, messages, or call logs
+- No browsing history or app usage data
+
+Everything you do in Locker stays on your device.
+
+## Camera Access
+
+Locker may request camera permission only when you choose to scan a QR code or take a photo to import into your vault. The camera is used solely for these purposes:
+
+- QR code scanning for quick vault access
+- Capturing photos to store in your vault
+
+Camera access is never used in the background. No photos or video from your camera are transmitted to any server. All captured media is stored locally and encrypted on your device.
+
+## Media & Files
+
+Locker is a secure media vault. Files you import into Locker are encrypted using AES-256 encryption and stored locally on your device. We do not:
+
+- Upload your files to any cloud or server
+- Scan or analyze your files
+- Share your files with any third party
+- Access your files without your explicit action
+
+Your vault key never leaves your device.
+
+## Storage Permission
+
+Locker requires storage permission to read files you want to vault and to save encrypted files to your device. This permission is used only when you explicitly choose to import or export files.
+
+## Biometric Authentication
+
+If you choose to use fingerprint or face unlock, biometric data is handled entirely by your device operating system. Locker only receives a success or failure signal — it never stores or accesses your biometric data.
+
+## Third-Party Services
+
+Locker does not integrate with any third-party analytics, advertising, or tracking services. The only external connection is:
+
+- Play Store update check (optional, triggered by you)
+- Donation link to Ko-fi (optional, opened in your browser)
+
+Neither of these transmits any personal data from Locker.
+
+## Local Backups
+
+If you choose to create a local backup, the backup file is saved to a location you select on your device. Locker does not upload backups anywhere. You are responsible for securing your backup files.
+
+## Children's Privacy
+
+Locker does not knowingly collect any information from anyone, including children under 13. Since no data is collected at all, there is no risk of personal information being gathered from minors.
+
+## Changes to This Policy
+
+If we update this Privacy Policy, the changes will be reflected in the app. We encourage you to review this policy periodically.
+
+## Contact
+
+If you have any questions about this Privacy Policy, please reach out through the project repository.

--- a/lib/screens/privacy_policy_screen.dart
+++ b/lib/screens/privacy_policy_screen.dart
@@ -1,162 +1,127 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 
-class PrivacyPolicyScreen extends StatelessWidget {
+class PrivacyPolicyScreen extends StatefulWidget {
   const PrivacyPolicyScreen({super.key});
 
   @override
+  State<PrivacyPolicyScreen> createState() => _PrivacyPolicyScreenState();
+}
+
+class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
+  String? _markdown;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMarkdown();
+  }
+
+  Future<void> _loadMarkdown() async {
+    try {
+      final content = await rootBundle.loadString('assets/privacy_policy.md');
+      if (mounted) {
+        setState(() => _markdown = content);
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() => _markdown = 'Failed to load privacy policy.');
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return Scaffold(
-      backgroundColor: _backgroundColor(context),
+      backgroundColor: isDark ? const Color(0xFF121212) : const Color(0xFFFFFFFF),
       appBar: AppBar(
         leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: _textPrimary(context)),
+          icon: Icon(Icons.arrow_back, color: _textPrimary(isDark)),
           onPressed: () => Navigator.pop(context),
         ),
         title: Text(
           'Privacy Policy',
           style: TextStyle(
             fontFamily: 'ProductSans',
-            color: _textPrimary(context),
+            color: _textPrimary(isDark),
             fontWeight: FontWeight.w600,
           ),
         ),
         backgroundColor: Colors.transparent,
         elevation: 0,
       ),
-      body: ListView(
-        padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
-        children: [
-          _buildLastUpdated(context),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Our Commitment',
-              'Locker is built with privacy as its core principle. We believe your personal data should stay on your device, not on our servers. This app does not collect, store, transmit, or share any personal information.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Data We Do Not Collect',
-              'Locker does not collect any data whatsoever. Specifically:\n\n'
-              '• No personal information (name, email, phone number, etc.)\n'
-              '• No usage analytics or telemetry\n'
-              '• No crash reports or diagnostics sent externally\n'
-              '• No advertising identifiers or tracking data\n'
-              '• No location data\n'
-              '• No device identifiers\n'
-              '• No contacts, messages, or call logs\n'
-              '• No browsing history or app usage data\n\n'
-              'Everything you do in Locker stays on your device.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Camera Access',
-              'Locker may request camera permission only when you choose to scan a QR code or take a photo to import into your vault. The camera is used solely for these purposes:\n\n'
-              '• QR code scanning for quick vault access\n'
-              '• Capturing photos to store in your vault\n\n'
-              'Camera access is never used in the background. No photos or video from your camera are transmitted to any server. All captured media is stored locally and encrypted on your device.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Media & Files',
-              'Locker is a secure media vault. Files you import into Locker are encrypted using AES-256 encryption and stored locally on your device. We do not:\n\n'
-              '• Upload your files to any cloud or server\n'
-              '• Scan or analyze your files\n'
-              '• Share your files with any third party\n'
-              '• Access your files without your explicit action\n\n'
-              'Your vault key never leaves your device.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Storage Permission',
-              'Locker requires storage permission to read files you want to vault and to save encrypted files to your device. This permission is used only when you explicitly choose to import or export files.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Biometric Authentication',
-              'If you choose to use fingerprint or face unlock, biometric data is handled entirely by your device operating system. Locker only receives a success or failure signal — it never stores or accesses your biometric data.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Third-Party Services',
-              'Locker does not integrate with any third-party analytics, advertising, or tracking services. The only external connection is:\n\n'
-              '• Play Store update check (optional, triggered by you)\n'
-              '• Donation link to Ko-fi (optional, opened in your browser)\n\n'
-              'Neither of these transmits any personal data from Locker.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Local Backups',
-              'If you choose to create a local backup, the backup file is saved to a location you select on your device. Locker does not upload backups anywhere. You are responsible for securing your backup files.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Children\'s Privacy',
-              'Locker does not knowingly collect any information from anyone, including children under 13. Since no data is collected at all, there is no risk of personal information being gathered from minors.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Changes to This Policy',
-              'If we update this Privacy Policy, the changes will be reflected in the app. We encourage you to review this policy periodically.'),
-          const SizedBox(height: 20),
-          _buildSection(context, 'Contact',
-              'If you have any questions about this Privacy Policy, please reach out through the project repository.'),
-        ],
-      ),
+      body: _markdown == null
+          ? Center(child: CircularProgressIndicator(color: Theme.of(context).colorScheme.primary))
+          : Markdown(
+              data: _markdown!,
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+              styleSheet: MarkdownStyleSheet(
+                h1: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 24,
+                  fontWeight: FontWeight.w700,
+                  color: _textPrimary(isDark),
+                ),
+                h2: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  color: _textPrimary(isDark),
+                ),
+                p: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 14,
+                  color: _textSecondary(isDark),
+                  height: 1.5,
+                ),
+                strong: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontWeight: FontWeight.w600,
+                  color: _textPrimary(isDark),
+                ),
+                listBullet: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 14,
+                  color: _textSecondary(isDark),
+                ),
+                listBulletPadding: const EdgeInsets.symmetric(horizontal: 8),
+                blockquote: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 14,
+                  fontStyle: FontStyle.italic,
+                  color: _textSecondary(isDark),
+                ),
+                blockquoteDecoration: BoxDecoration(
+                  border: Border(
+                    left: BorderSide(
+                      color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+                      width: 3,
+                    ),
+                  ),
+                ),
+                code: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  backgroundColor: isDark ? const Color(0xFF2A2A2A) : const Color(0xFFF0F0F0),
+                  color: _textPrimary(isDark),
+                ),
+                horizontalRuleDecoration: BoxDecoration(
+                  border: Border(
+                    top: BorderSide(
+                      color: isDark ? const Color(0xFF333333) : const Color(0xFFE0E0E0),
+                      width: 1,
+                    ),
+                  ),
+                ),
+              ),
+              selectable: true,
+            ),
     );
   }
 
-  Widget _buildSection(
-      BuildContext context, String title, String content) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          title,
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-            color: _textPrimary(context),
-          ),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          content,
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            fontSize: 14,
-            color: _textSecondary(context),
-            height: 1.5,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildLastUpdated(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: _accentColor(context).withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: _accentColor(context).withValues(alpha: 0.18),
-        ),
-      ),
-      child: Text(
-        'Last updated: May 4, 2026',
-        style: TextStyle(
-          fontFamily: 'ProductSans',
-          fontSize: 12,
-          color: _accentColor(context),
-        ),
-      ),
-    );
-  }
-
-  Color _backgroundColor(BuildContext context) {
-    final brightness = Theme.of(context).brightness;
-    return brightness == Brightness.dark
-        ? const Color(0xFF121212)
-        : const Color(0xFFFFFFFF);
-  }
-
-  Color _textPrimary(BuildContext context) {
-    final brightness = Theme.of(context).brightness;
-    return brightness == Brightness.dark
-        ? const Color(0xFFE5E5E5)
-        : const Color(0xFF1A1A1A);
-  }
-
-  Color _textSecondary(BuildContext context) {
-    final brightness = Theme.of(context).brightness;
-    return brightness == Brightness.dark
-        ? const Color(0xFFA0A0A0)
-        : const Color(0xFF555555);
-  }
-
-  Color _accentColor(BuildContext context) {
-    return Theme.of(context).colorScheme.primary;
-  }
+  Color _textPrimary(bool isDark) => isDark ? const Color(0xFFE5E5E5) : const Color(0xFF1A1A1A);
+  Color _textSecondary(bool isDark) => isDark ? const Color(0xFFA0A0A0) : const Color(0xFF555555);
 }

--- a/lib/screens/privacy_policy_screen.dart
+++ b/lib/screens/privacy_policy_screen.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+class PrivacyPolicyScreen extends StatelessWidget {
+  const PrivacyPolicyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: _backgroundColor(context),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: _textPrimary(context)),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Privacy Policy',
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            color: _textPrimary(context),
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+        children: [
+          _buildLastUpdated(context),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Our Commitment',
+              'Locker is built with privacy as its core principle. We believe your personal data should stay on your device, not on our servers. This app does not collect, store, transmit, or share any personal information.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Data We Do Not Collect',
+              'Locker does not collect any data whatsoever. Specifically:\n\n'
+              '• No personal information (name, email, phone number, etc.)\n'
+              '• No usage analytics or telemetry\n'
+              '• No crash reports or diagnostics sent externally\n'
+              '• No advertising identifiers or tracking data\n'
+              '• No location data\n'
+              '• No device identifiers\n'
+              '• No contacts, messages, or call logs\n'
+              '• No browsing history or app usage data\n\n'
+              'Everything you do in Locker stays on your device.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Camera Access',
+              'Locker may request camera permission only when you choose to scan a QR code or take a photo to import into your vault. The camera is used solely for these purposes:\n\n'
+              '• QR code scanning for quick vault access\n'
+              '• Capturing photos to store in your vault\n\n'
+              'Camera access is never used in the background. No photos or video from your camera are transmitted to any server. All captured media is stored locally and encrypted on your device.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Media & Files',
+              'Locker is a secure media vault. Files you import into Locker are encrypted using AES-256 encryption and stored locally on your device. We do not:\n\n'
+              '• Upload your files to any cloud or server\n'
+              '• Scan or analyze your files\n'
+              '• Share your files with any third party\n'
+              '• Access your files without your explicit action\n\n'
+              'Your vault key never leaves your device.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Storage Permission',
+              'Locker requires storage permission to read files you want to vault and to save encrypted files to your device. This permission is used only when you explicitly choose to import or export files.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Biometric Authentication',
+              'If you choose to use fingerprint or face unlock, biometric data is handled entirely by your device operating system. Locker only receives a success or failure signal — it never stores or accesses your biometric data.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Third-Party Services',
+              'Locker does not integrate with any third-party analytics, advertising, or tracking services. The only external connection is:\n\n'
+              '• Play Store update check (optional, triggered by you)\n'
+              '• Donation link to Ko-fi (optional, opened in your browser)\n\n'
+              'Neither of these transmits any personal data from Locker.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Local Backups',
+              'If you choose to create a local backup, the backup file is saved to a location you select on your device. Locker does not upload backups anywhere. You are responsible for securing your backup files.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Children\'s Privacy',
+              'Locker does not knowingly collect any information from anyone, including children under 13. Since no data is collected at all, there is no risk of personal information being gathered from minors.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Changes to This Policy',
+              'If we update this Privacy Policy, the changes will be reflected in the app. We encourage you to review this policy periodically.'),
+          const SizedBox(height: 20),
+          _buildSection(context, 'Contact',
+              'If you have any questions about this Privacy Policy, please reach out through the project repository.'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection(
+      BuildContext context, String title, String content) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            color: _textPrimary(context),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          content,
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            fontSize: 14,
+            color: _textSecondary(context),
+            height: 1.5,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLastUpdated(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: _accentColor(context).withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: _accentColor(context).withValues(alpha: 0.18),
+        ),
+      ),
+      child: Text(
+        'Last updated: May 4, 2026',
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: 12,
+          color: _accentColor(context),
+        ),
+      ),
+    );
+  }
+
+  Color _backgroundColor(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    return brightness == Brightness.dark
+        ? const Color(0xFF121212)
+        : const Color(0xFFFFFFFF);
+  }
+
+  Color _textPrimary(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    return brightness == Brightness.dark
+        ? const Color(0xFFE5E5E5)
+        : const Color(0xFF1A1A1A);
+  }
+
+  Color _textSecondary(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    return brightness == Brightness.dark
+        ? const Color(0xFFA0A0A0)
+        : const Color(0xFF555555);
+  }
+
+  Color _accentColor(BuildContext context) {
+    return Theme.of(context).colorScheme.primary;
+  }
+}

--- a/lib/screens/vault_settings_screen.dart
+++ b/lib/screens/vault_settings_screen.dart
@@ -16,6 +16,7 @@ import '../themes/app_colors.dart';
 import 'accent_color_picker_screen.dart';
 import 'change_security_screen.dart';
 import 'local_backup_screen.dart';
+import 'privacy_policy_screen.dart';
 
 class VaultSettingsScreen extends ConsumerStatefulWidget {
   const VaultSettingsScreen({super.key});
@@ -529,6 +530,30 @@ class _VaultSettingsScreenState extends ConsumerState<VaultSettingsScreen> {
                           ),
                         ),
                         onTap: () => _showLicenseDialog(),
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                      ListTile(
+                        leading: Icon(Icons.privacy_tip_outlined,
+                            color: context.accentColor),
+                        title: const Text('Privacy Policy',
+                            style: TextStyle(fontFamily: 'ProductSans')),
+                        subtitle: Text(
+                          'How we handle your data',
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 12,
+                            color: context.textTertiary,
+                          ),
+                        ),
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  const PrivacyPolicyScreen(),
+                            ),
+                          );
+                        },
                         contentPadding: EdgeInsets.zero,
                       ),
                     ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -374,6 +374,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.7+1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -736,6 +744,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   video_player: ^2.10.1
   xml: ^6.6.1
   in_app_update: ^4.2.5
+  flutter_markdown: ^0.7.7+1
 
 dev_dependencies:
   flutter_lints: ^6.0.0
@@ -94,6 +95,7 @@ flutter:
     - assets/locker_logo_bg.png
     - assets/locker_logo_nobg.png
     - assets/locker_logo_nobg.svg
+    - assets/privacy_policy.md
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware
   # For details regarding adding assets from package dependencies, see


### PR DESCRIPTION
## Summary
- Adds a privacy policy screen accessible from vault settings
- Displays a comprehensive privacy policy rendered from a markdown file

## Changes

### Privacy Policy
- Create new `PrivacyPolicyScreen` with comprehensive privacy details
- Add navigation entry in `VaultSettingsScreen`
- Add `privacy_policy.md` markdown asset
- Convert `PrivacyPolicyScreen` to stateful widget
- Load and render markdown with proper styling
- Support dark/light theme text colors

## Files Changed
| Category | Notes |
| --- | --- |
| **New Screen** | `PrivacyPolicyScreen` with markdown rendering |
| **Navigation** | `VaultSettingsScreen` privacy policy entry |
| **Assets** | `privacy_policy.md` asset added |