### PR TITLE
Unify file overlay badges with filename display for all file types

### DIFF
--- a/lib/screens/folder_detail_screen.dart
+++ b/lib/screens/folder_detail_screen.dart
@@ -463,33 +463,51 @@ class _FolderDetailScreenState extends ConsumerState<FolderDetailScreen> {
                 ),
               ),
             ),
-          if (file.isVideo)
-            Positioned(
-              bottom: 8,
-              right: 8,
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                decoration: BoxDecoration(
-                  color: Colors.black54,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
+          // Filename overlay for all file types
+          Positioned(
+            bottom: 8,
+            left: 8,
+            right: 8,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+              decoration: BoxDecoration(
+                color: Colors.black54,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (file.isVideo) ...[
                     const Icon(Icons.play_arrow, size: 14, color: Colors.white),
                     const SizedBox(width: 2),
-                    Text(
-                      file.formattedSize,
+                  ],
+                  Expanded(
+                    child: Text(
+                      file.originalName,
                       style: const TextStyle(
                         color: Colors.white,
                         fontSize: 10,
                         fontFamily: 'ProductSans',
                       ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  if (file.isVideo) ...[
+                    const SizedBox(width: 4),
+                    Text(
+                      file.formattedSize,
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 10,
+                        fontFamily: 'ProductSans',
+                      ),
                     ),
                   ],
-                ),
+                ],
               ),
             ),
+          ),
         ],
       ),
     );
@@ -519,23 +537,52 @@ class _FolderDetailScreenState extends ConsumerState<FolderDetailScreen> {
 
   Widget _buildFilePlaceholder(VaultedFile file) {
     IconData icon;
+    Color color;
     switch (file.type) {
+      case VaultedFileType.image:
+        icon = Icons.image;
+        color = context.accentColor;
+        break;
       case VaultedFileType.video:
-        icon = Icons.play_circle_outline;
+        icon = Icons.videocam;
+        color = Colors.red;
         break;
       case VaultedFileType.song:
-        icon = Icons.audiotrack;
+        icon = Icons.music_note;
+        color = Colors.purple;
         break;
       case VaultedFileType.document:
         icon = Icons.description;
+        color = Colors.green;
         break;
-      default:
+      case VaultedFileType.other:
         icon = Icons.insert_drive_file;
+        color = Colors.grey;
+        break;
     }
     return Container(
-      color: context.accentColor.withValues(alpha: 0.1),
-      child: Center(
-        child: Icon(icon, size: 32, color: context.accentColor),
+      color: color.withValues(alpha: 0.1),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 28, color: color),
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            child: Text(
+              file.originalName,
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+                color: color,
+                fontFamily: 'ProductSans',
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -1036,8 +1083,8 @@ class _FolderDetailScreenState extends ConsumerState<FolderDetailScreen> {
                     ),
                     const SizedBox(height: 20),
                     ListTile(
-                      leading: Icon(Icons.edit_outlined, color: AppColors.lightTextPrimary),
-                      title: Text('Rename', style: TextStyle(fontFamily: 'ProductSans', color: AppColors.lightTextPrimary)),
+                      leading: Icon(Icons.edit_outlined, color: context.textPrimary),
+                      title: Text('Rename', style: TextStyle(fontFamily: 'ProductSans', color: context.textPrimary)),
                       contentPadding: EdgeInsets.zero,
                       onTap: () {
                         Navigator.pop(context);
@@ -1467,22 +1514,53 @@ class _AddFilesToFolderSheetState extends ConsumerState<_AddFilesToFolderSheet> 
 
   Widget _buildPlaceholder(VaultedFile file) {
     IconData icon;
+    Color color;
     switch (file.type) {
+      case VaultedFileType.image:
+        icon = Icons.image;
+        color = context.accentColor;
+        break;
       case VaultedFileType.video:
-        icon = Icons.play_circle_outline;
+        icon = Icons.videocam;
+        color = Colors.red;
         break;
       case VaultedFileType.song:
-        icon = Icons.audiotrack;
+        icon = Icons.music_note;
+        color = Colors.purple;
         break;
       case VaultedFileType.document:
         icon = Icons.description;
+        color = Colors.green;
         break;
-      default:
+      case VaultedFileType.other:
         icon = Icons.insert_drive_file;
+        color = Colors.grey;
+        break;
     }
     return Container(
-      color: context.accentColor.withValues(alpha: 0.1),
-      child: Center(child: Icon(icon, size: 32, color: context.accentColor)),
+      color: color.withValues(alpha: 0.1),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 28, color: color),
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            child: Text(
+              file.originalName,
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+                color: color,
+                fontFamily: 'ProductSans',
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -646,58 +646,51 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
                     ),
                   ),
                 ),
-              // Video duration indicator
-              if (file.isVideo)
-                Positioned(
-                  bottom: 8,
-                  right: 8,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                    decoration: BoxDecoration(
-                      color: Colors.black54,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
+              // Filename overlay for all file types
+              Positioned(
+                bottom: 8,
+                left: 8,
+                right: 8,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: Colors.black54,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (file.isVideo) ...[
                         const Icon(Icons.play_arrow, size: 14, color: Colors.white),
                         const SizedBox(width: 2),
-                        Text(
-                          file.formattedSize,
+                      ],
+                      Expanded(
+                        child: Text(
+                          file.originalName,
                           style: const TextStyle(
                             color: Colors.white,
                             fontSize: 10,
                             fontFamily: 'ProductSans',
                           ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      if (file.isVideo) ...[
+                        const SizedBox(width: 4),
+                        Text(
+                          file.formattedSize,
+                          style: const TextStyle(
+                            color: Colors.white70,
+                            fontSize: 10,
+                            fontFamily: 'ProductSans',
+                          ),
                         ),
                       ],
-                    ),
+                    ],
                   ),
                 ),
-              // File type badge for non-visual files
-              if (file.isDocument || file.isSong)
-                Positioned(
-                  bottom: 8,
-                  left: 8,
-                  right: 8,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-                    decoration: BoxDecoration(
-                      color: Colors.black54,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: Text(
-                      file.originalName,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 10,
-                        fontFamily: 'ProductSans',
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ),
+              ),
             ],
           ),
         ),

--- a/lib/screens/media_viewer_screen.dart
+++ b/lib/screens/media_viewer_screen.dart
@@ -298,11 +298,11 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
                                         () => _slideshowDuration = seconds);
                                   }
                                 },
-                                selectedColor: AppColors.accent,
+                                selectedColor: context.accentColor,
                                 labelStyle: TextStyle(
                                   color: _slideshowDuration == seconds
                                       ? Colors.white
-                                      : AppColors.lightTextPrimary,
+                                      : context.textSecondary,
                                   fontFamily: 'ProductSans',
                                 ),
                               ),
@@ -319,7 +319,7 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
                           _startSlideshow();
                         },
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: AppColors.accent,
+                          backgroundColor: context.accentColor,
                           foregroundColor: Colors.white,
                           padding: const EdgeInsets.symmetric(vertical: 12),
                         ),

