### PR TITLE
Add What's New bottom sheet and changelog screen PR Description

### DIFF
--- a/lib/screens/changelog_screen.dart
+++ b/lib/screens/changelog_screen.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import '../themes/app_colors.dart';
+
+/// Full changelog viewer. Renders the bundled `CHANGELOG.md` asset and
+/// is reachable from the "What's New" bottom sheet and vault settings.
+class ChangelogScreen extends StatefulWidget {
+  const ChangelogScreen({super.key});
+
+  @override
+  State<ChangelogScreen> createState() => _ChangelogScreenState();
+}
+
+class _ChangelogScreenState extends State<ChangelogScreen> {
+  String? _markdown;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMarkdown();
+  }
+
+  Future<void> _loadMarkdown() async {
+    try {
+      final content = await rootBundle.loadString('CHANGELOG.md');
+      if (mounted) setState(() => _markdown = content);
+    } catch (_) {
+      if (mounted) setState(() => _markdown = 'Failed to load changelog.');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.backgroundColor,
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: context.textPrimary),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Changelog',
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            color: context.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+      ),
+      body: _markdown == null
+          ? Center(
+              child: CircularProgressIndicator(color: context.accentColor),
+            )
+          : Markdown(
+              data: _markdown!,
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+              styleSheet: _styleSheet(context),
+              selectable: true,
+            ),
+    );
+  }
+
+  MarkdownStyleSheet _styleSheet(BuildContext context) {
+    final isDark = context.isDarkMode;
+    return MarkdownStyleSheet(
+      h1: TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 24,
+        fontWeight: FontWeight.w700,
+        color: context.textPrimary,
+      ),
+      h2: TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 19,
+        fontWeight: FontWeight.w700,
+        color: context.textPrimary,
+      ),
+      h3: TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 15,
+        fontWeight: FontWeight.w600,
+        color: context.accentColor,
+      ),
+      p: TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 14,
+        color: context.textSecondary,
+        height: 1.5,
+      ),
+      strong: TextStyle(
+        fontFamily: 'ProductSans',
+        fontWeight: FontWeight.w600,
+        color: context.textPrimary,
+      ),
+      listBullet: TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 14,
+        color: context.textSecondary,
+      ),
+      listBulletPadding: const EdgeInsets.symmetric(horizontal: 8),
+      blockquote: TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 14,
+        fontStyle: FontStyle.italic,
+        color: context.textSecondary,
+      ),
+      blockquoteDecoration: BoxDecoration(
+        border: Border(
+          left: BorderSide(
+            color: context.accentColor.withValues(alpha: 0.3),
+            width: 3,
+          ),
+        ),
+      ),
+      code: TextStyle(
+        fontFamily: 'monospace',
+        fontSize: 13,
+        backgroundColor:
+            isDark ? const Color(0xFF2A2A2A) : const Color(0xFFF0F0F0),
+        color: context.textPrimary,
+      ),
+      horizontalRuleDecoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(color: context.dividerColor, width: 1),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -12,6 +12,7 @@ import '../models/album.dart';
 import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
 import '../services/file_import_service.dart';
+import '../services/whats_new_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 import '../utils/responsive_utils.dart';
@@ -33,6 +34,7 @@ import 'vault_settings_screen.dart';
 import '../widgets/operation_progress_sheet.dart';
 import '../widgets/media_hold_action_sheet.dart';
 import '../widgets/media_multi_select_action_sheet.dart';
+import '../widgets/whats_new_bottom_sheet.dart';
 
 /// Gallery vault screen - main screen after authentication
 class GalleryVaultScreen extends ConsumerStatefulWidget {
@@ -82,6 +84,29 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
     ref.read(isDecoyModeProvider.notifier).state =
         ref.read(decoyServiceProvider).isDecoyModeActive;
     ref.read(vaultNotifierProvider.notifier).loadFiles();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _maybeShowWhatsNew();
+    });
+  }
+
+  Future<void> _maybeShowWhatsNew() async {
+    // Decoy persona stays quiet to avoid leaking that a real vault exists.
+    if (ref.read(isDecoyModeProvider)) return;
+
+    final service = WhatsNewService.instance;
+    if (!await service.shouldShow()) return;
+
+    final version = await service.currentVersion();
+    final sections = service.highlightsFor(version);
+    if (sections.isEmpty || !mounted) return;
+
+    await WhatsNewBottomSheet.show(
+      context,
+      version: version,
+      sections: sections,
+    );
+    await service.markSeen();
   }
 
   @override

