### PR TITLE
Migrate encryption to isolate pool, switch image/PDF cache from bytes to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ flutter build apk --release --obfuscate --split-debug-info=./build/symbols
 #### Building from Source
 1. Clone the repository:
    ```bash
-   git clone https://github.com/heimin22/Locker.git
+   git clone https://github.com/moss-apps/Latch.git
    cd Locker
    ```
 2. Install dependencies:
@@ -290,7 +290,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 Latch is purely open-source and free. There are no premium features, ads, or paid components.
 
 ## Contributors
-- [@heimin22](https://github.com/heimin22) (Project creator)
+- [@ultraelectronica](https://github.com/ultraelectronica) (Project creator)
 
 ## Contributing
 Contributions are welcome. Please ensure all changes pass linting and testing before submitting pull requests.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Locker/
 │   └── ...
 ├── docs/                         # Architecture documentation
 │   ├── architecture_media.md     # Media encryption/compression design
-│   ├── improvement_roadmap.md    # Audit-driven backlog
+│   ├── unlock_autofill.md        # Unlock credential autofill design
 │   └── flick_integration.md      # Flick Player integration guide
 └── pubspec.yaml                  # Flutter dependencies
 ```
@@ -281,6 +281,7 @@ All sensitive data (PIN, passwords, encryption keys) is stored via `flutter_secu
 ## Documentation
 Additional documentation available:
 - [Architecture Diagram](docs/architecture_media.md) - Detailed system architecture design covering compression, encryption, and file operations
+- [Unlock Autofill](docs/unlock_autofill.md) - How the opt-in unlock credential autofill delegation works and its security model
 - [Flick Integration Guide](docs/flick_integration.md) - Contract and implementation notes for making Flick a first-class Latch playback companion
 
 ## License

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -37,13 +37,17 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
   bool _isConverting = false;
   String? _error;
   Uint8List? _decryptedData;
-  Uint8List? _plainFileData;
-  Uint8List? _convertedPdfData;
   String? _textContent;
   PdfViewerController? _pdfController;
   int _currentPage = 1;
   int _totalPages = 1;
   bool _isOfficeDocument = false;
+  // ponytail: pdfrx parses PdfViewer.data on the main isolate, which ANRs on
+  // large PDFs. We resolve a file path and hand it to PdfViewer.file so pdfrx
+  // does its own background load. _convertedPdfPath is a temp file we own and
+  // must delete on dispose.
+  String? _pdfPath;
+  String? _convertedPdfPath;
 
   @override
   void initState() {
@@ -66,8 +70,13 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
   void dispose() {
     // Clear decrypted data from memory
     _decryptedData = null;
-    _plainFileData = null;
-    _convertedPdfData = null;
+    // Clean up the converted-PDF temp file we wrote.
+    final convPath = _convertedPdfPath;
+    if (convPath != null) {
+      try {
+        File(convPath).deleteSync();
+      } catch (_) {}
+    }
     // Clean up temp decrypted files to prevent disk leaks
     _cleanupTempFiles();
     super.dispose();
@@ -154,8 +163,17 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
       if (!mounted) return;
 
       if (result.success && result.pdfData != null) {
+        // Write the converted PDF to a temp file so pdfrx can stream it
+        // instead of parsing the bytes on the main isolate.
+        final tempDir = await Directory.systemTemp.createTemp('lkr_conv');
+        final tempPath = '${tempDir.path}/${widget.file.originalName}.pdf';
+        await File(tempPath).writeAsBytes(result.pdfData!);
+        if (!mounted) {
+          await tempDir.delete(recursive: true);
+          return;
+        }
         setState(() {
-          _convertedPdfData = result.pdfData;
+          _convertedPdfPath = tempPath;
           _isLoading = false;
           _isConverting = false;
         });
@@ -189,37 +207,53 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
     });
 
     try {
-      if (widget.decryptedFile != null) {
-        final data = await widget.decryptedFile!.readAsBytes();
-        if (widget.file.isEncrypted && widget.file.encryptionIv != null) {
-          _decryptedData = data;
+      if (_isPdf) {
+        // PDFs: resolve the file path only. Reading bytes into a Uint8List
+        // forced PdfViewer.data to parse on the main isolate (ANR on large
+        // PDFs). PdfViewer.file lets pdfrx load in the background.
+        if (widget.decryptedFile != null) {
+          _pdfPath = widget.decryptedFile!.path;
+        } else if (widget.file.isEncrypted &&
+            widget.file.encryptionIv != null) {
+          final decryptedFile = await ref
+              .read(vaultServiceProvider)
+              .getVaultedFile(widget.file.id);
+          if (decryptedFile == null || !await decryptedFile.exists()) {
+            setState(() {
+              _error = 'Failed to decrypt document';
+              _isLoading = false;
+            });
+            return;
+          }
+          _pdfPath = decryptedFile.path;
         } else {
-          _plainFileData = data;
+          _pdfPath = widget.file.vaultPath;
         }
-      } else if (widget.file.isEncrypted && widget.file.encryptionIv != null) {
-        // Decrypt the file outside the main thread when possible.
-        final decryptedFile =
-            await ref.read(vaultServiceProvider).getVaultedFile(widget.file.id);
-        final data = decryptedFile != null
-            ? await decryptedFile.readAsBytes()
-            : await ref
-                .read(vaultServiceProvider)
-                .getDecryptedFileData(widget.file.id);
-        if (data == null) {
-          setState(() {
-            _error = 'Failed to decrypt document';
-            _isLoading = false;
-          });
-          return;
+      } else if (_isTextFile) {
+        Uint8List? bytes;
+        if (widget.decryptedFile != null) {
+          bytes = await widget.decryptedFile!.readAsBytes();
+        } else if (widget.file.isEncrypted &&
+            widget.file.encryptionIv != null) {
+          final decryptedFile = await ref
+              .read(vaultServiceProvider)
+              .getVaultedFile(widget.file.id);
+          bytes = decryptedFile != null
+              ? await decryptedFile.readAsBytes()
+              : await ref
+                  .read(vaultServiceProvider)
+                  .getDecryptedFileData(widget.file.id);
+          if (bytes == null) {
+            setState(() {
+              _error = 'Failed to decrypt document';
+              _isLoading = false;
+            });
+            return;
+          }
+        } else {
+          bytes = await File(widget.file.vaultPath).readAsBytes();
         }
-        _decryptedData = data;
-      } else if (_isPdf || _isTextFile) {
-        // Pre-load PDF/text bytes so the viewer does not block the UI thread.
-        _plainFileData = await File(widget.file.vaultPath).readAsBytes();
-      }
-
-      // Load text content for text files
-      if (_isTextFile) {
+        _decryptedData = bytes;
         await _loadTextContent();
       }
 
@@ -247,11 +281,11 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
         widget.file.mimeType.startsWith('text/');
   }
 
-  bool get _isConvertedPdf => _convertedPdfData != null;
+  bool get _isConvertedPdf => _convertedPdfPath != null;
 
   Future<void> _loadTextContent() async {
     try {
-      final bytes = _decryptedData ?? _plainFileData;
+      final bytes = _decryptedData;
       if (bytes != null) {
         _textContent = String.fromCharCodes(bytes);
       } else {
@@ -571,7 +605,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
   }
 
   Widget _buildConvertedPdfViewer() {
-    if (_convertedPdfData == null) {
+    if (_convertedPdfPath == null) {
       return Center(
         child: Text(
           'No PDF data available',
@@ -607,9 +641,8 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
         ),
         // PDF viewer
         Expanded(
-          child: PdfViewer.data(
-            _convertedPdfData!,
-            sourceName: '${widget.file.originalName}.pdf',
+          child: PdfViewer.file(
+            _convertedPdfPath!,
             controller: _pdfController,
             params: PdfViewerParams(
               pageDropShadow: BoxShadow(
@@ -635,8 +668,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
   }
 
   Widget _buildPdfViewer() {
-    final pdfData = _decryptedData ?? _plainFileData;
-    if (pdfData == null) {
+    if (_pdfPath == null) {
       return Center(
         child: Text(
           'No PDF data available',
@@ -648,9 +680,8 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
       );
     }
 
-    return PdfViewer.data(
-      pdfData,
-      sourceName: widget.file.originalName,
+    return PdfViewer.file(
+      _pdfPath!,
       controller: _pdfController,
       params: PdfViewerParams(
         pageDropShadow: BoxShadow(

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -1828,8 +1828,8 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen>
           child: Container(
             decoration: BoxDecoration(
               color: context.isDarkMode
-                  ? Colors.black.withValues(alpha: 0.7)
-                  : Colors.white.withValues(alpha: 0.7),
+                  ? Colors.black
+                  : Colors.white,
               border: Border(
                 right: BorderSide(
                   color: context.isDarkMode

--- a/lib/screens/media_viewer_screen.dart
+++ b/lib/screens/media_viewer_screen.dart
@@ -59,8 +59,12 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
   // Cancel token for in-flight video loads
   Completer<void>? _videoLoadCancel;
 
-  // For encrypted files
-  final Map<String, Uint8List?> _decryptedCache = {};
+  // ponytail: cache the decrypted File path per file id. Reading bytes into
+  // Uint8List and using Image.memory forced the whole file through the Dart
+  // heap and triggered main-isolate decode stalls on large images. Letting
+  // Image.file stream from disk keeps the Dart heap small and decoding on
+  // Flutter's background rasterizer.
+  final Map<String, File> _decryptedFileCache = {};
 
   // Debounce timer for video player updates (reduces setState calls)
   Timer? _videoUpdateTimer;
@@ -88,7 +92,7 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
     _videoController = null;
     _pageController.dispose();
     // Clear decrypted cache to free memory immediately
-    _decryptedCache.clear();
+    _decryptedFileCache.clear();
     // Clean up temp decrypted files in background
     _cleanupTempFiles();
     // Restore system UI
@@ -115,20 +119,19 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
       return;
     }
 
-    // Pre-load decrypted data for encrypted images only. Decrypt to a temp
-    // file in the crypto isolate pool (when possible) and then read the bytes.
+    // Resolve the decrypted File path for encrypted images. We keep the File
+    // (not its bytes) so Image.file can stream the decode off the main isolate.
     if (file.isEncrypted &&
         file.isImage &&
-        !_decryptedCache.containsKey(file.id)) {
+        !_decryptedFileCache.containsKey(file.id)) {
       final decryptedFile = file.id == widget.initialFile.id
           ? widget.initialDecryptedFile
           : await ref.read(vaultServiceProvider).getVaultedFile(file.id);
 
       if (decryptedFile != null && await decryptedFile.exists()) {
-        final data = await decryptedFile.readAsBytes();
         if (mounted) {
           setState(() {
-            _decryptedCache[file.id] = data;
+            _decryptedFileCache[file.id] = decryptedFile;
           });
         }
       }
@@ -865,16 +868,16 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
         final file = _files[index];
 
         if (file.isEncrypted) {
-          final data = _decryptedCache[file.id];
-          if (data != null) {
+          final decryptedFile = _decryptedFileCache[file.id];
+          if (decryptedFile != null) {
             // Use customChild for encrypted images to handle decode errors
             return PhotoViewGalleryPageOptions.customChild(
               child: PhotoView.customChild(
                 minScale: PhotoViewComputedScale.contained,
                 maxScale: PhotoViewComputedScale.covered * 3,
                 heroAttributes: PhotoViewHeroAttributes(tag: file.id),
-                child: Image.memory(
-                  data,
+                child: Image.file(
+                  decryptedFile,
                   fit: BoxFit.contain,
                   errorBuilder: (context, error, stackTrace) {
                     debugPrint('Error decoding encrypted image: $error');

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -58,7 +58,6 @@ class VaultService {
   VaultService._();
   static final VaultService instance = VaultService._();
 
-  static const int _largeFileIsolateThresholdBytes = 2 * 1024 * 1024;
   static const int _maxConcurrentBatchAdds = 3;
 
   static const _storage = FlutterSecureStorage(
@@ -699,7 +698,7 @@ class VaultService {
             100000;
         final salt = _encryptionService.generateFileSalt();
         final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy);
-        derivedKey = _encryptionService.deriveFileKey(masterKey, salt, iterations);
+        derivedKey = await _encryptionService.deriveFileKeyAsync(masterKey, salt, iterations);
         usedAlgorithm = algorithm;
         usedSalt = base64Encode(salt);
         usedKdfIterations = iterations;
@@ -711,32 +710,39 @@ class VaultService {
         if (shouldEncrypt) {
           onEncryptionProgress?.call(0, fileSize);
           final useGcm = usedAlgorithm == EncryptionAlgorithm.aes256Gcm;
-          final encResult = useGcm
-              ? await _encryptionService.encryptBytesStreamedGcm(
-                  compressedImageBytes,
-                  vaultPath,
-                  isDecoy: isDecoy,
-                  derivedKey: derivedKey,
-                )
-              : await _encryptionService.encryptBytesStreamed(
-                  compressedImageBytes,
-                  vaultPath,
-                  isDecoy: isDecoy,
-                  derivedKey: derivedKey,
-                  onProgress: (processed, total) {
-                    onEncryptionProgress?.call(processed, total);
-                  },
-                );
-          onEncryptionProgress?.call(fileSize, fileSize);
 
-          if (!encResult.success) {
-            debugPrint('Encryption failed: ${encResult.error}');
-            await _deleteFileIfExists(vaultPath);
-            return null;
+          // ponytail: write to temp file so we can use the isolate pool.
+          // In-memory bytes path runs GCM on the main isolate, which crashes
+          // under batch concurrency. Pool needs a path; cheap write pays for itself.
+          final tempDir = await getTemporaryDirectory();
+          final tempPath =
+              '${tempDir.path}/lkr_enc_${DateTime.now().microsecondsSinceEpoch}';
+          await File(tempPath).writeAsBytes(compressedImageBytes);
+
+          try {
+            final encResult = await _encryptionService.encryptFileInIsolate(
+              tempPath,
+              vaultPath,
+              isDecoy: isDecoy,
+              useGcm: useGcm,
+              derivedKey: derivedKey,
+              onProgress: (processed, total) {
+                onEncryptionProgress?.call(processed, total);
+              },
+            );
+            onEncryptionProgress?.call(fileSize, fileSize);
+
+            if (!encResult.success) {
+              debugPrint('Encryption failed: ${encResult.error}');
+              await _deleteFileIfExists(vaultPath);
+              return null;
+            }
+
+            encryptionIv = encResult.iv;
+            fileSize = encResult.originalSize ?? fileSize;
+          } finally {
+            await _deleteFileIfExists(tempPath);
           }
-
-          encryptionIv = encResult.iv;
-          fileSize = encResult.originalSize ?? fileSize;
         } else {
           await File(vaultPath).writeAsBytes(compressedImageBytes);
         }
@@ -752,38 +758,19 @@ class VaultService {
         if (shouldEncrypt) {
           onEncryptionProgress?.call(0, fileSize);
           final useGcm = usedAlgorithm == EncryptionAlgorithm.aes256Gcm;
-          final useIsolateEncryption =
-              fileSize >= _largeFileIsolateThresholdBytes;
-          final encResult = useIsolateEncryption
-              ? await _encryptionService.encryptFileInIsolate(
-                  sourcePathToUse,
-                  vaultPath,
-                  isDecoy: isDecoy,
-                  useGcm: useGcm,
-                  derivedKey: derivedKey,
-                  onProgress: (processed, total) {
-                    onEncryptionProgress?.call(processed, total);
-                  },
-                )
-              : useGcm
-                  ? await _encryptionService.encryptFileStreamedGcm(
-                      sourcePathToUse,
-                      vaultPath,
-                      isDecoy: isDecoy,
-                      derivedKey: derivedKey,
-                      onProgress: (processed, total) {
-                        onEncryptionProgress?.call(processed, total);
-                      },
-                    )
-                  : await _encryptionService.encryptFileStreamed(
-                      sourcePathToUse,
-                      vaultPath,
-                      isDecoy: isDecoy,
-                      derivedKey: derivedKey,
-                      onProgress: (processed, total) {
-                        onEncryptionProgress?.call(processed, total);
-                      },
-                    );
+          // ponytail: always isolate. The <2MB threshold used to keep small
+          // files on the main isolate; with batch concurrency that still froze
+          // UI on import. Pool dispatch is cheap, no reason to special-case.
+          final encResult = await _encryptionService.encryptFileInIsolate(
+            sourcePathToUse,
+            vaultPath,
+            isDecoy: isDecoy,
+            useGcm: useGcm,
+            derivedKey: derivedKey,
+            onProgress: (processed, total) {
+              onEncryptionProgress?.call(processed, total);
+            },
+          );
           onEncryptionProgress?.call(fileSize, fileSize);
 
           if (!encResult.success) {
@@ -1144,7 +1131,9 @@ class VaultService {
     if (file.keyDerivationSalt == null || file.kdfIterations == null) return null;
     final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
     final salt = base64Decode(file.keyDerivationSalt!);
-    return _encryptionService.deriveFileKey(masterKey, salt, file.kdfIterations!);
+    // ponytail: async (compute isolate). Sync PBKDF2 @ 100k iterations on the
+    // main isolate was the 5-7s UI freeze when opening encrypted files.
+    return _encryptionService.deriveFileKeyAsync(masterKey, salt, file.kdfIterations!);
   }
 
   /// Get the actual file from vault (decrypts if needed)

--- a/lib/themes/app_theme.dart
+++ b/lib/themes/app_theme.dart
@@ -44,6 +44,8 @@ class AppTheme {
         backgroundColor: AppColors.darkBackground,
         foregroundColor: AppColors.darkTextPrimary,
         elevation: 0,
+        scrolledUnderElevation: 0,
+        surfaceTintColor: Colors.transparent,
         centerTitle: true,
         titleTextStyle: TextStyle(
           color: AppColors.darkTextPrimary,
@@ -269,6 +271,8 @@ class AppTheme {
         backgroundColor: AppColors.lightBackground,
         foregroundColor: AppColors.lightTextPrimary,
         elevation: 0,
+        scrolledUnderElevation: 0,
+        surfaceTintColor: Colors.transparent,
         centerTitle: true,
         titleTextStyle: const TextStyle(
           color: AppColors.lightTextPrimary,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -772,10 +772,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: "direct main"
     description:
@@ -1273,26 +1273,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: "none"
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.15.0-beta.1+16
+version: 0.15.0-beta.1+18
 
 environment:
   sdk: ">=3.4.4 <4.0.0"


### PR DESCRIPTION
# Summary

Migrates all encryption to the isolate pool (removing file-size threshold), makes key derivation async to prevent UI stalls, and switches decrypted image cache and PDF viewer from in-memory bytes to file references to avoid ANRs on large files.

# Changes

## Crypto Performance

- Migrate encryption to isolate pool and make key derivation async
- Remove file-size threshold — always use `encryptFileInIsolate`
- Change `deriveFileKey` to async variant to prevent main-isolate stalls
- Write in-memory byte encryption to temp file for isolate processing

## Image/PDF Performance

- Switch decrypted image cache from bytes to `File` (avoids main-isolate decode stalls)
- Switch PDF viewer from bytes to file path (avoids ANR on large PDFs)

## UI

- Remove app bar surface tint and scrolled under elevation
- Remove overlay transparency from container decoration

## Build

- Add Flutter migrator flags to Gradle properties

## Docs

- Update repository URLs and contributor name
- Update documentation to reference unlock autofill design