### PR TITLE
Update docs for v0.14.0-beta.1: changelog, README, architecture with GCM/PBKDF2/re-encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+All notable changes to Latch are documented in this file.
+
+## 0.14.0-beta.1
+
+### Rebranding
+- App renamed from **Locker** to **Latch**
+- Package identifier changed from `com.ultraelectronica.locker` to `com.mossapps.locker`
+- Updated app label, assets, and all internal references
+- New launcher icons and logo assets
+
+### Encryption Hardening
+- Added **AES-256-GCM** encryption mode (authenticated encryption with integrity verification)
+- Re-encryption support: migrate existing vault files between AES-256-CTR and AES-256-GCM
+- **PBKDF2** key derivation for password/PIN hashing with configurable iteration count
+- Migration of decoy credentials to PBKDF2 with salted hashing
+- New **Encryption Settings** screen for algorithm selection and re-encryption management
+- `EncryptionAlgorithm` enum with display names and descriptions
+
+### Folder & Explorer Management
+- **VaultFolder** model for hierarchical folder organization
+- **Vault Explorer** screen with full folder management UI
+- **Folder Detail** screen with file management features
+- **Folders** screen with grid layout and folder import support
+- **Breadcrumb** navigation widget for folder paths
+- **Folder Tree** widget with expandable navigation
+- **Explorer Toolbar** widget with view mode and sort controls
+- **Explorer File Grid** widget with filter and selection support
+- **Explorer state providers** (Riverpod) for reactive folder state
+- File Explorer drawer item in gallery vault screen
+- Folder import functionality in file import service
+
+### Flick Audio Integration
+- **Flick Player** integration for external audio playback handoff
+- Flick integration service with deterministic package-targeted handoff
+- `locker://return` contract for explicit "Back to Latch" return
+- Song player with internal playback and Flick handoff support
+- Audio handling in favorites, gallery, and tags screens
+- Song directory support in vault and decoy modes
+- Updated `onNewIntent` for new activity launches from Flick
+
+### Performance Settings
+- New **Performance Settings** screen with custom theming and layout
+- Frame rate optimization and control
+- Real-time performance overlay widget
+- Performance state management with Riverpod
+
+### Security Improvements
+- **Auto-Kill** enhancements: improved background task removal
+- **Screenshot Protection** service
+- Backup credential fallback for biometric authentication
+- Decoy mode password migration to PBKDF2 with salted hashing
+- Temp file cleanup on player/viewer dispose
+
+### UI / UX
+- **Select All / Deselect All** buttons in album, favorites, and tags selection modes
+- **Sliding selection** in gallery vault and media picker screens
+- Original file names displayed instead of extensions throughout the app
+- Media scanner integration with duplicate detection
+- Privacy Policy screen with markdown rendering
+
+### Build & Infrastructure
+- **Release signing** configured (upload keystore)
+- Android `minSdkVersion` bumped to **26**
+- `in_app_update` and `package_info_plus` for Play Store update support
+- Google Services plugin for Firebase
+- Privacy policy markdown file added to assets
+- Google services JSON added to `.gitignore`
+
+### Documentation
+- README updated with feature details and Flick ecosystem info
+- `docs/architecture_media.md` — system architecture design
+- `docs/flick_integration.md` — Flick Player integration guide
+
+---
+
+> **GitHub Releases Deprecated**
+> 
+> GitHub Releases for Latch are no longer maintained. The app is distributed exclusively through **Google Play Store** as a Closed Beta Test.
+> 
+> To join the Closed Beta, email: `moss_apps@proton.me`
+>
+> Old release APKs and tags are kept for historical reference only.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Latch is a secure, private media vault application built with Flutter for Androi
 - **Compression Options**: Choose compression levels for media files to save storage space
 
 ### Organization
+- **Folders**: Create nested folder structures with drag-and-drop import, breadcrumb navigation, and expandable tree view
+- **File Explorer**: Browse vault contents with grid/list views, filtering, multi-select, and sort controls
 - **Albums**: Create custom albums to organize your hidden files
 - **Tags**: Add color-coded tags to files for easy categorization and filtering
 - **Favorites**: Mark files as favorites for quick access
@@ -40,7 +42,9 @@ Latch is a secure, private media vault application built with Flutter for Androi
 - **PIN Authentication**: 6-digit PIN lock with secure storage
 - **Password Authentication**: Traditional password protection option
 - **Biometric Authentication**: Fingerprint and face recognition support
-- **Optional Encryption**: AES-256-CBC/CTR encryption for stored files (off by default for performance)
+- **Encryption**: AES-256-GCM (authenticated) and AES-256-CTR (fast) encryption for stored files
+- **Encryption Settings**: Choose encryption algorithm, re-encrypt existing files, manage keys
+- **PBKDF2 Key Derivation**: Configurable iteration count for master key derivation with salted hashing
 - **Auto-Kill**: Automatically removes app from recent apps when leaving
 - **Decoy Mode**: Set up a fake vault with a separate PIN to show if forced to unlock
 - **Secure Delete**: Overwrite files before deletion to prevent recovery