--- a/lib/screens/vault_settings_screen.dart
+++ b/lib/screens/vault_settings_screen.dart
@@ -344,6 +344,28 @@ class _VaultSettingsScreenState extends ConsumerState<VaultSettingsScreen> {
                 activeThumbColor: context.accentColor,
                 contentPadding: EdgeInsets.zero,
               ),
+              SwitchListTile(
+                title: const Text(
+                  'Show Permission Warning',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  'Display a banner when All Files Access is not granted',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                value: settings.showPermissionWarning,
+                onChanged: (value) async {
+                  await _saveVaultSettings(
+                    settings.copyWith(showPermissionWarning: value),
+                  );
+                },
+                activeThumbColor: context.accentColor,
+                contentPadding: EdgeInsets.zero,
+              ),
               const SizedBox(height: 20),
               Divider(color: context.borderColor),
               const SizedBox(height: 20),

--- a/lib/screens/vault_settings_screen.dart
+++ b/lib/screens/vault_settings_screen.dart
@@ -12,9 +12,12 @@ import '../services/auth_service.dart';
 import '../services/auto_kill_service.dart';
 import '../services/screenshot_protection_service.dart';
 import '../services/vault_service.dart';
+import '../services/whats_new_service.dart';
 import '../themes/app_colors.dart';
+import '../widgets/whats_new_bottom_sheet.dart';
 import 'accent_color_picker_screen.dart';
 import 'change_security_screen.dart';
+import 'changelog_screen.dart';
 import 'encryption_settings_screen.dart';
 import 'local_backup_screen.dart';
 import 'performance_settings_screen.dart';
@@ -609,6 +612,43 @@ class _VaultSettingsScreenState extends ConsumerState<VaultSettingsScreen> {
                         contentPadding: EdgeInsets.zero,
                       ),
                       ListTile(
+                        leading: Icon(Icons.auto_awesome_outlined,
+                            color: context.accentColor),
+                        title: const Text("What's New",
+                            style: TextStyle(fontFamily: 'ProductSans')),
+                        subtitle: Text(
+                          'Highlights from this release',
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 12,
+                            color: context.textTertiary,
+                          ),
+                        ),
+                        onTap: _openWhatsNew,
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                      ListTile(
+                        leading: Icon(Icons.menu_book_outlined,
+                            color: context.accentColor),
+                        title: const Text('Changelog',
+                            style: TextStyle(fontFamily: 'ProductSans')),
+                        subtitle: Text(
+                          'Full version history',
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 12,
+                            color: context.textTertiary,
+                          ),
+                        ),
+                        onTap: () => Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => const ChangelogScreen(),
+                          ),
+                        ),
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                      ListTile(
                         leading: Icon(Icons.description_outlined,
                             color: context.accentColor),
                         title: const Text('License',
@@ -736,6 +776,30 @@ class _VaultSettingsScreenState extends ConsumerState<VaultSettingsScreen> {
         ],
       ),
     );
