### PR TITLE
Migrate UI to theme context colors and improve re-encryption crash recovery

### DIFF
--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -370,7 +370,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
                       style: TextStyle(
                         fontSize: 20,
                         fontWeight: FontWeight.bold,
-                        color: AppColors.lightTextPrimary,
+                        color: context.textPrimary,
                         fontFamily: 'ProductSans',
                       ),
                     ),
@@ -406,7 +406,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
               label,
               style: TextStyle(
                 fontFamily: 'ProductSans',
-                color: AppColors.lightTextTertiary,
+                color: context.textTertiary,
               ),
             ),
           ),
@@ -415,7 +415,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
               value,
               style: TextStyle(
                 fontFamily: 'ProductSans',
-                color: AppColors.lightTextPrimary,
+                color: context.textPrimary,
               ),
             ),
           ),
@@ -430,7 +430,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        foregroundColor: AppColors.lightTextPrimary,
+        foregroundColor: context.textPrimary,
         elevation: 0,
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -451,7 +451,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
                 style: TextStyle(
                   fontFamily: 'ProductSans',
                   fontSize: 12,
-                  color: AppColors.lightTextTertiary,
+                  color: context.textTertiary,
                 ),
               ),
           ],
@@ -486,7 +486,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
               _isConverting ? 'Converting to PDF...' : 'Loading document...',
               style: TextStyle(
                 fontFamily: 'ProductSans',
-                color: AppColors.lightTextSecondary,
+                color: context.textSecondary,
               ),
             ),
             if (_isConverting) ...[
@@ -496,7 +496,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
                 style: TextStyle(
                   fontFamily: 'ProductSans',
                   fontSize: 12,
-                  color: AppColors.lightTextTertiary,
+                  color: context.textTertiary,
                 ),
               ),
             ],
@@ -520,7 +520,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
               _error!,
               style: TextStyle(
                 fontFamily: 'ProductSans',
-                color: AppColors.lightTextSecondary,
+                color: context.textSecondary,
               ),
               textAlign: TextAlign.center,
             ),
@@ -556,7 +556,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
           'No PDF data available',
           style: TextStyle(
             fontFamily: 'ProductSans',
-            color: AppColors.lightTextSecondary,
+            color: context.textSecondary,
           ),
         ),
       );
@@ -643,7 +643,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
 
   Widget _buildTextViewer() {
     return Container(
-      color: Colors.white,
+      color: context.backgroundColor,
       child: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: SelectableText(
@@ -651,7 +651,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
           style: TextStyle(
             fontFamily: 'monospace',
             fontSize: 14,
-            color: AppColors.lightTextPrimary,
+            color: context.textPrimary,
             height: 1.5,
           ),
         ),
@@ -676,7 +676,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
               fontFamily: 'ProductSans',
               fontSize: 18,
               fontWeight: FontWeight.w600,
-              color: AppColors.lightTextPrimary,
+              color: context.textPrimary,
             ),
             textAlign: TextAlign.center,
           ),
@@ -685,7 +685,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
             widget.file.formattedSize,
             style: TextStyle(
               fontFamily: 'ProductSans',
-              color: AppColors.lightTextTertiary,
+              color: context.textTertiary,
             ),
           ),
           const SizedBox(height: 16),
@@ -709,7 +709,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
             'Preview not available for this document type',
             style: TextStyle(
               fontFamily: 'ProductSans',
-              color: AppColors.lightTextSecondary,
+              color: context.textSecondary,
             ),
           ),
           const SizedBox(height: 24),