@@ -107,23 +111,28 @@ locker/
 │   ├── main.dart                 # Application entry point
 │   ├── models/                   # Data models
 │   │   ├── album.dart            # Album and tag models
-│   │   └── vaulted_file.dart    # Vaulted file model
+│   │   ├── vaulted_file.dart     # Vaulted file model
+│   │   ├── vault_folder.dart     # Folder model
+│   │   └── encryption_algorithm.dart # Encryption algorithm enum
 │   ├── providers/                # Riverpod state providers
 │   │   ├── vault_providers.dart  # Vault state management
 │   │   ├── theme_provider.dart   # Theme management
-│   │   └── performance_provider.dart # Performance settings
+│   │   ├── performance_provider.dart # Performance settings
+│   │   └── explorer_providers.dart # Explorer state management
 │   ├── screens/                  # UI screens
 │   │   ├── unlock_screen.dart    # Authentication unlock screen
 │   │   ├── gallery_vault_screen.dart # Gallery import screen
 │   │   ├── media_viewer_screen.dart # Image/video viewer
 │   │   ├── document_viewer_screen.dart # PDF/Office document viewer
 │   │   ├── song_player_screen.dart # Audio player screen
-│   │   └── settings/             # Settings screens
-│   │       ├── vault_settings_screen.dart # Vault configuration
-│   │       └── performance_settings_screen.dart # Performance tweaks
+│   │   ├── vault_explorer_screen.dart # Vault explorer with folder management
+│   │   ├── folders_screen.dart   # Folder management screen
+│   │   ├── folder_detail_screen.dart # Folder detail with file management
+│   │   ├── encryption_settings_screen.dart # Encryption algorithm settings
+│   │   └── vault_settings_screen.dart # Vault configuration
 │   ├── services/                 # Business logic services
 │   │   ├── auth_service.dart     # Authentication handling
-│   │   ├── encryption_service.dart # AES-256 encryption/decryption
+│   │   ├── encryption_service.dart # AES-256-GCM/CTR encryption/decryption
 │   │   ├── vault_service.dart    # Core vault operations
 │   │   ├── backup_service.dart   # Backup and restore
 │   │   └── flick_integration_service.dart # Flick Player handoff
@@ -132,10 +141,14 @@ locker/
 │   │   └── app_theme.dart        # Theme configuration
 │   └── widgets/                  # Reusable widgets
 │       ├── pin_input_widget.dart # PIN entry widget
-│       └── performance_overlay_widget.dart # FPS overlay
+│       ├── performance_overlay_widget.dart # FPS overlay
+│       ├── explorer_file_grid.dart # Explorer grid widget
+│       ├── explorer_toolbar.dart  # Explorer toolbar widget
+│       ├── folder_breadcrumb_widget.dart # Breadcrumb navigation
+│       └── folder_tree_widget.dart # Expandable folder tree
 ├── android/                      # Android platform code
-│   └── app/src/main/kotlin/com/ultraelectronica/locker/
-│       └── MainActivity.kt       # Auto-kill and performance
+│   └── app/src/main/kotlin/com/mossapps/locker/
+│       └── MainActivity.kt       # Auto-kill, performance, content URI handling
 ├── assets/                       # Static assets
 │   ├── banner_locker.png         # App banner
 │   └── ...
@@ -155,11 +168,12 @@ locker/
 - Android device with Android 6.0 (API 23) or higher
 
 ### Installation
