### PR TITLE
Add per-file encryption settings with re-encrypt file picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to Latch are documented in this file.
 - **CTR decryption** now writes to a temporary file and renames on success, preventing data loss on failure
 - **Progress callback** added to `getVaultedFile` for better UX during decryption
 
+### Per-File Encryption
+- **Per-file encryption configuration** — each file can now have its own encryption algorithm and KDF settings
+- **Encryption settings prompt** on every import flow, letting users choose per-file options
+- **Re-encrypt file picker screen** with selection UI and progress tracking, replacing the old dialog
+- **`derivedKey` parameter** for per-file key derivation
+- `encryptionAlgorithm` and `kdfIterations` fields added to `VaultedFile`
+- Optional `fileFilter` parameter added to `reEncryptVault`
+
 ### Bug Fixes
 - Fixed `Uint8List.view` shared buffer issue in encryption workers — prevents corrupted output when iterating across views
 

--- a/lib/models/vaulted_file.dart
+++ b/lib/models/vaulted_file.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'encryption_algorithm.dart';
+
 /// Enum representing the type of file stored in the vault
 enum VaultedFileType {
   image,
@@ -72,6 +74,9 @@ class VaultedFile {
   final bool isFavorite;
   final bool isEncrypted;
   final String? encryptionIv; // Initialization vector for AES encryption
+  final EncryptionAlgorithm? encryptionAlgorithm;
+  final String? keyDerivationSalt;
+  final int? kdfIterations;
   final bool isDecoy; // Flag for decoy mode files
   final DateTime? lastViewed;
   final int viewCount;
@@ -96,6 +101,9 @@ class VaultedFile {
     this.isFavorite = false,
     this.isEncrypted = false,
     this.encryptionIv,
+    this.encryptionAlgorithm,
+    this.keyDerivationSalt,
+    this.kdfIterations,
     this.isDecoy = false,
     this.lastViewed,
     this.viewCount = 0,
@@ -122,6 +130,9 @@ class VaultedFile {
     bool? isFavorite,
     bool? isEncrypted,
     String? encryptionIv,
+    EncryptionAlgorithm? encryptionAlgorithm,
+    String? keyDerivationSalt,
+    int? kdfIterations,
     bool? isDecoy,
     DateTime? lastViewed,
     int? viewCount,
@@ -146,6 +157,9 @@ class VaultedFile {
       isFavorite: isFavorite ?? this.isFavorite,
       isEncrypted: isEncrypted ?? this.isEncrypted,
       encryptionIv: encryptionIv ?? this.encryptionIv,
+      encryptionAlgorithm: encryptionAlgorithm ?? this.encryptionAlgorithm,
+      keyDerivationSalt: keyDerivationSalt ?? this.keyDerivationSalt,
+      kdfIterations: kdfIterations ?? this.kdfIterations,
       isDecoy: isDecoy ?? this.isDecoy,
       lastViewed: lastViewed ?? this.lastViewed,
       viewCount: viewCount ?? this.viewCount,
@@ -262,6 +276,9 @@ class VaultedFile {
       'isFavorite': isFavorite,
       'isEncrypted': isEncrypted,
       'encryptionIv': encryptionIv,
+      'encryptionAlgorithm': encryptionAlgorithm?.name,
+      'keyDerivationSalt': keyDerivationSalt,
+      'kdfIterations': kdfIterations,
       'isDecoy': isDecoy,
       'lastViewed': lastViewed?.toIso8601String(),
       'viewCount': viewCount,
@@ -294,6 +311,14 @@ class VaultedFile {
       isFavorite: json['isFavorite'] as bool? ?? false,
       isEncrypted: json['isEncrypted'] as bool? ?? false,
       encryptionIv: json['encryptionIv'] as String?,
+      encryptionAlgorithm: json['encryptionAlgorithm'] != null
+          ? EncryptionAlgorithm.values.firstWhere(
+              (e) => e.name == json['encryptionAlgorithm'],
+              orElse: () => EncryptionAlgorithm.aes256Ctr,
+            )
+          : null,
+      keyDerivationSalt: json['keyDerivationSalt'] as String?,
+      kdfIterations: json['kdfIterations'] as int?,
       isDecoy: json['isDecoy'] as bool? ?? false,
       lastViewed: json['lastViewed'] != null
           ? DateTime.parse(json['lastViewed'] as String)

--- a/lib/providers/vault_providers.dart
+++ b/lib/providers/vault_providers.dart
@@ -524,11 +524,12 @@ class ReEncryptNotifier extends Notifier<ReEncryptProgress> {
 
   VaultService get _vaultService => ref.read(vaultServiceProvider);
 
-  Future<int> reEncryptVault(EncryptionAlgorithm targetAlgorithm) async {
+  Future<int> reEncryptVault(EncryptionAlgorithm targetAlgorithm, {Set<String>? fileFilter}) async {
     state = const ReEncryptProgress(isInProgress: true, current: 0, total: 0);
     try {
       final result = await _vaultService.reEncryptVault(
         targetAlgorithm,
+        fileFilter: fileFilter,
         onProgress: (current, total) {
           state = ReEncryptProgress(
             isInProgress: true,

--- a/lib/screens/encryption_settings_screen.dart
+++ b/lib/screens/encryption_settings_screen.dart
@@ -4,7 +4,7 @@ import '../models/encryption_algorithm.dart';
 import '../providers/vault_providers.dart';
 import '../services/vault_service.dart';
 import '../themes/app_colors.dart';
-import '../widgets/re_encrypt_warning_dialog.dart';
+import 're_encrypt_file_picker_screen.dart';
 
 class EncryptionSettingsScreen extends ConsumerStatefulWidget {
   const EncryptionSettingsScreen({super.key});
@@ -17,12 +17,10 @@ class EncryptionSettingsScreen extends ConsumerStatefulWidget {
 class _EncryptionSettingsScreenState
     extends ConsumerState<EncryptionSettingsScreen> {
   static const List<int> _kdfIterationOptions = [100000, 200000, 500000];
-  bool _isReEncrypting = false;
 
   @override
   Widget build(BuildContext context) {
     final settingsAsync = ref.watch(vaultSettingsProvider);
-    final reEncryptProgress = ref.watch(reEncryptProvider);
 
     return Scaffold(
       backgroundColor: context.backgroundColor,
@@ -95,27 +93,11 @@ class _EncryptionSettingsScreenState
                 ),
               ),
               const SizedBox(height: 12),
-              if (reEncryptProgress.isInProgress && _isReEncrypting)
-                _buildProgressBar(context, reEncryptProgress),
-              if (reEncryptProgress.error != null)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 12),
-                  child: Text(
-                    reEncryptProgress.error!,
-                    style: const TextStyle(
-                      fontFamily: 'ProductSans',
-                      color: Colors.red,
-                      fontSize: 12,
-                    ),
-                  ),
-                ),
               FilledButton.icon(
-                onPressed: _isReEncrypting
-                    ? null
-                    : () => _confirmReEncrypt(context, settings),
+                onPressed: () => _confirmReEncrypt(context, settings),
                 icon: const Icon(Icons.sync),
                 label: const Text(
-                  'Re-Encrypt All Files',
+                  'Re-Encrypt Files',
                   style: TextStyle(fontFamily: 'ProductSans'),
                 ),
                 style: FilledButton.styleFrom(
@@ -233,35 +215,6 @@ class _EncryptionSettingsScreenState
             ? Icon(Icons.check_circle, color: context.accentColor)
             : null,
         onTap: () => _selectIterations(settings, iterations),
-      ),
-    );
-  }
-
-  Widget _buildProgressBar(BuildContext context, ReEncryptProgress progress) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          LinearProgressIndicator(
-            value: progress.total > 0
-                ? progress.current / progress.total
-                : null,
-            backgroundColor: context.dividerColor,
-            color: context.accentColor,
-          ),
-          const SizedBox(height: 4),
-          Text(
-            progress.total > 0
-                ? 'Re-encrypting ${progress.current}/${progress.total} files...'
-                : 'Re-encrypting...',
-            style: TextStyle(
-              fontFamily: 'ProductSans',
-              fontSize: 12,
-              color: context.textTertiary,
-            ),
-          ),
-        ],
       ),
     );
   }
@@ -388,65 +341,14 @@ class _EncryptionSettingsScreenState
     BuildContext context,
     VaultSettings settings,
   ) async {
-    final warningAcknowledged = await showReEncryptWarningDialog(
-      context: context,
-    );
-    if (warningAcknowledged != true || !mounted) return;
-
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: context.surfaceColor,
-        title: Text(
-          'Re-Encrypt Vault',
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            color: context.textPrimary,
-          ),
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => ReEncryptFilePickerScreen(
+          targetAlgorithm: settings.encryptionAlgorithm,
         ),
-        content: Text(
-          'This will re-encrypt all encrypted files using ${settings.encryptionAlgorithm.displayName}. This cannot be undone and may take a while. Make sure your device has sufficient battery.',
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            color: context.textSecondary,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(
-              'Cancel',
-              style: TextStyle(color: context.textSecondary),
-            ),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Colors.red,
-            ),
-            child: const Text('Re-Encrypt'),
-          ),
-        ],
       ),
     );
-
-    if (confirmed == true && mounted) {
-      setState(() => _isReEncrypting = true);
-      await ref.read(reEncryptProvider.notifier).reEncryptVault(
-            settings.encryptionAlgorithm,
-          );
-      if (mounted) {
-        setState(() => _isReEncrypting = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'Re-encryption complete',
-              style: TextStyle(fontFamily: 'ProductSans'),
-            ),
-          ),
-        );
-      }
-    }
   }
 
   Future<void> _saveVaultSettings(VaultSettings settings) async {

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:path_provider/path_provider.dart';
+import '../models/encryption_algorithm.dart';
 import '../models/vaulted_file.dart';
 import '../models/album.dart';
 import '../providers/vault_providers.dart';
@@ -17,6 +19,7 @@ import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 import '../utils/responsive_utils.dart';
 import '../widgets/office_conversion_confirm_dialog.dart';
+import '../widgets/per_file_encryption_sheet.dart';
 import 'albums_screen.dart';
 import 'favorites_screen.dart';
 import 'tags_screen.dart';
@@ -3004,7 +3007,6 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
   Future<void> _importImagesFromGallery() async {
     Navigator.pop(context);
 
-    // Open custom media picker for images
     final selectedAssets = await Navigator.push<List<AssetEntity>?>(
       context,
       MaterialPageRoute(
@@ -3020,6 +3022,38 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
       return;
     }
 
+    final settings = await ref.read(vaultSettingsProvider.future);
+    final encryptionEnabled = settings.encryptionEnabled;
+    final defaultAlgorithm = settings.encryptionAlgorithm;
+
+    final perFileSettings = <PerFileEncryptionSettings>[];
+    for (final asset in selectedAssets) {
+      final file = await asset.file;
+      final fileSize = file != null ? await file.length() : 0;
+      perFileSettings.add(PerFileEncryptionSettings(
+        fileName: asset.title ?? 'Unknown',
+        filePath: file?.path ?? '',
+        fileSize: fileSize,
+        encrypt: encryptionEnabled,
+        algorithm: defaultAlgorithm,
+      ));
+    }
+
+    if (!mounted) return;
+    final confirmedSettings = await PerFileEncryptionSheet.show(
+      context,
+      files: perFileSettings,
+      encryptionEnabled: encryptionEnabled,
+      defaultAlgorithm: defaultAlgorithm,
+    );
+
+    if (confirmedSettings == null) return;
+
+    final perFileEncryption = <String, ({bool encrypt, EncryptionAlgorithm algorithm})>{};
+    for (final s in confirmedSettings) {
+      perFileEncryption[s.filePath] = (encrypt: s.encrypt, algorithm: s.algorithm);
+    }
+
     final progressState = ValueNotifier<OperationProgressState>(
       OperationProgressState(
         totalFiles: selectedAssets.length,
@@ -3032,7 +3066,6 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
       ),
     );
 
-    // Show progress sheet
     if (!mounted) return;
     showModalBottomSheet(
       context: context,
@@ -3058,7 +3091,8 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
 
     final result = await _importService.importFromAssets(
       assets: selectedAssets,
-      deleteOriginals: true, // Hide from gallery
+      deleteOriginals: true,
+      perFileEncryption: perFileEncryption,
       onProgress: (current, total, {int? currentSize, int? totalSize}) {
         progressState.value = progressState.value.copyWith(
           totalFiles: total,
@@ -3096,13 +3130,12 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
       ToastUtils.showError(result.error ?? 'Import failed');
     }
 
-    Navigator.pop(context); // Close progress sheet
+    Navigator.pop(context);
   }
 
   Future<void> _importVideosFromGallery() async {
     Navigator.pop(context);
 
-    // Open custom media picker for videos
     final selectedAssets = await Navigator.push<List<AssetEntity>?>(
       context,
       MaterialPageRoute(
@@ -3116,6 +3149,38 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
     if (selectedAssets == null || selectedAssets.isEmpty) {
       ToastUtils.showInfo('No videos selected');
       return;
+    }
+
+    final settings = await ref.read(vaultSettingsProvider.future);
+    final encryptionEnabled = settings.encryptionEnabled;
+    final defaultAlgorithm = settings.encryptionAlgorithm;
+
+    final perFileSettings = <PerFileEncryptionSettings>[];
+    for (final asset in selectedAssets) {
+      final file = await asset.file;
+      final fileSize = file != null ? await file.length() : 0;
+      perFileSettings.add(PerFileEncryptionSettings(
+        fileName: asset.title ?? 'Unknown',
+        filePath: file?.path ?? '',
+        fileSize: fileSize,
+        encrypt: encryptionEnabled,
+        algorithm: defaultAlgorithm,
+      ));
+    }
+
+    if (!mounted) return;
+    final confirmedSettings = await PerFileEncryptionSheet.show(
+      context,
+      files: perFileSettings,
+      encryptionEnabled: encryptionEnabled,
+      defaultAlgorithm: defaultAlgorithm,
+    );
+
+    if (confirmedSettings == null) return;
+
+    final perFileEncryption = <String, ({bool encrypt, EncryptionAlgorithm algorithm})>{};
+    for (final s in confirmedSettings) {
+      perFileEncryption[s.filePath] = (encrypt: s.encrypt, algorithm: s.algorithm);
     }
 
     final progressState = ValueNotifier<OperationProgressState>(
@@ -3155,7 +3220,8 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
 
     final result = await _importService.importFromAssets(
       assets: selectedAssets,
-      deleteOriginals: true, // Hide from gallery
+      deleteOriginals: true,
+      perFileEncryption: perFileEncryption,
       onProgress: (current, total, {int? currentSize, int? totalSize}) {
         progressState.value = progressState.value.copyWith(
           totalFiles: total,
@@ -3376,7 +3442,6 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
   Future<void> _importDocuments() async {
     Navigator.pop(context);
 
-    // Open custom document picker
     final selectedDocuments = await Navigator.push<List<DocumentFile>?>(
       context,
       MaterialPageRoute(
@@ -3391,18 +3456,49 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
       return;
     }
 
+    final settings = await ref.read(vaultSettingsProvider.future);
+    final encryptionEnabled = settings.encryptionEnabled;
+    final defaultAlgorithm = settings.encryptionAlgorithm;
+
+    final perFileSettings = <PerFileEncryptionSettings>[];
+    for (final doc in selectedDocuments) {
+      final file = File(doc.path);
+      final fileSize = await file.exists() ? await file.length() : 0;
+      perFileSettings.add(PerFileEncryptionSettings(
+        fileName: doc.name,
+        filePath: doc.path,
+        fileSize: fileSize,
+        encrypt: encryptionEnabled,
+        algorithm: defaultAlgorithm,
+      ));
+    }
+
+    if (!mounted) return;
+    final confirmedSettings = await PerFileEncryptionSheet.show(
+      context,
+      files: perFileSettings,
+      encryptionEnabled: encryptionEnabled,
+      defaultAlgorithm: defaultAlgorithm,
+    );
+
+    if (confirmedSettings == null) return;
+
+    final perFileEncryption = <String, ({bool encrypt, EncryptionAlgorithm algorithm})>{};
+    for (final s in confirmedSettings) {
+      perFileEncryption[s.filePath] = (encrypt: s.encrypt, algorithm: s.algorithm);
+    }
+
     setState(() {
       _isImporting = true;
       _importProgress = 0;
       _importTotal = selectedDocuments.length;
     });
 
-    // Use the new conversion-aware import method
     final result = await _importService.importFromDocumentFilesWithConversion(
       filePaths: selectedDocuments.map((d) => d.path).toList(),
-      deleteOriginals: true, // Hide from file manager
+      deleteOriginals: true,
+      perFileEncryption: perFileEncryption,
       onConversionConfirmation: (officeFiles) async {
-        // Show conversion confirmation dialog
         if (!mounted) return false;
         final confirmed = await showDialog<bool>(
           context: context,
@@ -3422,7 +3518,6 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
         });
       },
       onStatusUpdate: (message) {
-        // Could be used to show a status message
         debugPrint('[Import] $message');
       },
     );
@@ -3468,6 +3563,38 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
       return;
     }
 
+    final settings = await ref.read(vaultSettingsProvider.future);
+    final encryptionEnabled = settings.encryptionEnabled;
+    final defaultAlgorithm = settings.encryptionAlgorithm;
+
+    final perFileSettings = <PerFileEncryptionSettings>[];
+    for (final song in selectedSongs) {
+      final file = File(song.path);
+      final fileSize = await file.exists() ? await file.length() : 0;
+      perFileSettings.add(PerFileEncryptionSettings(
+        fileName: song.name,
+        filePath: song.path,
+        fileSize: fileSize,
+        encrypt: encryptionEnabled,
+        algorithm: defaultAlgorithm,
+      ));
+    }
+
+    if (!mounted) return;
+    final confirmedSettings = await PerFileEncryptionSheet.show(
+      context,
+      files: perFileSettings,
+      encryptionEnabled: encryptionEnabled,
+      defaultAlgorithm: defaultAlgorithm,
+    );
+
+    if (confirmedSettings == null) return;
+
+    final perFileEncryption = <String, ({bool encrypt, EncryptionAlgorithm algorithm})>{};
+    for (final s in confirmedSettings) {
+      perFileEncryption[s.filePath] = (encrypt: s.encrypt, algorithm: s.algorithm);
+    }
+
     setState(() {
       _isImporting = true;
       _importProgress = 0;
@@ -3477,6 +3604,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
     final result = await _importService.importFromDocumentFiles(
       filePaths: selectedSongs.map((song) => song.path).toList(),
       deleteOriginals: true,
+      perFileEncryption: perFileEncryption,
       onProgress: (current, total) {
         setState(() {
           _importProgress = current;
@@ -3502,14 +3630,65 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
 
   Future<void> _importAnyFiles() async {
     Navigator.pop(context);
+
+    final result = await FilePicker.pickFiles(
+      type: FileType.any,
+      allowMultiple: true,
+    );
+
+    if (result == null || result.files.isEmpty) {
+      ToastUtils.showInfo('No files selected');
+      return;
+    }
+
+    final settings = await ref.read(vaultSettingsProvider.future);
+    final encryptionEnabled = settings.encryptionEnabled;
+    final defaultAlgorithm = settings.encryptionAlgorithm;
+
+    final perFileSettings = <PerFileEncryptionSettings>[];
+    final validPaths = <String>[];
+    for (final file in result.files) {
+      if (file.path == null) continue;
+      validPaths.add(file.path!);
+      perFileSettings.add(PerFileEncryptionSettings(
+        fileName: file.name,
+        filePath: file.path!,
+        fileSize: file.size,
+        encrypt: encryptionEnabled,
+        algorithm: defaultAlgorithm,
+      ));
+    }
+
+    if (perFileSettings.isEmpty) {
+      ToastUtils.showInfo('No valid files selected');
+      return;
+    }
+
+    if (!mounted) return;
+    final confirmedSettings = await PerFileEncryptionSheet.show(
+      context,
+      files: perFileSettings,
+      encryptionEnabled: encryptionEnabled,
+      defaultAlgorithm: defaultAlgorithm,
+    );
+
+    if (confirmedSettings == null) return;
+
+    final perFileEncryption = <String, ({bool encrypt, EncryptionAlgorithm algorithm})>{};
+    for (final s in confirmedSettings) {
+      perFileEncryption[s.filePath] = (encrypt: s.encrypt, algorithm: s.algorithm);
+    }
+
     setState(() {
       _isImporting = true;
       _importProgress = 0;
-      _importTotal = 0;
+      _importTotal = perFileSettings.length;
     });
 
-    final result = await _importService.importAnyFiles(
-      deleteOriginals: true, // Hide originals
+    final importResult = await _importService.importFromDocumentFiles(
+      filePaths: validPaths,
+      deleteOriginals: true,
+      perFileEncryption: perFileEncryption,
       onProgress: (current, total) {
         setState(() {
           _importProgress = current;
@@ -3520,16 +3699,16 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
 
     setState(() => _isImporting = false);
 
-    if (result.success && result.importedCount > 0) {
-      final msg = result.deletedOriginals
-          ? 'Imported and hidden ${result.importedCount} file(s)'
-          : 'Imported ${result.importedCount} file(s)';
+    if (importResult.success && importResult.importedCount > 0) {
+      final msg = importResult.deletedOriginals
+          ? 'Imported and hidden ${importResult.importedCount} file(s)'
+          : 'Imported ${importResult.importedCount} file(s)';
       ToastUtils.showSuccess(msg);
       ref.read(vaultNotifierProvider.notifier).loadFiles();
-    } else if (!result.success) {
-      ToastUtils.showError(result.error ?? 'Import failed');
+    } else if (!importResult.success) {
+      ToastUtils.showError(importResult.error ?? 'Import failed');
     } else {
-      ToastUtils.showInfo('No files selected');
+      ToastUtils.showInfo('No files imported');
     }
   }
 

--- a/lib/screens/re_encrypt_file_picker_screen.dart
+++ b/lib/screens/re_encrypt_file_picker_screen.dart
@@ -1,0 +1,441 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/encryption_algorithm.dart';
+import '../models/vaulted_file.dart';
+import '../providers/vault_providers.dart';
+import '../themes/app_colors.dart';
+import '../widgets/re_encrypt_warning_dialog.dart';
+
+class ReEncryptFilePickerScreen extends ConsumerStatefulWidget {
+  final EncryptionAlgorithm targetAlgorithm;
+
+  const ReEncryptFilePickerScreen({
+    super.key,
+    required this.targetAlgorithm,
+  });
+
+  @override
+  ConsumerState<ReEncryptFilePickerScreen> createState() =>
+      _ReEncryptFilePickerScreenState();
+}
+
+class _ReEncryptFilePickerScreenState
+    extends ConsumerState<ReEncryptFilePickerScreen> {
+  Set<String> _selectedIds = {};
+  bool _isReEncrypting = false;
+
+  String _formatSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+  }
+
+  String _formatAlgorithm(EncryptionAlgorithm? algo) {
+    if (algo == null) return 'Unknown';
+    return algo == EncryptionAlgorithm.aes256Ctr ? 'AES-CTR' : 'AES-GCM';
+  }
+
+  IconData _iconForType(VaultedFileType type) {
+    switch (type) {
+      case VaultedFileType.image:
+        return Icons.image_outlined;
+      case VaultedFileType.video:
+        return Icons.videocam_outlined;
+      case VaultedFileType.song:
+        return Icons.audiotrack_outlined;
+      case VaultedFileType.document:
+        return Icons.description_outlined;
+      default:
+        return Icons.insert_drive_file_outlined;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filesAsync = ref.watch(allFilesProvider);
+    final reEncryptProgress = ref.watch(reEncryptProvider);
+
+    return Scaffold(
+      backgroundColor: context.backgroundColor,
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: context.textPrimary),
+          onPressed: _isReEncrypting ? null : () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Select Files to Re-Encrypt',
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            color: context.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        actions: [
+          if (!_isReEncrypting)
+            TextButton(
+              onPressed: () {
+                setState(() {
+                  if (_selectedIds.length == _encryptedFiles(filesAsync).length) {
+                    _selectedIds = {};
+                  } else {
+                    _selectedIds = _encryptedFiles(filesAsync)
+                        .map((f) => f.id)
+                        .toSet();
+                  }
+                });
+              },
+              child: Text(
+                _selectedIds.length == _encryptedFiles(filesAsync).length
+                    ? 'Deselect All'
+                    : 'Select All',
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  color: context.accentColor,
+                ),
+              ),
+            ),
+        ],
+      ),
+      body: filesAsync.when(
+        loading: () => Center(
+          child: CircularProgressIndicator(color: context.accentColor),
+        ),
+        error: (_, __) => Center(
+          child: Text(
+            'Failed to load files',
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              color: context.textPrimary,
+            ),
+          ),
+        ),
+        data: (files) {
+          final encryptedFiles = _encryptedFiles(filesAsync);
+
+          if (encryptedFiles.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.lock_open, size: 64, color: context.textTertiary),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No encrypted files',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 18,
+                      color: context.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(16),
+                margin: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: context.accentColor.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(
+                  children: [
+                    Icon(Icons.info_outline, color: context.accentColor, size: 20),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        'Target: ${widget.targetAlgorithm.displayName}\n'
+                        '${_selectedIds.length} of ${encryptedFiles.length} selected',
+                        style: TextStyle(
+                          fontFamily: 'ProductSans',
+                          fontSize: 13,
+                          color: context.textPrimary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (reEncryptProgress.isInProgress && _isReEncrypting)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Column(
+                    children: [
+                      LinearProgressIndicator(
+                        value: reEncryptProgress.total > 0
+                            ? reEncryptProgress.current /
+                                reEncryptProgress.total
+                            : null,
+                        backgroundColor: context.dividerColor,
+                        valueColor: AlwaysStoppedAnimation(context.accentColor),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Re-encrypting ${reEncryptProgress.current} of ${reEncryptProgress.total}...',
+                        style: TextStyle(
+                          fontFamily: 'ProductSans',
+                          fontSize: 12,
+                          color: context.textSecondary,
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                  ),
+                ),
+              if (reEncryptProgress.error != null)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text(
+                    reEncryptProgress.error!,
+                    style: const TextStyle(
+                      fontFamily: 'ProductSans',
+                      color: Colors.red,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  itemCount: encryptedFiles.length,
+                  itemBuilder: (context, index) {
+                    final file = encryptedFiles[index];
+                    final isSelected = _selectedIds.contains(file.id);
+                    final needsReEncrypt =
+                        file.encryptionAlgorithm != widget.targetAlgorithm;
+
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: isSelected
+                              ? context.accentColor.withValues(alpha: 0.08)
+                              : context.surfaceColor,
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                            color: isSelected
+                                ? context.accentColor
+                                : context.dividerColor,
+                          ),
+                        ),
+                        child: ListTile(
+                          leading: Icon(
+                            _iconForType(file.type),
+                            color: isSelected
+                                ? context.accentColor
+                                : context.textSecondary,
+                          ),
+                          title: Text(
+                            file.originalName,
+                            style: TextStyle(
+                              fontFamily: 'ProductSans',
+                              fontSize: 14,
+                              color: context.textPrimary,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          subtitle: Row(
+                            children: [
+                              if (file.fileSize > _largeFileThresholdBytes) ...[
+                                Icon(Icons.warning_amber, size: 14, color: Colors.orange),
+                                const SizedBox(width: 4),
+                              ],
+                              Expanded(
+                                child: Text(
+                                  '${_formatSize(file.fileSize)} • ${_formatAlgorithm(file.encryptionAlgorithm)}'
+                                  '${needsReEncrypt ? ' → ${_formatAlgorithm(widget.targetAlgorithm)}' : ' (no change)'}',
+                                  style: TextStyle(
+                                    fontFamily: 'ProductSans',
+                                    fontSize: 12,
+                                    color: needsReEncrypt
+                                        ? context.textSecondary
+                                        : context.textTertiary,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          trailing: Checkbox(
+                            value: isSelected,
+                            onChanged: _isReEncrypting
+                                ? null
+                                : (value) {
+                                    setState(() {
+                                      if (value == true) {
+                                        _selectedIds.add(file.id);
+                                      } else {
+                                        _selectedIds.remove(file.id);
+                                      }
+                                    });
+                                  },
+                            activeColor: context.accentColor,
+                          ),
+                          onTap: _isReEncrypting
+                              ? null
+                              : () {
+                                  setState(() {
+                                    if (isSelected) {
+                                      _selectedIds.remove(file.id);
+                                    } else {
+                                      _selectedIds.add(file.id);
+                                    }
+                                  });
+                                },
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _selectedIds.isEmpty || _isReEncrypting
+                        ? null
+                        : () => _startReEncrypt(),
+                    icon: const Icon(Icons.sync),
+                    label: Text(
+                      'Re-Encrypt ${_selectedIds.length} File(s)',
+                      style: const TextStyle(fontFamily: 'ProductSans'),
+                    ),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: context.accentColor,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  static const int _largeFileThresholdBytes = 50 * 1024 * 1024;
+
+  List<VaultedFile> _encryptedFiles(AsyncValue<List<VaultedFile>> filesAsync) {
+    return filesAsync.whenOrNull(
+          data: (files) => files.where((f) => f.isEncrypted).toList(),
+        ) ??
+        [];
+  }
+
+  Future<void> _startReEncrypt() async {
+    final encryptedFiles = _encryptedFiles(ref.read(allFilesProvider));
+    final largeFiles = encryptedFiles
+        .where((f) => _selectedIds.contains(f.id) && f.fileSize > _largeFileThresholdBytes)
+        .toList();
+
+    if (largeFiles.isNotEmpty) {
+      final proceed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          backgroundColor: context.surfaceColor,
+          title: Row(
+            children: [
+              Icon(Icons.warning_amber_rounded, color: Colors.orange, size: 24),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Large Files Detected',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    color: context.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '${largeFiles.length} file(s) over 50MB will be re-encrypted. This may take a long time and could corrupt files if interrupted.',
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  color: context.textSecondary,
+                  fontSize: 14,
+                ),
+              ),
+              const SizedBox(height: 12),
+              ...largeFiles.take(5).map((f) => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  '• ${f.originalName} (${_formatSize(f.fileSize)})',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+              )),
+              if (largeFiles.length > 5)
+                Text(
+                  '...and ${largeFiles.length - 5} more',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(
+                'Cancel',
+                style: TextStyle(color: context.textSecondary),
+              ),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              style: FilledButton.styleFrom(
+                backgroundColor: Colors.orange,
+              ),
+              child: const Text('Proceed'),
+            ),
+          ],
+        ),
+      );
+      if (proceed != true || !mounted) return;
+    }
+
+    final warningAcknowledged = await showReEncryptWarningDialog(
+      context: context,
+    );
+    if (warningAcknowledged != true || !mounted) return;
+
+    setState(() => _isReEncrypting = true);
+    await ref.read(reEncryptProvider.notifier).reEncryptVault(
+          widget.targetAlgorithm,
+          fileFilter: _selectedIds,
+        );
+    if (mounted) {
+      setState(() => _isReEncrypting = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Re-encryption complete',
+            style: TextStyle(fontFamily: 'ProductSans'),
+          ),
+        ),
+      );
+      ref.invalidate(allFilesProvider);
+    }
+  }
+}

--- a/lib/services/encryption_service.dart
+++ b/lib/services/encryption_service.dart
@@ -75,6 +75,10 @@ class EncryptionService {
     return _cachedMasterKey!;
   }
 
+  Future<Uint8List> getMasterKey({bool isDecoy = false}) async {
+    return isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+  }
+
   /// Get or create decoy key (for decoy mode)
   Future<Uint8List> _ensureDecoyKey() async {
     if (_cachedDecoyKey != null) return _cachedDecoyKey!;
@@ -109,6 +113,18 @@ class EncryptionService {
     return _generateRandomBytes(_ivSize);
   }
 
+  /// Generate a random 32-byte salt for per-file key derivation
+  Uint8List generateFileSalt() {
+    return _generateRandomBytes(32);
+  }
+
+  /// Derive a per-file encryption key from the master key + salt using PBKDF2
+  Uint8List deriveFileKey(Uint8List masterKey, Uint8List salt, int iterations) {
+    final pbkdf2 = PBKDF2KeyDerivator(HMac(SHA256Digest(), 64))
+      ..init(Pbkdf2Parameters(salt, iterations, _keySize));
+    return pbkdf2.process(masterKey);
+  }
+
   /// Derive key from password using PBKDF2
   Uint8List deriveKeyFromPassword(String password, {Uint8List? salt, int iterations = 100000}) {
     salt ??= _generateRandomBytes(16);
@@ -136,6 +152,11 @@ class EncryptionService {
     );
 
     return cipher;
+  }
+
+  Future<Uint8List> _resolveKey({bool isDecoy = false, Uint8List? derivedKey}) async {
+    if (derivedKey != null) return derivedKey;
+    return isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
   }
 
   GCMBlockCipher _getGcmCipher(
@@ -237,6 +258,7 @@ class EncryptionService {
     String sourcePath,
     String destinationPath, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
     Function(int bytesProcessed, int totalBytes)? onProgress,
   }) async {
     try {
@@ -248,7 +270,7 @@ class EncryptionService {
         );
       }
 
-      final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+      final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
       final iv = generateIV();
       final totalBytes = await sourceFile.length();
 
@@ -311,10 +333,11 @@ class EncryptionService {
     Uint8List data,
     String destinationPath, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
     Function(int bytesProcessed, int totalBytes)? onProgress,
   }) async {
     try {
-      final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+      final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
       final iv = generateIV();
       final totalBytes = data.length;
 
@@ -367,9 +390,10 @@ class EncryptionService {
     Uint8List data,
     String destinationPath, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
   }) async {
     try {
-      final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+      final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
       final iv = generateIV();
 
       final gcm = GCMBlockCipher(AESEngine())
@@ -420,6 +444,7 @@ class EncryptionService {
     String destinationPath,
     String ivBase64, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
     Function(int current, int total)? onProgress,
   }) async {
     try {
@@ -449,6 +474,7 @@ class EncryptionService {
           encryptedPath,
           ivBase64,
           isDecoy: isDecoy,
+          derivedKey: derivedKey,
         );
         onProgress?.call(2, 3);
 
@@ -483,6 +509,7 @@ class EncryptionService {
           destinationPath,
           ivBase64,
           isDecoy: isDecoy,
+          derivedKey: derivedKey,
         );
 
         onProgress?.call(3, 3);
@@ -513,6 +540,7 @@ class EncryptionService {
           encryptedData,
           ivBase64,
           isDecoy: isDecoy,
+          customKey: derivedKey,
         );
         onProgress?.call(2, 3);
 
@@ -549,6 +577,7 @@ class EncryptionService {
     String destinationPath,
     String ivBase64, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
     Function(int bytesProcessed, int totalBytes)? onProgress,
   }) async {
     try {
@@ -560,7 +589,7 @@ class EncryptionService {
         );
       }
 
-      final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+      final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
       final iv = base64Decode(ivBase64);
       final encryptedSize = await encryptedFile.length();
 
@@ -713,6 +742,7 @@ class EncryptionService {
     String encryptedPath,
     String ivBase64, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
   }) async {
     try {
       final encryptedFile = File(encryptedPath);
@@ -741,6 +771,7 @@ class EncryptionService {
           encryptedPath,
           ivBase64,
           isDecoy: isDecoy,
+          derivedKey: derivedKey,
         );
       } else if (header.length >= 4 &&
           header[0] == 0x4C &&
@@ -749,8 +780,7 @@ class EncryptionService {
           header[3] == 0x53) {
         // CTR-encrypted streamed file - use streaming decryption
         debugPrint('[Encryption] Detected CTR streamed format');
-        final key =
-            isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+        final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
         final iv = base64Decode(ivBase64);
 
         final ctr = CTRStreamCipher(AESEngine())
@@ -795,6 +825,7 @@ class EncryptionService {
           Uint8List.fromList(encryptedData),
           ivBase64,
           isDecoy: isDecoy,
+          customKey: derivedKey,
         );
       } else {
         // Legacy CBC file without header - decrypt entire file
@@ -818,6 +849,7 @@ class EncryptionService {
           encryptedData,
           ivBase64,
           isDecoy: isDecoy,
+          customKey: derivedKey,
         );
       }
     } catch (e) {
@@ -835,12 +867,14 @@ class EncryptionService {
     String encryptedPath,
     String ivBase64, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
   }) async {
     // Delegate to the format-detecting function
     return decryptStreamedFileToMemory(
       encryptedPath,
       ivBase64,
       isDecoy: isDecoy,
+      derivedKey: derivedKey,
     );
   }
 
@@ -963,6 +997,7 @@ class EncryptionService {
     String sourcePath,
     String destinationPath, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
     Function(int bytesProcessed, int totalBytes)? onProgress,
   }) async {
     try {
@@ -974,7 +1009,7 @@ class EncryptionService {
         );
       }
 
-      final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+      final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
       final iv = generateIV();
       final totalBytes = await sourceFile.length();
 
@@ -1041,6 +1076,7 @@ class EncryptionService {
     String encryptedPath,
     String ivBase64, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
   }) async {
     try {
       final encryptedFile = File(encryptedPath);
@@ -1051,7 +1087,7 @@ class EncryptionService {
         );
       }
 
-      final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+      final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
       final iv = base64Decode(ivBase64);
 
       final raf = await encryptedFile.open();
@@ -1115,6 +1151,7 @@ class EncryptionService {
     String destinationPath, {
     bool isDecoy = false,
     bool useGcm = true,
+    Uint8List? derivedKey,
     Function(int bytesProcessed, int totalBytes)? onProgress,
   }) async {
     try {
@@ -1126,7 +1163,7 @@ class EncryptionService {
         );
       }
 
-      final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+      final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
 
       final job = _pool!.encryptFile(
         sourcePath: sourcePath,
@@ -1167,6 +1204,7 @@ class EncryptionService {
     String destinationPath,
     String ivBase64, {
     bool isDecoy = false,
+    Uint8List? derivedKey,
     Function(int bytesProcessed, int totalBytes)? onProgress,
   }) async {
     try {
@@ -1178,7 +1216,7 @@ class EncryptionService {
         );
       }
 
-      final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+      final key = await _resolveKey(isDecoy: isDecoy, derivedKey: derivedKey);
 
       final job = _pool!.decryptFile(
         encryptedPath: encryptedPath,
@@ -1297,11 +1335,13 @@ class EncryptionService {
     String oldIvBase64, {
     required EncryptionAlgorithm targetAlgorithm,
     bool isDecoy = false,
+    Uint8List? oldDerivedKey,
+    Uint8List? newDerivedKey,
   }) async {
     final format = detectFileFormat(filePath);
     final isLegacyCbc = (format == 0 || format == 3);
 
-    final key = isDecoy ? await _ensureDecoyKey() : await _ensureMasterKey();
+    final key = await _resolveKey(isDecoy: isDecoy, derivedKey: oldDerivedKey);
     final tempDir = await Directory.systemTemp.createTemp('lkr_reencrypt_');
     final tempDecPath = '${tempDir.path}/decrypted';
 
@@ -1309,7 +1349,7 @@ class EncryptionService {
       try { await File('$filePath.tmp').delete(); } catch (_) {}
 
       if (isLegacyCbc) {
-        final decrypted = await decryptFileToMemory(filePath, oldIvBase64, isDecoy: isDecoy);
+        final decrypted = await decryptFileToMemory(filePath, oldIvBase64, isDecoy: isDecoy, derivedKey: oldDerivedKey);
         if (!decrypted.success || decrypted.data == null) {
           throw Exception('Failed to decrypt CBC file for re-encryption: ${decrypted.error}');
         }
@@ -1327,11 +1367,12 @@ class EncryptionService {
         }
       }
 
+      final newKey = await _resolveKey(isDecoy: isDecoy, derivedKey: newDerivedKey);
       final useGcm = targetAlgorithm == EncryptionAlgorithm.aes256Gcm;
       final encJob = _pool!.encryptFile(
         sourcePath: tempDecPath,
         destinationPath: filePath,
-        key: key,
+        key: newKey,
         useGcm: useGcm,
       );
       final encResult = await encJob.future;

--- a/lib/services/file_import_service.dart
+++ b/lib/services/file_import_service.dart
@@ -5,6 +5,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:mime/mime.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:photo_manager/photo_manager.dart';
+import '../models/encryption_algorithm.dart';
 import '../models/vaulted_file.dart';
 import '../models/vault_folder.dart';
 import 'auto_kill_service.dart';
@@ -132,6 +133,7 @@ class FileImportService {
     Function(int current, int total, {int currentSize, int totalSize})?
         onProgress,
     Function(FileProgressInfo)? onFileProgress,
+    Map<String, ({bool encrypt, EncryptionAlgorithm algorithm})>? perFileEncryption,
   }) async {
     if (assets.isEmpty) {
       return ImportResult(
@@ -188,11 +190,14 @@ class FileImportService {
             mimeType = lookupMimeType(filePath) ?? 'application/octet-stream';
           }
 
+          final perFileConfig = perFileEncryption?[filePath];
           filesToVault.add(FileToVault(
             sourcePath: filePath,
             originalName: fileName,
             type: type,
             mimeType: mimeType,
+            encrypt: perFileConfig?.encrypt,
+            encryptionAlgorithm: perFileConfig?.algorithm,
           ));
           validAssets.add(asset);
 
@@ -890,6 +895,7 @@ class FileImportService {
     required List<String> filePaths,
     bool deleteOriginals = true,
     Function(int current, int total)? onProgress,
+    Map<String, ({bool encrypt, EncryptionAlgorithm algorithm})>? perFileEncryption,
   }) async {
     if (filePaths.isEmpty) {
       return ImportResult(
@@ -919,11 +925,14 @@ class FileImportService {
           final mimeType = lookupMimeType(path) ?? 'application/octet-stream';
           final type = getFileTypeFromMime(mimeType);
 
+          final perFileConfig = perFileEncryption?[path];
           filesToVault.add(FileToVault(
             sourcePath: path,
             originalName: fileName,
             type: type,
             mimeType: mimeType,
+            encrypt: perFileConfig?.encrypt,
+            encryptionAlgorithm: perFileConfig?.algorithm,
           ));
 
           pathsToDelete.add(path);
@@ -994,6 +1003,7 @@ class FileImportService {
     bool deleteOriginals = true,
     Function(int current, int total)? onProgress,
     Function(String message)? onStatusUpdate,
+    Map<String, ({bool encrypt, EncryptionAlgorithm algorithm})>? perFileEncryption,
   }) async {
     if (filePaths.isEmpty) {
       return OfficeImportResult(
@@ -1066,11 +1076,14 @@ class FileImportService {
           final fileName = path.split('/').last;
           final mimeType = lookupMimeType(path) ?? 'application/octet-stream';
 
+          final perFileConfig = perFileEncryption?[path];
           filesToVault.add(FileToVault(
             sourcePath: path,
             originalName: fileName,
             type: VaultedFileType.document,
             mimeType: mimeType,
+            encrypt: perFileConfig?.encrypt,
+            encryptionAlgorithm: perFileConfig?.algorithm,
           ));
 
           pathsToDelete.add(path);
@@ -1097,11 +1110,14 @@ class FileImportService {
 
             final mimeType =
                 lookupMimeType(officeFile.path) ?? 'application/octet-stream';
+            final perFileConfig = perFileEncryption?[officeFile.path];
             filesToVault.add(FileToVault(
               sourcePath: officeFile.path,
               originalName: officeFile.fileName,
               type: VaultedFileType.document,
               mimeType: mimeType,
+              encrypt: perFileConfig?.encrypt,
+              encryptionAlgorithm: perFileConfig?.algorithm,
             ));
 
             pathsToDelete.add(officeFile.path);
@@ -1139,11 +1155,14 @@ class FileImportService {
             final tempPdfPath = '${tempDir.path}/$pdfFileName';
             await File(tempPdfPath).writeAsBytes(result.pdfData!);
 
+            final perFileConfig = perFileEncryption?[officeFile.path];
             filesToVault.add(FileToVault(
               sourcePath: tempPdfPath,
               originalName: pdfFileName,
               type: VaultedFileType.document,
               mimeType: 'application/pdf',
+              encrypt: perFileConfig?.encrypt,
+              encryptionAlgorithm: perFileConfig?.algorithm,
             ));
 
             pathsToDelete.add(officeFile.path);
@@ -1159,11 +1178,14 @@ class FileImportService {
             // Fallback to original file
             final mimeType =
                 lookupMimeType(officeFile.path) ?? 'application/octet-stream';
+            final perFileConfig = perFileEncryption?[officeFile.path];
             filesToVault.add(FileToVault(
               sourcePath: officeFile.path,
               originalName: officeFile.fileName,
               type: VaultedFileType.document,
               mimeType: mimeType,
+              encrypt: perFileConfig?.encrypt,
+              encryptionAlgorithm: perFileConfig?.algorithm,
             ));
 
             pathsToDelete.add(officeFile.path);
@@ -1270,6 +1292,7 @@ class FileImportService {
   Future<ImportResult> importAnyFiles({
     bool deleteOriginals = true,
     Function(int current, int total)? onProgress,
+    Map<String, ({bool encrypt, EncryptionAlgorithm algorithm})>? perFileEncryption,
   }) async {
     try {
       // Pick any files
@@ -1300,11 +1323,14 @@ class FileImportService {
         final extension = file.extension ?? '';
         final type = getFileTypeFromExtension(extension);
 
+        final perFileConfig = perFileEncryption?[file.path!];
         filesToVault.add(FileToVault(
           sourcePath: file.path!,
           originalName: file.name,
           type: type,
           mimeType: mimeType,
+          encrypt: perFileConfig?.encrypt,
+          encryptionAlgorithm: perFileConfig?.algorithm,
         ));
 
         // Categorize for deletion

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -483,6 +483,8 @@ class VaultService {
     bool isDecoy = false,
     List<String>? tags,
     List<String>? albumIds,
+    EncryptionAlgorithm? encryptionAlgorithm,
+    int? kdfIterations,
   }) async {
     final prepared = await _prepareVaultAddition(
       sourcePath: sourcePath,
@@ -493,6 +495,8 @@ class VaultService {
       isDecoy: isDecoy,
       tags: tags,
       albumIds: albumIds,
+      encryptionAlgorithm: encryptionAlgorithm,
+      kdfIterations: kdfIterations,
     );
 
     if (prepared == null) {
@@ -521,7 +525,6 @@ class VaultService {
     final results = <VaultedFile>[];
 
     int completed = 0;
-    final shouldEncrypt = encrypt || _cachedSettings?.encryptionEnabled == true;
 
     for (int start = 0;
         start < files.length;
@@ -541,15 +544,17 @@ class VaultService {
       final preparedChunk = await Future.wait(
         chunk.map((entry) async {
           final fileSize = await _getFileSizeIfExists(entry.file.sourcePath);
+          final fileEncrypt = entry.file.encrypt ?? encrypt;
+          final fileShouldEncrypt = fileEncrypt || _cachedSettings?.encryptionEnabled == true;
 
           onFileProgress?.call(FileProgressInfo(
             current: entry.index + 1,
             total: files.length,
             fileName: entry.file.originalName,
             fileSize: fileSize,
-            status: shouldEncrypt ? 'Encrypting 0%...' : 'Processing...',
-            isEncrypting: shouldEncrypt,
-            totalBytes: shouldEncrypt ? fileSize : 0,
+            status: fileShouldEncrypt ? 'Encrypting 0%...' : 'Processing...',
+            isEncrypting: fileShouldEncrypt,
+            totalBytes: fileShouldEncrypt ? fileSize : 0,
           ));
 
           final prepared = await _prepareVaultAddition(
@@ -557,9 +562,11 @@ class VaultService {
             originalName: entry.file.originalName,
             type: entry.file.type,
             mimeType: entry.file.mimeType,
-            encrypt: encrypt,
+            encrypt: fileEncrypt,
             isDecoy: isDecoy,
-            onEncryptionProgress: shouldEncrypt
+            encryptionAlgorithm: entry.file.encryptionAlgorithm,
+            kdfIterations: entry.file.kdfIterations,
+            onEncryptionProgress: fileShouldEncrypt
                 ? (processed, total) {
                     final pct = total > 0
                         ? (processed / total * 100).toStringAsFixed(0)
@@ -623,6 +630,8 @@ class VaultService {
     Function(int processed, int total)? onEncryptionProgress,
     List<String>? tags,
     List<String>? albumIds,
+    EncryptionAlgorithm? encryptionAlgorithm,
+    int? kdfIterations,
   }) async {
     String? sourcePathToUse;
     String? vaultPath;
@@ -669,23 +678,44 @@ class VaultService {
           encrypt || _cachedSettings?.encryptionEnabled == true;
       String? encryptionIv;
       int fileSize;
+      EncryptionAlgorithm? usedAlgorithm;
+      String? usedSalt;
+      int? usedKdfIterations;
+
+      Uint8List? derivedKey;
+      if (shouldEncrypt) {
+        final algorithm = encryptionAlgorithm ??
+            _cachedSettings?.encryptionAlgorithm ??
+            EncryptionAlgorithm.aes256Ctr;
+        final iterations = kdfIterations ??
+            _cachedSettings?.kdfIterations ??
+            100000;
+        final salt = _encryptionService.generateFileSalt();
+        final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy);
+        derivedKey = _encryptionService.deriveFileKey(masterKey, salt, iterations);
+        usedAlgorithm = algorithm;
+        usedSalt = base64Encode(salt);
+        usedKdfIterations = iterations;
+      }
 
       if (compressedImageBytes != null) {
         fileSize = compressedImageBytes.length;
 
         if (shouldEncrypt) {
           onEncryptionProgress?.call(0, fileSize);
-          final useGcm = _cachedSettings?.encryptionAlgorithm == EncryptionAlgorithm.aes256Gcm;
+          final useGcm = usedAlgorithm == EncryptionAlgorithm.aes256Gcm;
           final encResult = useGcm
               ? await _encryptionService.encryptBytesStreamedGcm(
                   compressedImageBytes,
                   vaultPath,
                   isDecoy: isDecoy,
+                  derivedKey: derivedKey,
                 )
               : await _encryptionService.encryptBytesStreamed(
                   compressedImageBytes,
                   vaultPath,
                   isDecoy: isDecoy,
+                  derivedKey: derivedKey,
                   onProgress: (processed, total) {
                     onEncryptionProgress?.call(processed, total);
                   },
@@ -714,7 +744,7 @@ class VaultService {
 
         if (shouldEncrypt) {
           onEncryptionProgress?.call(0, fileSize);
-          final useGcm = _cachedSettings?.encryptionAlgorithm == EncryptionAlgorithm.aes256Gcm;
+          final useGcm = usedAlgorithm == EncryptionAlgorithm.aes256Gcm;
           final useIsolateEncryption =
               fileSize >= _largeFileIsolateThresholdBytes;
           final encResult = useIsolateEncryption
@@ -723,6 +753,7 @@ class VaultService {
                   vaultPath,
                   isDecoy: isDecoy,
                   useGcm: useGcm,
+                  derivedKey: derivedKey,
                   onProgress: (processed, total) {
                     onEncryptionProgress?.call(processed, total);
                   },
@@ -732,6 +763,7 @@ class VaultService {
                       sourcePathToUse,
                       vaultPath,
                       isDecoy: isDecoy,
+                      derivedKey: derivedKey,
                       onProgress: (processed, total) {
                         onEncryptionProgress?.call(processed, total);
                       },
@@ -740,6 +772,7 @@ class VaultService {
                       sourcePathToUse,
                       vaultPath,
                       isDecoy: isDecoy,
+                      derivedKey: derivedKey,
                       onProgress: (processed, total) {
                         onEncryptionProgress?.call(processed, total);
                       },
@@ -784,6 +817,9 @@ class VaultService {
           isFavorite: normalizedAlbumIds.contains('favorites'),
           isEncrypted: shouldEncrypt,
           encryptionIv: encryptionIv,
+          encryptionAlgorithm: usedAlgorithm,
+          keyDerivationSalt: usedSalt,
+          kdfIterations: usedKdfIterations,
           isDecoy: isDecoy,
           tags: normalizedTags,
           albumIds: normalizedAlbumIds,
@@ -847,11 +883,42 @@ class VaultService {
       return;
     }
 
+    final originalFile = File(vaultedFile.originalPath!);
+    bool deleted = false;
+
     try {
-      await File(vaultedFile.originalPath!).delete();
+      if (await originalFile.exists()) {
+        await originalFile.delete();
+        deleted = true;
+      } else {
+        deleted = true; // already gone, nothing to do
+      }
     } catch (e) {
       debugPrint('Could not delete original file: $e');
     }
+
+    // Verify the original was actually removed from storage
+    if (!deleted) {
+      try {
+        if (await originalFile.exists()) {
+          debugPrint(
+              'Original file still exists, attempting secure delete: ${vaultedFile.originalPath}');
+          if (_cachedSettings?.secureDelete == true) {
+            await _encryptionService.secureDelete(vaultedFile.originalPath!);
+          } else {
+            await originalFile.delete();
+          }
+        }
+      } catch (_) {}
+    }
+
+    // Final check — the file must be gone for the hide to be effective
+    try {
+      if (await originalFile.exists()) {
+        debugPrint(
+            'WARNING: Could not delete original file from device storage: ${vaultedFile.originalPath}');
+      }
+    } catch (_) {}
   }
 
   /// Update a file's metadata
@@ -1066,6 +1133,13 @@ class VaultService {
     }
   }
 
+  Future<Uint8List?> _deriveKeyForFile(VaultedFile file, {bool isDecoy = false}) async {
+    if (file.keyDerivationSalt == null || file.kdfIterations == null) return null;
+    final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
+    final salt = base64Decode(file.keyDerivationSalt!);
+    return _encryptionService.deriveFileKey(masterKey, salt, file.kdfIterations!);
+  }
+
   /// Get the actual file from vault (decrypts if needed)
   Future<File?> getVaultedFile(
     String fileId, {
@@ -1086,6 +1160,7 @@ class VaultService {
 
       final format = _encryptionService.detectFileFormat(vaultedFile.vaultPath);
       final isLegacyCbc = (format == 0 || format == 3);
+      final derivedKey = await _deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
 
       FileDecryptionResult result;
       if (isLegacyCbc) {
@@ -1094,6 +1169,7 @@ class VaultService {
           tempPath,
           vaultedFile.encryptionIv!,
           isDecoy: isDecoy,
+          derivedKey: derivedKey,
           onProgress: onProgress == null
               ? null
               : (current, total) {
@@ -1109,6 +1185,7 @@ class VaultService {
           tempPath,
           vaultedFile.encryptionIv!,
           isDecoy: isDecoy,
+          derivedKey: derivedKey,
           onProgress: onProgress,
         );
       }
@@ -1131,12 +1208,12 @@ class VaultService {
     if (vaultedFile == null) return null;
 
     if (vaultedFile.isEncrypted && vaultedFile.encryptionIv != null) {
-      // Use decryptStreamedFileToMemory which auto-detects format
-      // (legacy CBC vs new CTR streamed encryption)
+      final derivedKey = await _deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
       final result = await _encryptionService.decryptStreamedFileToMemory(
         vaultedFile.vaultPath,
         vaultedFile.encryptionIv!,
         isDecoy: isDecoy,
+        derivedKey: derivedKey,
       );
 
       if (result.success && result.data != null) {
@@ -2080,6 +2157,7 @@ class VaultService {
       if (vaultedFile.isEncrypted && vaultedFile.encryptionIv != null) {
         final format = _encryptionService.detectFileFormat(vaultedFile.vaultPath);
         final isLegacyCbc = (format == 0 || format == 3);
+        final derivedKey = await _deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
 
         FileDecryptionResult result;
         if (isLegacyCbc) {
@@ -2087,6 +2165,7 @@ class VaultService {
             vaultedFile.vaultPath,
             destinationPath,
             vaultedFile.encryptionIv!,
+            derivedKey: derivedKey,
             onProgress: onProgress == null
                 ? null
                 : (current, total) {
@@ -2102,6 +2181,7 @@ class VaultService {
             destinationPath,
             vaultedFile.encryptionIv!,
             isDecoy: isDecoy,
+            derivedKey: derivedKey,
             onProgress: onProgress == null
                 ? null
                 : (bytesProcessed, totalBytes) {
@@ -2134,12 +2214,17 @@ class VaultService {
     EncryptionAlgorithm targetAlgorithm, {
     bool isDecoy = false,
     Function(int current, int total)? onProgress,
+    Set<String>? fileFilter,
   }) async {
     try {
       final files = isDecoy
           ? (await getAllFiles(isDecoy: true))
           : (await getAllFiles(isDecoy: false));
       var encryptedFiles = files.where((f) => f.isEncrypted).toList();
+
+      if (fileFilter != null && fileFilter.isNotEmpty) {
+        encryptedFiles = encryptedFiles.where((f) => fileFilter.contains(f.id)).toList();
+      }
 
       if (encryptedFiles.isEmpty) return 0;
 
@@ -2194,11 +2279,19 @@ class VaultService {
           }),
         );
 
+        final oldDerivedKey = await _deriveKeyForFile(file, isDecoy: isDecoy);
+        final newSalt = _encryptionService.generateFileSalt();
+        final newIterations = _cachedSettings?.kdfIterations ?? 100000;
+        final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
+        final newDerivedKey = _encryptionService.deriveFileKey(masterKey, newSalt, newIterations);
+
         final newIv = await _encryptionService.reEncryptFile(
           file.vaultPath,
           file.encryptionIv ?? '',
           targetAlgorithm: targetAlgorithm,
           isDecoy: isDecoy,
+          oldDerivedKey: oldDerivedKey,
+          newDerivedKey: newDerivedKey,
         );
 
         journalIvs[file.vaultPath] = newIv;
@@ -2211,7 +2304,12 @@ class VaultService {
 
         final fileIndex = files.indexWhere((f) => f.id == file.id);
         if (fileIndex >= 0) {
-          files[fileIndex] = file.copyWith(encryptionIv: newIv);
+          files[fileIndex] = file.copyWith(
+            encryptionIv: newIv,
+            encryptionAlgorithm: targetAlgorithm,
+            keyDerivationSalt: base64Encode(newSalt),
+            kdfIterations: newIterations,
+          );
           reEncryptedCount++;
         }
       }
@@ -2298,12 +2396,18 @@ class FileToVault {
   final String originalName;
   final VaultedFileType type;
   final String mimeType;
+  final bool? encrypt;
+  final EncryptionAlgorithm? encryptionAlgorithm;
+  final int? kdfIterations;
 
   const FileToVault({
     required this.sourcePath,
     required this.originalName,
     required this.type,
     required this.mimeType,
+    this.encrypt,
+    this.encryptionAlgorithm,
+    this.kdfIterations,
   });
 }
 

--- a/lib/widgets/per_file_encryption_sheet.dart
+++ b/lib/widgets/per_file_encryption_sheet.dart
@@ -1,0 +1,379 @@
+import 'package:flutter/material.dart';
+import '../models/encryption_algorithm.dart';
+import '../themes/app_colors.dart';
+
+class PerFileEncryptionSettings {
+  final String fileName;
+  final String filePath;
+  final int fileSize;
+  bool encrypt;
+  EncryptionAlgorithm algorithm;
+
+  PerFileEncryptionSettings({
+    required this.fileName,
+    required this.filePath,
+    required this.fileSize,
+    this.encrypt = true,
+    this.algorithm = EncryptionAlgorithm.aes256Ctr,
+  });
+}
+
+class PerFileEncryptionSheet extends StatefulWidget {
+  final List<PerFileEncryptionSettings> files;
+  final bool encryptionEnabled;
+  final EncryptionAlgorithm defaultAlgorithm;
+
+  const PerFileEncryptionSheet({
+    super.key,
+    required this.files,
+    required this.encryptionEnabled,
+    required this.defaultAlgorithm,
+  });
+
+  static Future<List<PerFileEncryptionSettings>?> show(
+    BuildContext context, {
+    required List<PerFileEncryptionSettings> files,
+    required bool encryptionEnabled,
+    required EncryptionAlgorithm defaultAlgorithm,
+  }) {
+    return showModalBottomSheet<List<PerFileEncryptionSettings>>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.7,
+        minChildSize: 0.5,
+        maxChildSize: 0.95,
+        builder: (context, scrollController) => PerFileEncryptionSheet(
+          files: files,
+          encryptionEnabled: encryptionEnabled,
+          defaultAlgorithm: defaultAlgorithm,
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<PerFileEncryptionSheet> createState() => _PerFileEncryptionSheetState();
+}
+
+class _PerFileEncryptionSheetState extends State<PerFileEncryptionSheet> {
+  late List<PerFileEncryptionSettings> _files;
+  late bool _globalEncrypt;
+  late EncryptionAlgorithm _globalAlgorithm;
+
+  @override
+  void initState() {
+    super.initState();
+    _files = widget.files;
+    _globalEncrypt = widget.encryptionEnabled;
+    _globalAlgorithm = widget.defaultAlgorithm;
+    for (final file in _files) {
+      file.encrypt = _globalEncrypt;
+      file.algorithm = _globalAlgorithm;
+    }
+  }
+
+  String _formatSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: context.surfaceColor,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      child: Column(
+        children: [
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: context.dividerColor,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Encryption Settings',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 20,
+                      fontWeight: FontWeight.w600,
+                      color: context.textPrimary,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: Text(
+                    'Cancel',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      color: context.textSecondary,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: () => Navigator.pop(context, _files),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: context.accentColor,
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text(
+                    'Confirm',
+                    style: TextStyle(fontFamily: 'ProductSans'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildGlobalToggle(),
+                const SizedBox(height: 12),
+                if (_globalEncrypt) _buildGlobalAlgorithm(),
+                const SizedBox(height: 8),
+                Text(
+                  '${_files.length} file(s) selected',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 24),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              itemCount: _files.length,
+              itemBuilder: (context, index) => _buildFileItem(index),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGlobalToggle() {
+    return Row(
+      children: [
+        Icon(Icons.lock_outline, size: 20, color: context.textSecondary),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            'Encrypt all files',
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              fontSize: 16,
+              color: context.textPrimary,
+            ),
+          ),
+        ),
+        Switch(
+          value: _globalEncrypt,
+          onChanged: (value) {
+            setState(() {
+              _globalEncrypt = value;
+              for (final file in _files) {
+                file.encrypt = value;
+              }
+            });
+          },
+          activeTrackColor: context.accentColor,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildGlobalAlgorithm() {
+    return Row(
+      children: [
+        const SizedBox(width: 32),
+        Expanded(
+          child: Text(
+            'Algorithm',
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              fontSize: 14,
+              color: context.textSecondary,
+            ),
+          ),
+        ),
+        DropdownButton<EncryptionAlgorithm>(
+          value: _globalAlgorithm,
+          underline: const SizedBox(),
+          items: EncryptionAlgorithm.values.map((algo) {
+            return DropdownMenuItem(
+              value: algo,
+              child: Text(
+                algo == EncryptionAlgorithm.aes256Ctr ? 'AES-CTR' : 'AES-GCM',
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 14,
+                  color: context.textPrimary,
+                ),
+              ),
+            );
+          }).toList(),
+          onChanged: (value) {
+            if (value != null) {
+              setState(() {
+                _globalAlgorithm = value;
+                for (final file in _files) {
+                  file.algorithm = value;
+                }
+              });
+            }
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFileItem(int index) {
+    final file = _files[index];
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: context.surfaceColor,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: context.dividerColor),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        file.fileName,
+                        style: TextStyle(
+                          fontFamily: 'ProductSans',
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                          color: context.textPrimary,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 2),
+                      Row(
+                        children: [
+                          if (file.fileSize > 50 * 1024 * 1024) ...[
+                            Icon(Icons.warning_amber, size: 14, color: Colors.orange),
+                            const SizedBox(width: 4),
+                          ],
+                          Text(
+                            _formatSize(file.fileSize),
+                            style: TextStyle(
+                              fontFamily: 'ProductSans',
+                              fontSize: 12,
+                              color: context.textTertiary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                Switch(
+                  value: file.encrypt,
+                  onChanged: _globalEncrypt
+                      ? null
+                      : (value) {
+                          setState(() {
+                            file.encrypt = value;
+                          });
+                        },
+                  activeTrackColor: context.accentColor,
+                ),
+              ],
+            ),
+            if (file.encrypt)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Row(
+                  children: [
+                    Text(
+                      'Algorithm: ',
+                      style: TextStyle(
+                        fontFamily: 'ProductSans',
+                        fontSize: 12,
+                        color: context.textSecondary,
+                      ),
+                    ),
+                    ChoiceChip(
+                      label: const Text(
+                        'CTR',
+                        style: TextStyle(fontFamily: 'ProductSans', fontSize: 11),
+                      ),
+                      selected: file.algorithm == EncryptionAlgorithm.aes256Ctr,
+                      onSelected: (selected) {
+                        if (selected) {
+                          setState(() {
+                            file.algorithm = EncryptionAlgorithm.aes256Ctr;
+                          });
+                        }
+                      },
+                      selectedColor: context.accentColor.withValues(alpha: 0.2),
+                      labelStyle: TextStyle(
+                        color: file.algorithm == EncryptionAlgorithm.aes256Ctr
+                            ? context.accentColor
+                            : context.textSecondary,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    ChoiceChip(
+                      label: const Text(
+                        'GCM',
+                        style: TextStyle(fontFamily: 'ProductSans', fontSize: 11),
+                      ),
+                      selected: file.algorithm == EncryptionAlgorithm.aes256Gcm,
+                      onSelected: (selected) {
+                        if (selected) {
+                          setState(() {
+                            file.algorithm = EncryptionAlgorithm.aes256Gcm;
+                          });
+                        }
+                      },
+                      selectedColor: context.accentColor.withValues(alpha: 0.2),
+                      labelStyle: TextStyle(
+                        color: file.algorithm == EncryptionAlgorithm.aes256Gcm
+                            ? context.accentColor
+                            : context.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Summary

Adds per-file encryption configuration support across all import flows, a re-encrypt file picker screen for selective re-encryption, and per-file encryption settings bottom sheet.

# Changes

## Per-File Encryption

- Add per-file key derivation support with `derivedKey` parameter
- Add per-file encryption configuration to import methods
- Add per-file encryption settings prompt for all import flows
- Add per-file encryption configuration support

## Re-Encryption

- Add optional `fileFilter` parameter to `reEncryptVault`
- Replace re-encrypt dialog with file picker screen
- Add re-encrypt file picker screen with selection and progress UI
- Add per-file encryption settings bottom sheet