--- a/lib/widgets/explorer_file_grid.dart
+++ b/lib/widgets/explorer_file_grid.dart
@@ -326,55 +326,53 @@ class ExplorerFileGrid extends ConsumerWidget {
               ),
             ),
 
-          // File Extension/Type text tag for non-images
-          if (!file.isImage && !file.isVideo)
-            Positioned(
-              bottom: 6,
-              left: 6,
-              right: 6,
-              child: Text(
-                file.originalName,
-                style: const TextStyle(
-                  color: Colors.white70,
-                  fontSize: 8,
-                  fontFamily: 'ProductSans',
-                  fontWeight: FontWeight.w500,
-                  shadows: [Shadow(blurRadius: 3, color: Colors.black54)],
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                textAlign: TextAlign.center,
+          // Filename overlay for all file types
+          Positioned(
+            bottom: 6,
+            left: 6,
+            right: 6,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 3),
+              decoration: BoxDecoration(
+                color: Colors.black54,
+                borderRadius: BorderRadius.circular(4),
               ),
-            ),
-
-          // Video length/size badge
-          if (file.isVideo)
-            Positioned(
-              bottom: 6,
-              right: 6,
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-                decoration: BoxDecoration(
-                  color: Colors.black54,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (file.isVideo) ...[
                     const Icon(Icons.play_arrow, size: 10, color: Colors.white),
                     const SizedBox(width: 1),
+                  ],
+                  Expanded(
+                    child: Text(
+                      file.originalName,
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 8,
+                        fontFamily: 'ProductSans',
+                        fontWeight: FontWeight.w500,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  if (file.isVideo) ...[
+                    const SizedBox(width: 2),
                     Text(
                       file.formattedSize,
                       style: const TextStyle(
-                        color: Colors.white,
+                        color: Colors.white70,
                         fontSize: 8,
                         fontFamily: 'ProductSans',
                       ),
                     ),
                   ],
-                ),
+                ],
               ),
             ),
+          ),
 
           // Checkbox overlaid in Selection Mode
           if (isSelectionMode)


### PR DESCRIPTION
# Summary

Unifies file overlay badges into a single container with filename display for all file types, and migrates color references from hardcoded `AppColors` to context-based theming.

# Changes

## UI Improvements

- Show filename overlay for all file types in gallery vault
- Unify file overlay badges into single container with play icon and file size for videos
- Use context for colors instead of hardcoded `AppColors`