-#### From Release APK
-1. Download the latest APK from the [Releases page](https://github.com/heimin22/Locker/releases)
-2. Enable "Install from unknown sources" in your device settings
-3. Install the APK
-4. Launch and set up your authentication method
+
+> **GitHub Releases are deprecated.** Latch is distributed through the **Google Play Store** as a Closed Beta Test.
+>
+> To join the Closed Beta, email: `moss_apps@proton.me`
+>
+> Old release APKs and tags on GitHub are kept for historical reference only.
 
 ### Running
 ```bash

--- a/docs/architecture_media.md
+++ b/docs/architecture_media.md
@@ -36,9 +36,10 @@
     │  └─────────────────────┘ │   │  └────────────────────┘ │
     │           ↓               │   │           ↓              │
     │  ┌─────────────────────┐ │   │  ┌────────────────────┐ │
-    │  │   Background Isolate│ │   │  │   CTR/CBC Cipher   │ │
+    │  │   Background Isolate│ │   │  │   CTR/CBC/GCM Cipher   │ │
     │  │  • FFmpeg process   │ │   │  │  • Chunk streaming │ │
     │  │  • Progress parsing │ │   │  │  • Memory efficient│ │
+    │  │  • Auth tag (GCM)  │ │
     │  │  • SendPort comms   │ │   │  └────────────────────┘ │
     │  └─────────────────────┘ │   └──────────────────────────┘
     └───────────────────────────┘
@@ -297,6 +298,8 @@ Update UI: "Compressing video... 7%"
 
 ### Encryption Progress
 
+For both CTR and GCM modes, progress is tracked by chunk count:
+
 ```
 File size: 100MB
 Chunk size: 1MB
@@ -307,6 +310,8 @@ Progress: 45 / 100 = 0.45 = 45%
                            ↓
 Update UI: "Encrypting file... 45%"
 ```
+
+GCM additionally writes a 16-byte authentication tag at the end of each file for integrity verification on decryption.
 
 ## Rollback Stack
 
@@ -392,3 +397,125 @@ This architecture provides:
 - ✅ Automatic cleanup
 - ✅ Memory efficiency
 - ✅ Thread safety
+
+---
+
+## Encryption Modes
+
+Latch supports two AES-256 encryption modes, selectable via the Encryption Settings screen:
+
+### AES-256-CTR (Counter Mode)
+- **Speed**: Fast, no integrity verification
+- **Parallelizable**: Encryption and decryption can be parallelized
+- **Magic bytes**: `0x4C4B5253`
+- **Use case**: Default mode for performance
+
+### AES-256-GCM (Galois/Counter Mode)
+- **Speed**: Slightly slower due to authentication overhead
+- **Integrity**: Authenticated encryption with built-in integrity verification
+- **Magic bytes**: `0x4C4B5247`
+- **Use case**: Recommended for security-sensitive vaults
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     Encryption Flow                          │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  ┌──────────────┐                                            │
+│  │ Source File  │                                            │
+│  └──────┬───────┘                                            │
+│         ↓                                                    │
+│  ┌──────────────────────────────────────────────────┐       │
+│  │              Algorithm Selection                  │       │
+│  │  ┌─────────────────┐   ┌─────────────────────┐   │       │
+│  │  │   AES-256-CTR   │   │    AES-256-GCM      │   │       │
+│  │  │  16-byte IV     │   │   12-byte nonce     │   │       │
+│  │  │  No auth tag    │   │   16-byte auth tag  │   │       │
+│  │  └────────┬────────┘   └──────────┬──────────┘   │       │
+│  └───────────┼───────────────────────┼──────────────┘       │
+│              ↓                       ↓                       │
+│  ┌─────────────────┐   ┌─────────────────────────┐         │
+│  │ Stream encrypt  │   │ Encrypt + auth tag      │         │
+│  │ in 1MB chunks   │   │ appended to each file   │         │
+│  └────────┬────────┘   └────────────┬────────────┘         │
+│           ↓                          ↓                      │
+│  ┌────────────────────────────────────────────────┐         │
+│  │              Vault Storage                     │         │
+│  │  [magic][IV/nonce][ciphertext][auth tag (GCM)]│         │
+│  └────────────────────────────────────────────────┘         │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## PBKDF2 Key Derivation
+
+All password-based secrets (master key, decoy credentials, PIN/password hashes) use PBKDF2 with SHA-256 for key derivation:
+
+```
+User Password/PIN
+        │
+        ↓
+┌──────────────────────────────┐
+│  PBKDF2-HMAC-SHA256          │
+│  • Iteration count: 100,000  │
+│  • Salt: 32-byte random      │
+│  • Key length: 32 bytes      │
+│  • Configurable iterations   │
+└──────────────┬───────────────┘
+               ↓
+        Derived 256-bit Key
+```
+
+### Salt Generation
+- Each credential gets a unique 32-byte random salt
+- Salt is stored alongside the derived hash for verification
+- Prevents rainbow table attacks across vaults
+
+### Legacy Migration
+- Pre-PBKDF2 vaults stored passwords using plain SHA-256
+- On unlock, legacy hashes are detected and automatically migrated to PBKDF2
+- Decoy credentials migrated with separate salted hashing
+
+---
+
+## Re-Encryption (Algorithm Migration)
+
+When the user changes the encryption algorithm (e.g., CTR → GCM), existing vault files are re-encrypted:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                  Re-Encryption Flow                          │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  1. Select new algorithm in Encryption Settings              │
+│              ↓                                               │
+│  2. Decrypt each vault file with old algorithm               │
+│              ↓                                               │
+│  3. Encrypt plaintext with new algorithm                     │
+│              ↓                                               │
+│  4. Verify integrity (GCM auth tag validation)              │
+│              ↓                                               │
+│  5. Replace vault file with new-format file                  │
+│              ↓                                               │
+│  6. Update vault index metadata                              │
+│              ↓                                               │
+│  7. Clean up temporary plaintext                             │
+│                                                              │
+│  Rollback: If any file fails, operation is aborted           │
+│  and original files are preserved.                           │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### ReEncryptNotifier
+- Manages re-encryption state across all vault files
+- Provides progress tracking per file
+- Reports success, failure, and progress to UI
+
+### Security Guarantees
+- Plaintext is never written to persistent storage
+- Temporary decrypted data is held in memory only
+- On cancellation or failure, the original vault files are untouched
+- GCM auth tag validation catches corruption during migration


### PR DESCRIPTION
- Add CHANGELOG.md with full v0.14.0-beta.1 release notes
- Update README with folder/explorer features, encryption hardening, Play Store distribution
- Add GitHub Releases deprecation notice
- Extend architecture docs with AES-256-GCM, PBKDF2 key derivation, and re-encryption flow