--- a/lib/services/crypto_isolate_pool.dart
+++ b/lib/services/crypto_isolate_pool.dart
@@ -614,7 +614,10 @@ Future<void> _workerDoDecrypt(
 
     try {
       final finalBuf = Uint8List(32);
-      gcm.doFinal(finalBuf, 0);
+      final finalLen = gcm.doFinal(finalBuf, 0);
+      if (finalLen > 0) {
+        sink.add(Uint8List.view(finalBuf.buffer, 0, finalLen));
+      }
     } on InvalidCipherTextException {
       authFailed = true;
     }

--- a/lib/services/crypto_isolate_pool.dart
+++ b/lib/services/crypto_isolate_pool.dart
@@ -435,99 +435,109 @@ Future<void> _workerDoEncrypt(
   final iv = Uint8List.fromList(
       List<int>.generate(16, (_) => random.nextInt(256)));
 
-  final destFile = File(destPath);
-  final sink = destFile.openWrite();
+  final tempPath = '$destPath.tmp';
+  final tempFile = File(tempPath);
+  final sink = tempFile.openWrite();
 
-  if (useGcm) {
-    final gcm = GCMBlockCipher(AESEngine())
-      ..init(true, AEADParameters(KeyParameter(key), 128, iv, Uint8List(0)));
+  try {
+    if (useGcm) {
+      final gcm = GCMBlockCipher(AESEngine())
+        ..init(true, AEADParameters(KeyParameter(key), 128, iv, Uint8List(0)));
 
-    final header = Uint8List(9);
-    header[0] = 0x4C;
-    header[1] = 0x4B;
-    header[2] = 0x52;
-    header[3] = 0x32;
-    header[4] = 0x02;
-    header[5] = (totalBytes & 0xFF);
-    header[6] = ((totalBytes >> 8) & 0xFF);
-    header[7] = ((totalBytes >> 16) & 0xFF);
-    header[8] = ((totalBytes >> 24) & 0xFF);
-    sink.add(header);
+      final header = Uint8List(9);
+      header[0] = 0x4C;
+      header[1] = 0x4B;
+      header[2] = 0x52;
+      header[3] = 0x32;
+      header[4] = 0x02;
+      header[5] = (totalBytes & 0xFF);
+      header[6] = ((totalBytes >> 8) & 0xFF);
+      header[7] = ((totalBytes >> 16) & 0xFF);
+      header[8] = ((totalBytes >> 24) & 0xFF);
+      sink.add(header);
 
-    final outBuf = Uint8List(_kChunkSize + 16);
-    int bytesProcessed = 0;
+      final outBuf = Uint8List(_kChunkSize + 16);
+      int bytesProcessed = 0;
 
-    final raf = sourceFile.openSync();
-    try {
-      while (true) {
-        final chunk = raf.readSync(_kChunkSize);
-        if (chunk.isEmpty) break;
-        final outLen = gcm.processBytes(chunk, 0, chunk.length, outBuf, 0);
-        if (outLen > 0) {
-          sink.add(Uint8List.view(outBuf.buffer, 0, outLen));
+      final raf = sourceFile.openSync();
+      try {
+        while (true) {
+          final chunk = raf.readSync(_kChunkSize);
+          if (chunk.isEmpty) break;
+          final outLen = gcm.processBytes(chunk, 0, chunk.length, outBuf, 0);
+          if (outLen > 0) {
+            sink.add(Uint8List.view(outBuf.buffer, 0, outLen));
+          }
+          bytesProcessed += chunk.length;
+          replyPort.send({
+            'type': 'progress',
+            'jobId': jobId,
+            'bytesProcessed': bytesProcessed,
+            'totalBytes': totalBytes,
+          });
         }
-        bytesProcessed += chunk.length;
-        replyPort.send({
-          'type': 'progress',
-          'jobId': jobId,
-          'bytesProcessed': bytesProcessed,
-          'totalBytes': totalBytes,
-        });
+      } finally {
+        raf.closeSync();
       }
-    } finally {
-      raf.closeSync();
-    }
 
-    final finalBuf = Uint8List(32);
-    final finalLen = gcm.doFinal(finalBuf, 0);
-    if (finalLen > 0) {
-      sink.add(Uint8List.view(finalBuf.buffer, 0, finalLen));
-    }
-  } else {
-    final ctr = CTRStreamCipher(AESEngine())
-      ..init(true, ParametersWithIV<KeyParameter>(KeyParameter(key), iv));
-
-    final header = Uint8List(8);
-    header[0] = 0x4C;
-    header[1] = 0x4B;
-    header[2] = 0x52;
-    header[3] = 0x53;
-    header[4] = (totalBytes & 0xFF);
-    header[5] = ((totalBytes >> 8) & 0xFF);
-    header[6] = ((totalBytes >> 16) & 0xFF);
-    header[7] = ((totalBytes >> 24) & 0xFF);
-    sink.add(header);
-
-    int bytesProcessed = 0;
-    final raf = sourceFile.openSync();
-    try {
-      while (true) {
-        final chunk = raf.readSync(_kChunkSize);
-        if (chunk.isEmpty) break;
-        sink.add(ctr.process(chunk));
-        bytesProcessed += chunk.length;
-        replyPort.send({
-          'type': 'progress',
-          'jobId': jobId,
-          'bytesProcessed': bytesProcessed,
-          'totalBytes': totalBytes,
-        });
+      final finalBuf = Uint8List(32);
+      final finalLen = gcm.doFinal(finalBuf, 0);
+      if (finalLen > 0) {
+        sink.add(Uint8List.view(finalBuf.buffer, 0, finalLen));
       }
-    } finally {
-      raf.closeSync();
+    } else {
+      final ctr = CTRStreamCipher(AESEngine())
+        ..init(true, ParametersWithIV<KeyParameter>(KeyParameter(key), iv));
+
+      final header = Uint8List(8);
+      header[0] = 0x4C;
+      header[1] = 0x4B;
+      header[2] = 0x52;
+      header[3] = 0x53;
+      header[4] = (totalBytes & 0xFF);
+      header[5] = ((totalBytes >> 8) & 0xFF);
+      header[6] = ((totalBytes >> 16) & 0xFF);
+      header[7] = ((totalBytes >> 24) & 0xFF);
+      sink.add(header);
+
+      int bytesProcessed = 0;
+      final raf = sourceFile.openSync();
+      try {
+        while (true) {
+          final chunk = raf.readSync(_kChunkSize);
+          if (chunk.isEmpty) break;
+          sink.add(ctr.process(chunk));
+          bytesProcessed += chunk.length;
+          replyPort.send({
+            'type': 'progress',
+            'jobId': jobId,
+            'bytesProcessed': bytesProcessed,
+            'totalBytes': totalBytes,
+          });
+        }
+      } finally {
+        raf.closeSync();
+      }
     }
+
+    await sink.flush();
+    await sink.close();
+
+    await tempFile.rename(destPath);
+
+    replyPort.send({
+      'type': 'encrypt_complete',
+      'jobId': jobId,
+      'ivBase64': base64Encode(iv),
+      'originalSize': totalBytes,
+      'encryptedSize': File(destPath).lengthSync(),
+    });
+  } catch (e) {
+    try { await sink.flush(); } catch (_) {}
+    try { await sink.close(); } catch (_) {}
+    try { await tempFile.delete(); } catch (_) {}
+    rethrow;
   }
-
-  await sink.flush();
-  await sink.close();
-
-  replyPort.send({
-    'type': 'encrypt_complete',
-    'jobId': jobId,
-    'ivBase64': base64Encode(iv),
-    'originalSize': totalBytes,
-    'encryptedSize': destFile.lengthSync(),
-  });
 }
 
 Future<void> _workerDoDecrypt(

--- a/lib/services/encryption_service.dart
+++ b/lib/services/encryption_service.dart
@@ -1296,6 +1296,8 @@ class EncryptionService {
     final tempDecPath = '${tempDir.path}/decrypted';
 
     try {
+      try { await File('$filePath.tmp').delete(); } catch (_) {}
+
       if (isLegacyCbc) {
         final decrypted = await decryptFileToMemory(filePath, oldIvBase64, isDecoy: isDecoy);
         if (!decrypted.success || decrypted.data == null) {
@@ -1323,6 +1325,11 @@ class EncryptionService {
         useGcm: useGcm,
       );
       final encResult = await encJob.future;
+
+      final outFile = File(filePath);
+      if (!await outFile.exists() || await outFile.length() == 0) {
+        throw Exception('Re-encrypted output file is missing or empty');
+      }
 
       return encResult.ivBase64!;
     } finally {

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -2113,28 +2113,39 @@ class VaultService {
       final files = isDecoy
           ? (await getAllFiles(isDecoy: true))
           : (await getAllFiles(isDecoy: false));
-      final encryptedFiles = files.where((f) => f.isEncrypted).toList();
+      var encryptedFiles = files.where((f) => f.isEncrypted).toList();
 
       if (encryptedFiles.isEmpty) return 0;
+
+      final journalIvs = <String, String>{};
+      String? priorInProgress;
 
       final journalStr = await _storage.read(key: _reEncryptJournalKey);
       if (journalStr != null) {
         try {
           final journal = jsonDecode(journalStr) as Map<String, dynamic>;
-          final ivMap = (journal['ivs'] as Map<String, dynamic>).cast<String, String>();
-          for (final entry in ivMap.entries) {
+          final savedIvs = (journal['ivs'] as Map<String, dynamic>?)?.cast<String, String>() ?? {};
+          journalIvs.addAll(savedIvs);
+          priorInProgress = journal['inProgress'] as String?;
+
+          for (final entry in journalIvs.entries) {
             final idx = files.indexWhere((f) => f.vaultPath == entry.key);
             if (idx >= 0) {
               files[idx] = files[idx].copyWith(encryptionIv: entry.value);
             }
           }
+
+          if (priorInProgress != null) {
+            try { await File('$priorInProgress.tmp').delete(); } catch (_) {}
+          }
+
+          encryptedFiles = files.where((f) => f.isEncrypted).toList();
+
           if (isDecoy) { _cachedDecoyFiles = files; } else { _cachedFiles = files; }
           await _saveFileIndex(isDecoy: isDecoy);
         } catch (_) {}
-        await _storage.delete(key: _reEncryptJournalKey);
       }
 
-      final journalIvs = <String, String>{};
       int reEncryptedCount = 0;
 
       for (int i = 0; i < encryptedFiles.length; i++) {
@@ -2149,6 +2160,14 @@ class VaultService {
 
         if (currentIsGcm == targetIsGcm && currentFormat != 0 && currentFormat != 3) continue;
 
+        await _storage.write(
+          key: _reEncryptJournalKey,
+          value: jsonEncode({
+            'ivs': journalIvs,
+            'inProgress': file.vaultPath,
+          }),
+        );
+
         final newIv = await _encryptionService.reEncryptFile(
           file.vaultPath,
           file.encryptionIv ?? '',
@@ -2159,7 +2178,9 @@ class VaultService {
         journalIvs[file.vaultPath] = newIv;
         await _storage.write(
           key: _reEncryptJournalKey,
-          value: jsonEncode({'ivs': journalIvs}),
+          value: jsonEncode({
+            'ivs': journalIvs,
+          }),
         );
 
         final fileIndex = files.indexWhere((f) => f.id == file.id);

--- a/lib/widgets/conversion_warning_dialog.dart
+++ b/lib/widgets/conversion_warning_dialog.dart
@@ -25,7 +25,7 @@ class ConversionWarningDialog extends StatelessWidget {
     final canConvert = OfficeConverterService.canConvertOnDevice(extension);
 
     return AlertDialog(
-      backgroundColor: AppColors.lightBackground,
+      backgroundColor: context.backgroundColor,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       title: Row(
         children: [
@@ -41,7 +41,7 @@ class ConversionWarningDialog extends StatelessWidget {
               style: TextStyle(
                 fontFamily: 'ProductSans',
                 fontWeight: FontWeight.bold,
-                color: AppColors.lightTextPrimary,
+                color: context.textPrimary,
                 fontSize: 20,
               ),
             ),
@@ -56,7 +56,7 @@ class ConversionWarningDialog extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: AppColors.lightBackgroundSecondary,
+              color: context.backgroundSecondary,
               borderRadius: BorderRadius.circular(12),
             ),
             child: Row(
@@ -84,7 +84,7 @@ class ConversionWarningDialog extends StatelessWidget {
                         style: TextStyle(
                           fontFamily: 'ProductSans',
                           fontWeight: FontWeight.w600,
-                          color: AppColors.lightTextPrimary,
+                          color: context.textPrimary,
                           fontSize: 14,
                         ),
                         maxLines: 1,
@@ -95,7 +95,7 @@ class ConversionWarningDialog extends StatelessWidget {
                         fileTypeName,
                         style: TextStyle(
                           fontFamily: 'ProductSans',
-                          color: AppColors.lightTextSecondary,
+                          color: context.textSecondary,
                           fontSize: 12,
                         ),
                       ),
@@ -114,7 +114,7 @@ class ConversionWarningDialog extends StatelessWidget {
                 : 'This document format cannot be converted on-device. Would you like to open it with an external app?',
             style: TextStyle(
               fontFamily: 'ProductSans',
-              color: AppColors.lightTextSecondary,
+              color: context.textSecondary,
               fontSize: 14,
               height: 1.4,
             ),
@@ -194,7 +194,7 @@ class ConversionWarningDialog extends StatelessWidget {
             'Cancel',
             style: TextStyle(
               fontFamily: 'ProductSans',
-              color: AppColors.lightTextSecondary,
+              color: context.textSecondary,
             ),
           ),
         ),
@@ -232,7 +232,7 @@ class ConversionWarningDialog extends StatelessWidget {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: AppColors.lightBackground,
+        backgroundColor: context.backgroundColor,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
         title: Row(
           children: [
@@ -243,7 +243,7 @@ class ConversionWarningDialog extends StatelessWidget {
               style: TextStyle(
                 fontFamily: 'ProductSans',
                 fontWeight: FontWeight.bold,
-                color: AppColors.lightTextPrimary,
+                color: context.textPrimary,
                 fontSize: 18,
               ),
             ),
@@ -254,24 +254,28 @@ class ConversionWarningDialog extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildExplanationItem(
+              context,
               Icons.security,
               'Security First',
               'Converting documents locally keeps your files secure. No data is sent to external servers.',
             ),
             const SizedBox(height: 16),
             _buildExplanationItem(
+              context,
               Icons.devices,
               'Universal Viewing',
               'PDF is a universal format that works consistently across all devices without needing special software.',
             ),
             const SizedBox(height: 16),
             _buildExplanationItem(
+              context,
               Icons.lock,
               'Vault Protection',
               'Your original encrypted document remains safe in the vault. Only a temporary PDF is created for viewing.',
             ),
             const SizedBox(height: 16),
             _buildExplanationItem(
+              context,
               Icons.warning_amber,
               'Limitations',
               'Complex formatting, images, charts, and special fonts may not be perfectly preserved during conversion.',
@@ -296,7 +300,7 @@ class ConversionWarningDialog extends StatelessWidget {
   }
 
   Widget _buildExplanationItem(
-      IconData icon, String title, String description) {
+      BuildContext context, IconData icon, String title, String description) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -318,7 +322,7 @@ class ConversionWarningDialog extends StatelessWidget {
                 style: TextStyle(
                   fontFamily: 'ProductSans',
                   fontWeight: FontWeight.w600,
-                  color: AppColors.lightTextPrimary,
+                  color: context.textPrimary,
                   fontSize: 14,
                 ),
               ),
@@ -327,7 +331,7 @@ class ConversionWarningDialog extends StatelessWidget {
                 description,
                 style: TextStyle(
                   fontFamily: 'ProductSans',
-                  color: AppColors.lightTextSecondary,
+                  color: context.textSecondary,
                   fontSize: 12,
                   height: 1.4,
                 ),

--- a/lib/widgets/office_conversion_confirm_dialog.dart
+++ b/lib/widgets/office_conversion_confirm_dialog.dart
@@ -22,7 +22,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
     final nonConvertibleCount = officeFiles.length - convertibleCount;
 
     return AlertDialog(
-      backgroundColor: AppColors.lightBackground,
+      backgroundColor: context.backgroundColor,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       title: Row(
         children: [
@@ -41,7 +41,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
               style: TextStyle(
                 fontFamily: 'ProductSans',
                 fontWeight: FontWeight.bold,
-                color: AppColors.lightTextPrimary,
+                color: context.textPrimary,
                 fontSize: 18,
               ),
             ),
@@ -57,7 +57,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
               'The following Office documents will be converted to PDF for secure storage and easy viewing:',
               style: TextStyle(
                 fontFamily: 'ProductSans',
-                color: AppColors.lightTextSecondary,
+                color: context.textSecondary,
                 fontSize: 14,
                 height: 1.4,
               ),
@@ -68,7 +68,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
             Container(
               constraints: const BoxConstraints(maxHeight: 200),
               decoration: BoxDecoration(
-                color: AppColors.lightBackgroundSecondary,
+                color: context.backgroundSecondary,
                 borderRadius: BorderRadius.circular(12),
               ),
               child: ListView.separated(
@@ -95,7 +95,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
                               style: TextStyle(
                                 fontFamily: 'ProductSans',
                                 fontWeight: FontWeight.w500,
-                                color: AppColors.lightTextPrimary,
+                                color: context.textPrimary,
                                 fontSize: 13,
                               ),
                               maxLines: 1,
@@ -105,7 +105,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
                               file.typeName,
                               style: TextStyle(
                                 fontFamily: 'ProductSans',
-                                color: AppColors.lightTextTertiary,
+                                color: context.textTertiary,
                                 fontSize: 11,
                               ),
                             ),
@@ -159,6 +159,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
             // Summary
             if (convertibleCount > 0)
               _buildSummaryItem(
+                context,
                 Icons.check_circle_outline,
                 Colors.green,
                 '$convertibleCount file(s) will be converted to PDF',
@@ -166,6 +167,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
             if (nonConvertibleCount > 0) ...[
               const SizedBox(height: 8),
               _buildSummaryItem(
+                context,
                 Icons.warning_amber,
                 Colors.orange,
                 '$nonConvertibleCount file(s) cannot be converted (unsupported format)',
@@ -213,7 +215,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
             'Cancel',
             style: TextStyle(
               fontFamily: 'ProductSans',
-              color: AppColors.lightTextSecondary,
+              color: context.textSecondary,
             ),
           ),
         ),
@@ -233,7 +235,8 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
     );
   }
 
-  Widget _buildSummaryItem(IconData icon, Color color, String text) {
+  Widget _buildSummaryItem(
+      BuildContext context, IconData icon, Color color, String text) {
     return Row(
       children: [
         Icon(icon, color: color, size: 18),
@@ -243,7 +246,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
             text,
             style: TextStyle(
               fontFamily: 'ProductSans',
-              color: AppColors.lightTextSecondary,
+              color: context.textSecondary,
               fontSize: 12,
             ),
           ),
@@ -256,7 +259,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: AppColors.lightBackground,
+        backgroundColor: context.backgroundColor,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
         title: Row(
           children: [
@@ -267,7 +270,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
               style: TextStyle(
                 fontFamily: 'ProductSans',
                 fontWeight: FontWeight.bold,
-                color: AppColors.lightTextPrimary,
+                color: context.textPrimary,
                 fontSize: 18,
               ),
             ),
@@ -278,24 +281,28 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildExplanationItem(
+              context,
               Icons.security,
               'Secure & Private',
               'Conversion happens entirely on your device. No data is sent to external servers.',
             ),
             const SizedBox(height: 16),
             _buildExplanationItem(
+              context,
               Icons.visibility,
               'Easy Viewing',
               'PDF files can be viewed directly in the app without requiring external software.',
             ),
             const SizedBox(height: 16),
             _buildExplanationItem(
+              context,
               Icons.devices,
               'Universal Format',
               'PDF works consistently across all devices and platforms.',
             ),
             const SizedBox(height: 16),
             _buildExplanationItem(
+              context,
               Icons.warning_amber,
               'Limitations',
               'Complex formatting, images, and special fonts may not be perfectly preserved.',
@@ -320,7 +327,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
   }
 
   Widget _buildExplanationItem(
-      IconData icon, String title, String description) {
+      BuildContext context, IconData icon, String title, String description) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -342,7 +349,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
                 style: TextStyle(
                   fontFamily: 'ProductSans',
                   fontWeight: FontWeight.w600,
-                  color: AppColors.lightTextPrimary,
+                  color: context.textPrimary,
                   fontSize: 14,
                 ),
               ),
@@ -351,7 +358,7 @@ class OfficeConversionConfirmDialog extends StatelessWidget {
                 description,
                 style: TextStyle(
                   fontFamily: 'ProductSans',
-                  color: AppColors.lightTextSecondary,
+                  color: context.textSecondary,
                   fontSize: 12,
                   height: 1.4,
                 ),


### PR DESCRIPTION
# Summary

Migrates remaining hardcoded light theme colors to context-based theming across gallery vault and document viewer, and improves re-encryption crash recovery with journal tracking.

# Changes

## Theme Migration

- Replace hardcoded light theme colors with context theme colors in gallery vault
- Migrate hardcoded light colors to theme context in document viewer
- Use theme context colors and pass context to helper widgets

## Re-Encryption

- Add crash recovery to re-encryption journal with in-progress file tracking
- Clean up temp file on resume after interruption
- Remove old journal entry only after all files successfully processed
- Check re-encrypted output exists

## Bug Fixes

- Handle non-empty final block in GCM decryption worker