+  }
+
+  Future<void> _openWhatsNew() async {
+    final service = WhatsNewService.instance;
+    final version = await service.currentVersion();
+    final sections = service.highlightsFor(version);
+
+    if (!mounted) return;
+
+    if (sections.isEmpty) {
+      // Nothing curated for this build — fall back to the raw changelog.
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const ChangelogScreen()),
+      );
+      return;
+    }
+
+    await WhatsNewBottomSheet.show(
+      context,
+      version: version,
+      sections: sections,
+    );
+    await service.markSeen();
   }
 
   void _showLicenseDialog() {

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -2316,6 +2316,7 @@ class VaultSettings {
   final int lockoutDurationSeconds;
   final bool wipeVaultOnMaxFailedAttempts;
   final int maxFailedAttemptsBeforeWipe;
+  final bool showPermissionWarning;
 
   const VaultSettings({
     this.encryptionEnabled = false,
@@ -2336,6 +2337,7 @@ class VaultSettings {
     this.lockoutDurationSeconds = 30,
     this.wipeVaultOnMaxFailedAttempts = false,
     this.maxFailedAttemptsBeforeWipe = 12,
+    this.showPermissionWarning = true,
   });
 
   VaultSettings copyWith({
@@ -2357,6 +2359,7 @@ class VaultSettings {
     int? lockoutDurationSeconds,
     bool? wipeVaultOnMaxFailedAttempts,
     int? maxFailedAttemptsBeforeWipe,
+    bool? showPermissionWarning,
   }) {
     return VaultSettings(
       encryptionEnabled: encryptionEnabled ?? this.encryptionEnabled,
@@ -2383,6 +2386,8 @@ class VaultSettings {
           wipeVaultOnMaxFailedAttempts ?? this.wipeVaultOnMaxFailedAttempts,
       maxFailedAttemptsBeforeWipe:
           maxFailedAttemptsBeforeWipe ?? this.maxFailedAttemptsBeforeWipe,
+      showPermissionWarning:
+          showPermissionWarning ?? this.showPermissionWarning,
     );
   }
 
@@ -2405,6 +2410,7 @@ class VaultSettings {
         'lockoutDurationSeconds': lockoutDurationSeconds,
         'wipeVaultOnMaxFailedAttempts': wipeVaultOnMaxFailedAttempts,
         'maxFailedAttemptsBeforeWipe': maxFailedAttemptsBeforeWipe,
+        'showPermissionWarning': showPermissionWarning,
       };
 
   factory VaultSettings.fromJson(Map<String, dynamic> json) {
@@ -2438,6 +2444,8 @@ class VaultSettings {
           json['wipeVaultOnMaxFailedAttempts'] as bool? ?? false,
       maxFailedAttemptsBeforeWipe:
           json['maxFailedAttemptsBeforeWipe'] as int? ?? 12,
+      showPermissionWarning:
+          json['showPermissionWarning'] as bool? ?? true,
     );
   }
 }

--- a/lib/services/whats_new_service.dart
+++ b/lib/services/whats_new_service.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A single highlight item shown in the "What's New" bottom sheet.
+class WhatsNewItem {
+  final IconData icon;
+  final String title;
+  final String description;
+
+  const WhatsNewItem({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+}
+
+/// Highlights grouped under a single section header (e.g. "Encryption").
+class WhatsNewSection {
+  final String title;
+  final List<WhatsNewItem> items;
+
+  const WhatsNewSection({
+    required this.title,
+    required this.items,
+  });
+}
+
+/// Tracks app version transitions and serves the highlights shown to the
+/// user the first time they open a freshly-updated build.
+class WhatsNewService {
+  WhatsNewService._();
+  static final WhatsNewService instance = WhatsNewService._();
+
+  static const String _lastSeenVersionKey = 'whats_new_last_seen_version';
+
+  /// Version-keyed highlights. The key MUST match `PackageInfo.version`
+  /// exactly (the `+buildNumber` suffix is ignored).
+  ///
+  /// Add a new entry here whenever the app version in `pubspec.yaml` is
+  /// bumped to surface the changes to users on first launch.
+  static const Map<String, List<WhatsNewSection>> _highlights = {
+    '0.14.2-beta.3': [
+      WhatsNewSection(
+        title: 'Encryption & Crypto',
+        items: [
+          WhatsNewItem(
+            icon: Icons.shield_outlined,
+            title: 'AES-256-GCM v2',
+            description:
+                'Authenticated encryption with an isolate-based crypto worker pool — heavy work runs off the UI thread.',
+          ),
+          WhatsNewItem(
+            icon: Icons.key_outlined,
+            title: 'Dynamic KDF iterations',
+            description:
+                'Password and PIN hashing now uses per-credential PBKDF2 iteration counts that rotate automatically when vault settings change.',
+          ),
+          WhatsNewItem(
+            icon: Icons.warning_amber_outlined,
+            title: 'Re-encryption safeguards',
+            description:
+                'Detailed risk explanations are surfaced before any re-encryption begins.',
+          ),
+        ],
+      ),
+      WhatsNewSection(
+        title: 'Selection & Gestures',
+        items: [
+          WhatsNewItem(
+            icon: Icons.touch_app_outlined,
+            title: 'Hold-to-action',
+            description:
+                'Long-press a file to open an action sheet instead of immediately entering selection mode.',
+          ),
+          WhatsNewItem(
+            icon: Icons.checklist_outlined,
+            title: 'Multi-select action sheet',
+            description:
+                'Batch operations are now organised into a clean quick-action grid.',
+          ),
+        ],
+      ),
+      WhatsNewSection(
+        title: 'Updates & Reliability',
+        items: [
+          WhatsNewItem(
+            icon: Icons.system_update_outlined,
+            title: 'In-app updates',
+            description:
+                'Latch now checks the Play Store on launch and offers to update without leaving the app.',
+          ),
+          WhatsNewItem(
+            icon: Icons.bug_report_outlined,
+            title: 'Sturdier exports',
+            description:
+                'Parallel file export with improved progress tracking, plus fixes for vault entry parsing and empty index saves.',
+          ),
+        ],
+      ),
+    ],
+  };
+
+  String? _currentVersion;
+
+  /// Resolves and caches the running app's version string.
+  Future<String> currentVersion() async {
+    if (_currentVersion != null) return _currentVersion!;
+    final info = await PackageInfo.fromPlatform();
+    _currentVersion = info.version;
+    return _currentVersion!;
+  }
+
+  /// Returns the highlight sections for [version], or an empty list if no
+  /// entry exists for it.
+  List<WhatsNewSection> highlightsFor(String version) {
+    return _highlights[version] ?? const [];
+  }
+
+  /// Whether the "What's New" sheet should be shown on this launch.
+  ///
+  /// Returns `false` on a fresh install (no prior version recorded) so a
+  /// first-time user is not greeted with update notes for a release they
+  /// have never used.
+  Future<bool> shouldShow() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastSeen = prefs.getString(_lastSeenVersionKey);
+    final current = await currentVersion();
+
+    if (lastSeen == null) {
+      // Fresh install — record the current version and stay silent.
+      await prefs.setString(_lastSeenVersionKey, current);
+      return false;
+    }
+
+    if (lastSeen == current) return false;
+    return highlightsFor(current).isNotEmpty;
+  }
+
+  /// Persist the current version as "seen" so the sheet does not reappear
+  /// until the next update.
+  Future<void> markSeen() async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = await currentVersion();
+    await prefs.setString(_lastSeenVersionKey, current);
+  }
+
+  /// Force the sheet to reappear on the next launch (used by tests and
+  /// debug tooling).
+  Future<void> reset() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_lastSeenVersionKey);
+  }
+}

--- a/lib/widgets/permission_warning_banner.dart
+++ b/lib/widgets/permission_warning_banner.dart
@@ -1,12 +1,14 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
+import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
 import '../services/permission_service.dart';
 
 /// A warning banner that displays when "All Files Access" permission is not granted.
 /// This permission is required on Android 11+ for the app to hide files.
-class PermissionWarningBanner extends StatefulWidget {
+class PermissionWarningBanner extends ConsumerStatefulWidget {
   /// Callback when the permission status changes
   final VoidCallback? onPermissionChanged;
 
@@ -16,11 +18,11 @@ class PermissionWarningBanner extends StatefulWidget {
   });
 
   @override
-  State<PermissionWarningBanner> createState() =>
+  ConsumerState<PermissionWarningBanner> createState() =>
       _PermissionWarningBannerState();
 }
 
-class _PermissionWarningBannerState extends State<PermissionWarningBanner>
+class _PermissionWarningBannerState extends ConsumerState<PermissionWarningBanner>
     with WidgetsBindingObserver {
   bool _hasPermission = true;
   bool _isLoading = true;
@@ -97,6 +99,10 @@ class _PermissionWarningBannerState extends State<PermissionWarningBanner>
 
     // Don't show if permission is granted or dismissed
     if (_hasPermission || _isDismissed) return const SizedBox.shrink();
+
+    // Respect user preference to hide permission warning
+    final showWarning = ref.watch(vaultSettingsProvider).value?.showPermissionWarning ?? true;
+    if (!showWarning) return const SizedBox.shrink();
 
     return Container(
       margin: const EdgeInsets.all(12),
@@ -237,7 +243,7 @@ class _PermissionWarningBannerState extends State<PermissionWarningBanner>
 }
 
 /// A compact version of the permission warning for use in app bars or smaller spaces
-class CompactPermissionWarning extends StatefulWidget {
+class CompactPermissionWarning extends ConsumerStatefulWidget {
   final VoidCallback? onTap;
 
   const CompactPermissionWarning({
@@ -246,11 +252,11 @@ class CompactPermissionWarning extends StatefulWidget {
   });
 
   @override
-  State<CompactPermissionWarning> createState() =>
+  ConsumerState<CompactPermissionWarning> createState() =>
       _CompactPermissionWarningState();
 }
 
-class _CompactPermissionWarningState extends State<CompactPermissionWarning>
+class _CompactPermissionWarningState extends ConsumerState<CompactPermissionWarning>
     with WidgetsBindingObserver {
   bool _hasPermission = true;
   bool _isLoading = true;
@@ -298,6 +304,10 @@ class _CompactPermissionWarningState extends State<CompactPermissionWarning>
     if (!Platform.isAndroid || _isLoading || _hasPermission) {
       return const SizedBox.shrink();
     }
+
+    // Respect user preference to hide permission warning
+    final showWarning = ref.watch(vaultSettingsProvider).value?.showPermissionWarning ?? true;
+    if (!showWarning) return const SizedBox.shrink();
 
     return GestureDetector(
       onTap: widget.onTap ??

--- a/lib/widgets/whats_new_bottom_sheet.dart
+++ b/lib/widgets/whats_new_bottom_sheet.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../services/whats_new_service.dart';
+import '../themes/app_colors.dart';
+import '../screens/changelog_screen.dart';
+
+/// Modal bottom sheet that highlights what changed in the current build.
+///
+/// Shown automatically the first time a user opens the app after an
+/// update (see [WhatsNewService.shouldShow]) and reopened on demand from
+/// vault settings.
+class WhatsNewBottomSheet extends StatelessWidget {
+  final String version;
+  final List<WhatsNewSection> sections;
+
+  const WhatsNewBottomSheet({
+    super.key,
+    required this.version,
+    required this.sections,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required String version,
+    required List<WhatsNewSection> sections,
+  }) {
+    HapticFeedback.lightImpact();
+    return showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (ctx) => WhatsNewBottomSheet(
+        version: version,
+        sections: sections,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final maxHeight = mediaQuery.size.height * 0.85;
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: maxHeight),
+      child: Container(
+        width: double.infinity,
+        decoration: BoxDecoration(
+          color: context.backgroundColor,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _DragHandle(),
+            const SizedBox(height: 20),
+            _Header(version: version),
+            const SizedBox(height: 20),
+            Flexible(
+              child: ListView.separated(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
+                itemCount: sections.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 20),
+                itemBuilder: (ctx, i) => _SectionView(section: sections[i]),
+              ),
+            ),
+            _Footer(),
+            SizedBox(height: 12 + mediaQuery.padding.bottom),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DragHandle extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(top: 12),
+      width: 40,
+      height: 4,
+      decoration: BoxDecoration(
+        color: context.borderColor,
+        borderRadius: BorderRadius.circular(2),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final String version;
+  const _Header({required this.version});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 64,
+          height: 64,
+          decoration: BoxDecoration(
+            color: context.accentColor.withValues(alpha: 0.1),
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            Icons.auto_awesome_outlined,
+            size: 28,
+            color: context.accentColor,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          "What's New",
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+            color: context.textPrimary,
+            fontFamily: 'ProductSans',
+          ),
+        ),
+        const SizedBox(height: 6),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+          decoration: BoxDecoration(
+            color: context.accentColor.withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: context.accentColor.withValues(alpha: 0.2),
+            ),
+          ),
+          child: Text(
+            'Version $version',
+            style: TextStyle(
+              fontSize: 12,
+              color: context.accentColor,
+              fontFamily: 'ProductSans',
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SectionView extends StatelessWidget {
+  final WhatsNewSection section;
+  const _SectionView({required this.section});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 10, left: 2),
+          child: Text(
+            section.title,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: context.textSecondary,
+              fontFamily: 'ProductSans',
+              letterSpacing: 0.3,
+            ),
+          ),
+        ),
+        ...section.items.map((item) => _ItemTile(item: item)),
+      ],
+    );
+  }
+}
+
+class _ItemTile extends StatelessWidget {
+  final WhatsNewItem item;
+  const _ItemTile({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: context.accentColor.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(
+              item.icon,
+              size: 20,
+              color: context.accentColor,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.title,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: context.textPrimary,
+                    fontFamily: 'ProductSans',
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  item.description,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: context.textSecondary,
+                    fontFamily: 'ProductSans',
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Footer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 4, 20, 4),
+      child: Column(
+        children: [
+          Divider(color: context.dividerColor, height: 1),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: TextButton.icon(
+                  onPressed: () {
+                    Navigator.pop(context);
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const ChangelogScreen(),
+                      ),
+                    );
+                  },
+                  icon: Icon(
+                    Icons.menu_book_outlined,
+                    size: 18,
+                    color: context.accentColor,
+                  ),
+                  label: Text(
+                    'Full changelog',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontWeight: FontWeight.w500,
+                      color: context.accentColor,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: FilledButton(
+                  onPressed: () => Navigator.pop(context),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: context.accentColor,
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    'Got it',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: "none"
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.14.1-beta.2+11
+version: 0.14.2-beta.3+12
 
 environment:
   sdk: ">=3.4.4 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,6 +99,7 @@ flutter:
     - assets/reverse_locker_logo_nobg.svg
     - assets/reverse_locker_logo_transparent.png
     - assets/privacy_policy.md
+    - CHANGELOG.md
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware
   # For details regarding adding assets from package dependencies, see


### PR DESCRIPTION
# Summary

Adds a "What's New" bottom sheet widget and changelog screen to highlight new features per version, along with a permission warning setting.

# Changes

## What's New / Changelog

- Add "What's New" bottom sheet widget
- Add `WhatsNewService` for displaying version highlights
- Add changelog screen
- Add "What's New" and "Changelog" entries to vault settings screen

## Settings

- Add permission warning setting to vault settings