### PR TITLE
Add in-app update service with connectivity checks and re-encryption warnings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,28 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:in_app_update/in_app_update.dart';
 import 'services/auto_kill_service.dart';
 import 'services/screenshot_protection_service.dart';
+import 'services/update_service.dart';
 import 'services/vault_service.dart';
 import 'themes/app_theme.dart';
 import 'providers/theme_provider.dart';
+import 'providers/vault_providers.dart';
 import 'services/auth_service.dart';
 import 'screens/auth_method_selection_screen.dart';
 import 'screens/unlock_screen.dart';
 import 'utils/frame_rate_optimizer.dart';
 import 'utils/performance_config.dart';
 
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Configure high frame rate support
   PerformanceConfig.configureHighFrameRate();
   PerformanceConfig.optimizeImageCache();
 
-  // Start frame rate monitoring
   FrameRateOptimizer().startMonitoring();
 
-  // Set preferred orientations and system UI
   await SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,
@@ -33,6 +35,8 @@ Future<void> main() async {
   await ScreenshotProtectionService.setEnabled(
     settings.screenshotProtectionEnabled,
   );
+
+  UpdateService.instance.start();
 
   runApp(const ProviderScope(child: LatchApp()));
 }
@@ -46,6 +50,7 @@ class LatchApp extends ConsumerWidget {
     final accentColor = ref.watch(accentColorProvider);
 
     return MaterialApp(
+      navigatorKey: navigatorKey,
       debugShowCheckedModeBanner: false,
       title: 'Latch',
       theme: AppTheme.getLightTheme(accentColor),
@@ -56,15 +61,14 @@ class LatchApp extends ConsumerWidget {
   }
 }
 
-/// Initialize app and determine initial route based on authentication state
-class AppInitializer extends StatefulWidget {
+class AppInitializer extends ConsumerStatefulWidget {
   const AppInitializer({super.key});
 
   @override
-  State<AppInitializer> createState() => _AppInitializerState();
+  ConsumerState<AppInitializer> createState() => _AppInitializerState();
 }
 
-class _AppInitializerState extends State<AppInitializer> {
+class _AppInitializerState extends ConsumerState<AppInitializer> {
   final AuthService _authService = AuthService();
   bool _isLoading = true;
   bool _isFirstTime = true;
@@ -73,6 +77,45 @@ class _AppInitializerState extends State<AppInitializer> {
   void initState() {
     super.initState();
     _checkAuthStatus();
+
+    final updateService = ref.read(updateServiceProvider);
+    updateService.onUpdateCheck.listen((info) {
+      if (info != null &&
+          info.updateAvailability == UpdateAvailability.updateAvailable) {
+        _showUpdateDialog();
+      }
+    });
+  }
+
+  void _showUpdateDialog() {
+    final context = navigatorKey.currentContext;
+    if (context == null) return;
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor:
+            Theme.of(dialogContext).scaffoldBackgroundColor,
+        title: const Text('Update Available',
+            style: TextStyle(fontFamily: 'ProductSans')),
+        content: const Text(
+          'A new version is available on the Play Store. Update now?',
+          style: TextStyle(fontFamily: 'ProductSans'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Later'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              InAppUpdate.performImmediateUpdate();
+            },
+            child: const Text('Update'),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _checkAuthStatus() async {
@@ -100,7 +143,6 @@ class _AppInitializerState extends State<AppInitializer> {
       );
     }
 
-    // Route to appropriate screen
     if (_isFirstTime) {
       return const AuthMethodSelectionScreen();
     } else {

--- a/lib/providers/vault_providers.dart
+++ b/lib/providers/vault_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:in_app_update/in_app_update.dart';
 import '../models/album.dart';
 import '../models/encryption_algorithm.dart';
 import '../models/vault_folder.dart';
@@ -7,6 +8,7 @@ import '../models/vaulted_file.dart';
 import '../services/vault_service.dart';
 import '../services/decoy_service.dart';
 import '../services/encryption_service.dart';
+import '../services/update_service.dart';
 
 // ========== SERVICE PROVIDERS ==========
 
@@ -555,4 +557,15 @@ class ReEncryptNotifier extends Notifier<ReEncryptProgress> {
 final reEncryptProvider =
     NotifierProvider<ReEncryptNotifier, ReEncryptProgress>(() {
   return ReEncryptNotifier();
+});
+
+// ========== UPDATE PROVIDERS ==========
+
+final updateServiceProvider = Provider<UpdateService>((ref) {
+  return UpdateService.instance;
+});
+
+final updateInfoProvider = StateProvider<AppUpdateInfo?>((ref) {
+  final service = ref.watch(updateServiceProvider);
+  return service.lastUpdateInfo;
 });

--- a/lib/screens/encryption_settings_screen.dart
+++ b/lib/screens/encryption_settings_screen.dart
@@ -4,6 +4,7 @@ import '../models/encryption_algorithm.dart';
 import '../providers/vault_providers.dart';
 import '../services/vault_service.dart';
 import '../themes/app_colors.dart';
+import '../widgets/re_encrypt_warning_dialog.dart';
 
 class EncryptionSettingsScreen extends ConsumerStatefulWidget {
   const EncryptionSettingsScreen({super.key});
@@ -387,6 +388,11 @@ class _EncryptionSettingsScreenState
     BuildContext context,
     VaultSettings settings,
   ) async {
+    final warningAcknowledged = await showReEncryptWarningDialog(
+      context: context,
+    );
+    if (warningAcknowledged != true || !mounted) return;
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(

--- a/lib/screens/vault_settings_screen.dart
+++ b/lib/screens/vault_settings_screen.dart
@@ -43,15 +43,28 @@ class _VaultSettingsScreenState extends ConsumerState<VaultSettingsScreen> {
   void initState() {
     super.initState();
     _packageInfoFuture = PackageInfo.fromPlatform();
+    _syncWithAutoScan();
+  }
+
+  void _syncWithAutoScan() {
+    final updateService = ref.read(updateServiceProvider);
+    final info = updateService.lastUpdateInfo;
+    if (info != null) {
+      _updateInfo = info;
+      _hasScanned = true;
+    }
   }
 
   Future<void> _scanForUpdate() async {
     if (!Platform.isAndroid) return;
     setState(() => _isScanning = true);
     try {
-      _updateInfo = await InAppUpdate.checkForUpdate();
+      final updateService = ref.read(updateServiceProvider);
+      _updateInfo = await updateService.checkForUpdate();
+      ref.read(updateInfoProvider.notifier).state = _updateInfo;
     } catch (_) {
       _updateInfo = null;
+      ref.read(updateInfoProvider.notifier).state = null;
     }
     if (mounted) {
       setState(() {

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:in_app_update/in_app_update.dart';
+
+class UpdateService {
+  UpdateService._();
+  static final UpdateService instance = UpdateService._();
+
+  StreamSubscription<List<ConnectivityResult>>? _subscription;
+  bool _isChecking = false;
+
+  AppUpdateInfo? _lastUpdateInfo;
+  AppUpdateInfo? get lastUpdateInfo => _lastUpdateInfo;
+
+  bool _hasPendingUpdate = false;
+  bool get hasPendingUpdate => _hasPendingUpdate;
+
+  final _updateController = StreamController<AppUpdateInfo?>.broadcast();
+  Stream<AppUpdateInfo?> get onUpdateCheck => _updateController.stream;
+
+  void start() {
+    if (!Platform.isAndroid) return;
+
+    _checkForUpdate();
+
+    _subscription = Connectivity().onConnectivityChanged.listen((results) {
+      final hasConnection = results.any((r) => r != ConnectivityResult.none);
+      if (hasConnection) {
+        _checkForUpdate();
+      }
+    });
+  }
+
+  void dispose() {
+    _subscription?.cancel();
+    _updateController.close();
+  }
+
+  Future<AppUpdateInfo?> checkForUpdate() async {
+    await _checkForUpdate();
+    return _lastUpdateInfo;
+  }
+
+  Future<void> _checkForUpdate() async {
+    if (_isChecking) return;
+    _isChecking = true;
+    try {
+      _lastUpdateInfo = await InAppUpdate.checkForUpdate();
+      _hasPendingUpdate = _lastUpdateInfo?.updateAvailability ==
+          UpdateAvailability.updateAvailable;
+      _updateController.add(_lastUpdateInfo);
+    } catch (_) {
+      _lastUpdateInfo = null;
+      _hasPendingUpdate = false;
+      _updateController.add(null);
+    } finally {
+      _isChecking = false;
+    }
+  }
+}

--- a/lib/widgets/re_encrypt_warning_dialog.dart
+++ b/lib/widgets/re_encrypt_warning_dialog.dart
@@ -207,7 +207,7 @@ class ReEncryptWarningDialog extends StatelessWidget {
                 ctx,
                 Icons.history,
                 'Recovery is not guaranteed',
-                'Locker keeps a recovery journal that lets it resume an interrupted re-encryption on the next launch, and it can roll back files that did not finish rewriting. However, if the journal itself is lost — for example due to storage corruption or an uninstall — any files that were caught mid-rewrite cannot be recovered.',
+                'Latch keeps a recovery journal that lets it resume an interrupted re-encryption on the next launch, and it can roll back files that did not finish rewriting. However, if the journal itself is lost — for example due to storage corruption or an uninstall — any files that were caught mid-rewrite cannot be recovered.',
               ),
               const SizedBox(height: 16),
               _buildExplanationItem(

--- a/lib/widgets/re_encrypt_warning_dialog.dart
+++ b/lib/widgets/re_encrypt_warning_dialog.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import '../themes/app_colors.dart';
+
+/// Dialog shown before re-encrypting the vault.
+///
+/// Warns the user that an interrupted re-encryption can leave encrypted
+/// files in a corrupted/unrecoverable state, and surfaces a "More
+/// information" entry point that opens a follow-up dialog explaining the
+/// risk in detail.
+///
+/// Returns `true` if the user acknowledges the warning and wants to
+/// continue, `false` (or `null` on dismiss) otherwise.
+class ReEncryptWarningDialog extends StatelessWidget {
+  final VoidCallback onContinue;
+  final VoidCallback onCancel;
+
+  const ReEncryptWarningDialog({
+    super.key,
+    required this.onContinue,
+    required this.onCancel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: context.surfaceColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      title: Row(
+        children: [
+          Icon(Icons.warning_amber_rounded, color: AppColors.warning, size: 28),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              'Re-Encryption Warning',
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontWeight: FontWeight.bold,
+                color: context.textPrimary,
+                fontSize: 20,
+              ),
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Re-encryption rewrites every encrypted file in your vault. If the process is interrupted — for example by a dead battery, app crash, force-stop, or running out of storage — some files may be left in a corrupted state and become permanently unrecoverable.',
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              color: context.textSecondary,
+              fontSize: 14,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: AppColors.warning.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: AppColors.warning.withValues(alpha: 0.3),
+              ),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  Icons.error_outline,
+                  color: AppColors.warning,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Make sure your device is charged, has enough free storage, and will not be interrupted before continuing.',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      color: context.textPrimary,
+                      fontSize: 12,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          InkWell(
+            onTap: () => _showMoreInformationDialog(context),
+            borderRadius: BorderRadius.circular(8),
+            child: Container(
+              padding: const EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: 12,
+              ),
+              decoration: BoxDecoration(
+                color: context.accentColor.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.info_outline,
+                    color: context.accentColor,
+                    size: 18,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    'More information',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      color: context.accentColor,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: onCancel,
+          child: Text(
+            'Cancel',
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              color: context.textSecondary,
+            ),
+          ),
+        ),
+        FilledButton(
+          onPressed: onContinue,
+          style: FilledButton.styleFrom(
+            backgroundColor: Colors.red,
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+          ),
+          child: const Text(
+            'I Understand, Continue',
+            style: TextStyle(fontFamily: 'ProductSans'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showMoreInformationDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: context.surfaceColor,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Row(
+          children: [
+            Icon(Icons.shield_outlined, color: context.accentColor),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Why Can Re-Encryption Corrupt Files?',
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontWeight: FontWeight.bold,
+                  color: context.textPrimary,
+                  fontSize: 18,
+                ),
+              ),
+            ),
+          ],
+        ),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildExplanationItem(
+                ctx,
+                Icons.battery_alert,
+                'Process interruption',
+                'If the app is killed mid-write — by a low battery shutdown, a system kill, the user force-stopping it, or another app taking focus — the file on disk may end up partially rewritten. A partially rewritten file cannot be decrypted and is effectively lost.',
+              ),
+              const SizedBox(height: 16),
+              _buildExplanationItem(
+                ctx,
+                Icons.sd_storage,
+                'Storage running out',
+                'Re-encryption needs roughly the same amount of free space as the encrypted files themselves, because each file is decrypted, re-encrypted, and rewritten. If storage fills up halfway through a file, the rewrite can fail and leave the file unreadable.',
+              ),
+              const SizedBox(height: 16),
+              _buildExplanationItem(
+                ctx,
+                Icons.lock_reset,
+                'Algorithm & key change',
+                'Switching the algorithm or changing the KDF parameters produces a brand new ciphertext and a new IV for every file. If a single file fails to rewrite correctly while its index entry is updated, the vault will no longer know which key or IV to use for that file.',
+              ),
+              const SizedBox(height: 16),
+              _buildExplanationItem(
+                ctx,
+                Icons.history,
+                'Recovery is not guaranteed',
+                'Locker keeps a recovery journal that lets it resume an interrupted re-encryption on the next launch, and it can roll back files that did not finish rewriting. However, if the journal itself is lost — for example due to storage corruption or an uninstall — any files that were caught mid-rewrite cannot be recovered.',
+              ),
+              const SizedBox(height: 16),
+              _buildExplanationItem(
+                ctx,
+                Icons.backup_outlined,
+                'Recommended safeguards',
+                'Before continuing: charge your device, ensure you have at least 2× the size of your vault in free storage, keep the app in the foreground, and avoid switching apps until the process finishes. A full backup of the vault folder is strongly recommended.',
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(
+              'Got it',
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                color: context.accentColor,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildExplanationItem(
+    BuildContext context,
+    IconData icon,
+    String title,
+    String description,
+  ) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: context.accentColor.withValues(alpha: 0.1),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Icon(icon, color: context.accentColor, size: 20),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontWeight: FontWeight.w600,
+                  color: context.textPrimary,
+                  fontSize: 14,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                description,
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  color: context.textSecondary,
+                  fontSize: 12,
+                  height: 1.4,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Shows the re-encryption warning dialog.
+///
+/// Returns `true` only if the user explicitly acknowledges the warning and
+/// taps "I Understand, Continue". Returns `false` if the user cancels or
+/// dismisses the dialog. The dialog is `barrierDismissible: false` so
+/// accidental taps outside it cannot silently approve it.
+Future<bool> showReEncryptWarningDialog({required BuildContext context}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    barrierDismissible: false,
+    builder: (ctx) => ReEncryptWarningDialog(
+      onContinue: () => Navigator.pop(ctx, true),
+      onCancel: () => Navigator.pop(ctx, false),
+    ),
+  );
+  return result ?? false;
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import audio_session
+import connectivity_plus
 import file_picker
 import file_selector_macos
 import flutter_image_compress_macos
@@ -21,6 +22,7 @@ import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,6 +161,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   convert:
     dependency: transitive
     description:
@@ -792,6 +808,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.6"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: locker
+name: latch
 description: "A secure media vault."
 publish_to: "none"
 
@@ -14,7 +14,7 @@ publish_to: "none"
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.14.0-beta.1+9
+version: 0.14.1-beta.2+10
 
 environment:
   sdk: ">=3.4.4 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: latch
+name: locker
 description: "A secure media vault."
 publish_to: "none"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   video_player: ^2.10.1
   xml: ^6.6.1
   in_app_update: ^4.2.5
+  connectivity_plus: ^6.0.0
   flutter_markdown: ^0.7.7+1
 
 dev_dependencies:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <local_auth_windows/local_auth_plugin.h>
@@ -13,6 +14,8 @@
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   file_selector_windows
   flutter_secure_storage_windows
   local_auth_windows


### PR DESCRIPTION
# Summary

Adds an in-app update service with connectivity monitoring, re-encryption warning dialogs with detailed risk explanations, and syncs vault settings with update info on init.

# Changes

## In-App Updates

- Add update service for in-app update checks
- Add in-app update support with update dialog on startup
- Add update state providers
- Sync vault settings with auto-scan update info on init
- Add `connectivity_plus` dependency and register plugin for Windows and macOS

## Re-Encryption UX

- Show re-encrypt warning before confirmation dialog
- Add re-encryption warning dialog with detailed risk explanations
- Fix typo in re-encrypt warning dialog
