### PR TITLE
Add encrypted thumbnail generation with GCM-encrypted caching and FIFO eviction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 android/app/google-services.json
+
+# graphify knowledge graph (regenerated locally)
+graphify-out/

--- a/lib/models/vaulted_file.dart
+++ b/lib/models/vaulted_file.dart
@@ -67,6 +67,7 @@ class VaultedFile {
   final DateTime dateAdded;
   final DateTime? dateModified;
   final String? thumbnailPath;
+  final String? thumbnailIv; // IV for encrypted thumbnail (mirrors encryptionIv)
   final Map<String, dynamic>? metadata;
 
   // New fields for organization
@@ -96,6 +97,7 @@ class VaultedFile {
     required this.dateAdded,
     this.dateModified,
     this.thumbnailPath,
+    this.thumbnailIv,
     this.metadata,
     this.tags = const [],
     this.isFavorite = false,
@@ -125,6 +127,7 @@ class VaultedFile {
     DateTime? dateAdded,
     DateTime? dateModified,
     String? thumbnailPath,
+    String? thumbnailIv,
     Map<String, dynamic>? metadata,
     List<String>? tags,
     bool? isFavorite,
@@ -152,6 +155,7 @@ class VaultedFile {
       dateAdded: dateAdded ?? this.dateAdded,
       dateModified: dateModified ?? this.dateModified,
       thumbnailPath: thumbnailPath ?? this.thumbnailPath,
+      thumbnailIv: thumbnailIv ?? this.thumbnailIv,
       metadata: metadata ?? this.metadata,
       tags: tags ?? List.from(this.tags),
       isFavorite: isFavorite ?? this.isFavorite,
@@ -271,6 +275,7 @@ class VaultedFile {
       'dateAdded': dateAdded.toIso8601String(),
       'dateModified': dateModified?.toIso8601String(),
       'thumbnailPath': thumbnailPath,
+      'thumbnailIv': thumbnailIv,
       'metadata': metadata,
       'tags': tags,
       'isFavorite': isFavorite,
@@ -304,6 +309,7 @@ class VaultedFile {
           ? DateTime.parse(json['dateModified'] as String)
           : null,
       thumbnailPath: json['thumbnailPath'] as String?,
+      thumbnailIv: json['thumbnailIv'] as String?,
       metadata: json['metadata'] as Map<String, dynamic>?,
       tags:
           (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList() ??

--- a/lib/screens/accent_color_picker_screen.dart
+++ b/lib/screens/accent_color_picker_screen.dart
@@ -1,5 +1,5 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/accent_color.dart';
 import '../providers/theme_provider.dart';
@@ -112,115 +112,110 @@ class AccentColorPickerScreen extends ConsumerWidget {
     final displayColor = color.getColor(isDarkMode ? Brightness.dark : Brightness.light);
     final variantColor = color.getVariantColor(isDarkMode ? Brightness.dark : Brightness.light);
 
-    return ClipRRect(
+    return InkWell(
+      onTap: () async {
+        HapticFeedback.selectionClick();
+        await ref.read(accentColorProvider.notifier).setAccentColor(color);
+      },
       borderRadius: BorderRadius.circular(16),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: InkWell(
-          onTap: () async {
-            await ref.read(accentColorProvider.notifier).setAccentColor(color);
-          },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [displayColor, variantColor],
+          ),
           borderRadius: BorderRadius.circular(16),
-          child: Container(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [displayColor, variantColor],
-              ),
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(
-                color: isSelected
-                    ? Colors.white.withValues(alpha: 0.6)
-                    : Colors.white.withValues(alpha: 0.2),
-                width: isSelected ? 3 : 1.5,
-              ),
-              boxShadow: [
-                BoxShadow(
-                  color: displayColor.withValues(alpha: 0.3),
-                  blurRadius: isSelected ? 16 : 8,
-                  offset: const Offset(0, 4),
-                ),
-              ],
+          border: Border.all(
+            color: isSelected
+                ? Colors.white.withValues(alpha: 0.6)
+                : Colors.white.withValues(alpha: 0.2),
+            width: isSelected ? 3 : 1.5,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: displayColor.withValues(alpha: 0.3),
+              blurRadius: isSelected ? 16 : 8,
+              offset: const Offset(0, 4),
             ),
-            child: Stack(
-              children: [
-                // Color name
-                Positioned(
-                  left: 16,
-                  bottom: 16,
-                  right: 16,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        color.name,
-                        style: const TextStyle(
-                          fontSize: 16,
+          ],
+        ),
+        child: Stack(
+          children: [
+            Positioned(
+              left: 16,
+              bottom: 16,
+              right: 16,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    color.name,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white,
+                      fontFamily: 'ProductSans',
+                      shadows: [
+                        Shadow(
+                          color: Colors.black26,
+                          blurRadius: 4,
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (isSelected) ...[
+                    const SizedBox(height: 4),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.3),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Text(
+                        'Active',
+                        style: TextStyle(
+                          fontSize: 11,
                           fontWeight: FontWeight.w600,
                           color: Colors.white,
                           fontFamily: 'ProductSans',
-                          shadows: [
-                            Shadow(
-                              color: Colors.black26,
-                              blurRadius: 4,
-                            ),
-                          ],
                         ),
-                      ),
-                      if (isSelected) ...[
-                        const SizedBox(height: 4),
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 8,
-                            vertical: 2,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Colors.white.withValues(alpha: 0.3),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: const Text(
-                            'Active',
-                            style: TextStyle(
-                              fontSize: 11,
-                              fontWeight: FontWeight.w600,
-                              color: Colors.white,
-                              fontFamily: 'ProductSans',
-                            ),
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-                // Check icon for selected
-                if (isSelected)
-                  Positioned(
-                    top: 12,
-                    right: 12,
-                    child: Container(
-                      padding: const EdgeInsets.all(6),
-                      decoration: BoxDecoration(
-                        color: Colors.white,
-                        shape: BoxShape.circle,
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.2),
-                            blurRadius: 8,
-                            offset: const Offset(0, 2),
-                          ),
-                        ],
-                      ),
-                      child: Icon(
-                        Icons.check,
-                        size: 18,
-                        color: displayColor,
                       ),
                     ),
-                  ),
-              ],
+                  ],
+                ],
+              ),
             ),
-          ),
+            if (isSelected)
+              Positioned(
+                top: 12,
+                right: 12,
+                child: Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    shape: BoxShape.circle,
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.2),
+                        blurRadius: 8,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Icon(
+                    Icons.check,
+                    size: 18,
+                    color: displayColor,
+                  ),
+                ),
+              ),
+          ],
         ),
       ),
     );

--- a/lib/screens/album_detail_screen.dart
+++ b/lib/screens/album_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:open_filex/open_filex.dart';
 import '../utils/path_utils.dart';
 import '../models/album.dart';
 import '../models/vaulted_file.dart';
+import '../widgets/encrypted_thumbnail.dart';
 import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
 import '../themes/app_colors.dart';
@@ -298,6 +299,9 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
 
   Widget _buildFileThumbnail(VaultedFile file) {
     if (file.isImage) {
+      if (file.isEncrypted) {
+        return EncryptedThumbnail(file: file);
+      }
       final imageFile = File(file.vaultPath);
       return FutureBuilder<bool>(
         future: imageFile.exists(),
@@ -1167,6 +1171,9 @@ class _AddFilesToAlbumSheetState extends ConsumerState<_AddFilesToAlbumSheet> {
 
   Widget _buildFileThumbnail(VaultedFile file) {
     if (file.isImage) {
+      if (file.isEncrypted) {
+        return EncryptedThumbnail(file: file);
+      }
       final imageFile = File(file.vaultPath);
       return FutureBuilder<bool>(
         future: imageFile.exists(),
@@ -1186,6 +1193,20 @@ class _AddFilesToAlbumSheetState extends ConsumerState<_AddFilesToAlbumSheet> {
     }
 
     if (file.isVideo) {
+      if (file.isEncrypted) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            EncryptedThumbnail(file: file),
+            Container(
+              color: Colors.black26,
+              child: const Center(
+                child: Icon(Icons.play_circle_outline, size: 32, color: Colors.white70),
+              ),
+            ),
+          ],
+        );
+      }
       return Container(
         color: Colors.black87,
         child: const Center(

--- a/lib/screens/albums_screen.dart
+++ b/lib/screens/albums_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/album.dart';
 import '../models/vaulted_file.dart';
+import '../widgets/encrypted_thumbnail.dart';
 import '../providers/vault_providers.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
@@ -234,6 +235,9 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
           if (snapshot.hasData && snapshot.data != null) {
             final file = snapshot.data!;
             if (file.isImage) {
+              if (file.isEncrypted) {
+                return EncryptedThumbnail(file: file);
+              }
               final imageFile = File(file.vaultPath);
               return Image.file(
                 imageFile,
@@ -259,6 +263,9 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
           if (snapshot.hasData && snapshot.data!.isNotEmpty) {
             final imageFiles = snapshot.data!.where((f) => f.isImage).toList();
             if (imageFiles.isNotEmpty) {
+              if (imageFiles.first.isEncrypted) {
+                return EncryptedThumbnail(file: imageFiles.first);
+              }
               final imageFile = File(imageFiles.first.vaultPath);
               return Image.file(
                 imageFile,
@@ -1018,14 +1025,29 @@ class _ChangeCoverSheetState extends ConsumerState<_ChangeCoverSheet> {
             child: ClipRRect(
               borderRadius: BorderRadius.circular(isSelected ? 5 : 8),
               child: file.isImage
-                    ? Image.file(
-                        File(file.vaultPath),
-                        fit: BoxFit.cover,
-                        cacheWidth: 200,
-                        filterQuality: FilterQuality.low,
-                        errorBuilder: (_, __, ___) => _buildPlaceholder(),
-                      )
-                  : _buildVideoPlaceholder(),
+                    ? (file.isEncrypted
+                        ? EncryptedThumbnail(file: file)
+                        : Image.file(
+                            File(file.vaultPath),
+                            fit: BoxFit.cover,
+                            cacheWidth: 200,
+                            filterQuality: FilterQuality.low,
+                            errorBuilder: (_, __, ___) => _buildPlaceholder(),
+                          ))
+                  : (file.isVideo && file.isEncrypted
+                      ? Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            EncryptedThumbnail(file: file),
+                            Container(
+                              color: Colors.black26,
+                              child: const Center(
+                                child: Icon(Icons.play_circle_outline, size: 32, color: Colors.white70),
+                              ),
+                            ),
+                          ],
+                        )
+                      : _buildVideoPlaceholder()),
             ),
           ),
           // Selection indicator

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:open_filex/open_filex.dart';
 import '../utils/path_utils.dart';
 import '../models/vaulted_file.dart';
+import '../widgets/encrypted_thumbnail.dart';
 import '../models/album.dart';
 import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
@@ -309,6 +310,9 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
 
   Widget _buildFileThumbnail(VaultedFile file) {
     if (file.isImage) {
+      if (file.isEncrypted) {
+        return EncryptedThumbnail(file: file);
+      }
       final imageFile = File(file.vaultPath);
       return FutureBuilder<bool>(
         future: imageFile.exists(),
@@ -329,6 +333,20 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     }
 
     if (file.isVideo) {
+      if (file.isEncrypted) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            EncryptedThumbnail(file: file),
+            Container(
+              color: Colors.black26,
+              child: const Center(
+                child: Icon(Icons.play_circle_outline, size: 48, color: Colors.white70),
+              ),
+            ),
+          ],
+        );
+      }
       return Stack(
         fit: StackFit.expand,
         children: [

--- a/lib/screens/folder_detail_screen.dart
+++ b/lib/screens/folder_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import '../models/album.dart';
 import '../models/vault_folder.dart';
 import '../models/vaulted_file.dart';
+import '../widgets/encrypted_thumbnail.dart';
 import '../providers/vault_providers.dart';
 import '../services/file_import_service.dart';
 import '../services/vault_service.dart';
@@ -525,6 +526,9 @@ class _FolderDetailScreenState extends ConsumerState<FolderDetailScreen> {
 
   Widget _buildFileThumbnail(VaultedFile file) {
     if (file.isImage) {
+      if (file.isEncrypted) {
+        return EncryptedThumbnail(file: file);
+      }
       final imageFile = File(file.vaultPath);
       return Image.file(
         imageFile,
@@ -1529,6 +1533,9 @@ class _AddFilesToFolderSheetState
 
   Widget _buildFileThumbnail(VaultedFile file) {
     if (file.isImage) {
+      if (file.isEncrypted) {
+        return EncryptedThumbnail(file: file);
+      }
       final imageFile = File(file.vaultPath);
       return FutureBuilder<bool>(
         future: imageFile.exists(),

--- a/lib/screens/folders_screen.dart
+++ b/lib/screens/folders_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 import '../models/vault_folder.dart';
 import '../models/vaulted_file.dart';
+import '../widgets/encrypted_thumbnail.dart';
 import '../providers/vault_providers.dart';
 import '../services/file_import_service.dart';
 import '../themes/app_colors.dart';
@@ -230,6 +231,9 @@ class _FoldersScreenState extends ConsumerState<FoldersScreen> {
           if (snapshot.hasData && snapshot.data != null) {
             final file = snapshot.data!;
             if (file.isImage) {
+              if (file.isEncrypted) {
+                return EncryptedThumbnail(file: file);
+              }
               final imageFile = File(file.vaultPath);
               return Image.file(
                 imageFile,

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -20,6 +20,7 @@ import '../services/whats_new_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 import '../utils/responsive_utils.dart';
+import '../widgets/encrypted_thumbnail.dart';
 import '../widgets/file_info_sheet.dart';
 import '../widgets/office_conversion_confirm_dialog.dart';
 import '../widgets/per_file_encryption_sheet.dart';
@@ -1177,6 +1178,9 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
   Widget _buildFileThumbnail(VaultedFile file) {
     // Show image thumbnail
     if (file.isImage) {
+      if (file.isEncrypted) {
+        return EncryptedThumbnail(file: file);
+      }
       final imageFile = File(file.vaultPath);
 
       return Image.file(
@@ -1200,6 +1204,24 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
 
     // Show video thumbnail (first frame preview)
     if (file.isVideo) {
+      if (file.isEncrypted) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            EncryptedThumbnail(file: file),
+            Container(
+              color: Colors.black26,
+              child: const Center(
+                child: Icon(
+                  Icons.play_circle_outline,
+                  size: 48,
+                  color: Colors.white70,
+                ),
+              ),
+            ),
+          ],
+        );
+      }
       // Try to show video thumbnail from the vault path
       // Videos don't have a simple thumbnail, so we use a styled placeholder
       return Stack(

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -4032,27 +4032,39 @@ class _ImportOptionsSheet extends StatelessWidget {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-            child: Column(
+            padding: const EdgeInsets.fromLTRB(20, 20, 8, 0),
+            child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  'Import Files',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: context.textPrimary,
-                    fontFamily: 'ProductSans',
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Import Files',
+                        style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                          color: context.textPrimary,
+                          fontFamily: 'ProductSans',
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Files will be encrypted and hidden securely',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: context.textSecondary,
+                          fontFamily: 'ProductSans',
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-                const SizedBox(height: 8),
-                Text(
-                  'Files will be encrypted and hidden securely',
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: context.textSecondary,
-                    fontFamily: 'ProductSans',
-                  ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Close',
+                  onPressed: () => Navigator.of(context).pop(),
                 ),
               ],
             ),

--- a/lib/screens/local_backup_screen.dart
+++ b/lib/screens/local_backup_screen.dart
@@ -1,10 +1,14 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
-import '../utils/path_utils.dart';
 import '../models/vaulted_file.dart';
 import '../services/backup_service.dart';
+import '../services/vault_service.dart';
 import '../themes/app_colors.dart';
+import '../utils/path_utils.dart';
 import '../utils/toast_utils.dart';
 import 'backup_file_selection_screen.dart';
 import 'folder_picker_screen.dart';
@@ -27,9 +31,19 @@ class LocalBackupScreen extends ConsumerStatefulWidget {
 
 class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
   final BackupService _backupService = BackupService.instance;
+  final VaultService _vaultService = VaultService.instance;
+
   bool _isBackingUp = false;
   bool _backupSelectedFilesOnly = false;
   List<VaultedFile> _selectedFiles = const [];
+
+  List<VaultedFile> _allFiles = const [];
+  bool _allFilesLoaded = false;
+
+  // ponytail: ValueNotifier drives the progress dialog across the route
+  // boundary (setState here won't rebuild a separately-pushed dialog route).
+  final ValueNotifier<({int current, int total})?> _progress =
+      ValueNotifier(null);
 
   static List<SaveLocation> get _saveLocations => [
         SaveLocation(
@@ -47,6 +61,36 @@ class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
           },
         ),
       ];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAllFiles();
+    if (kDebugMode) _selfCheckHumanSize();
+  }
+
+  @override
+  void dispose() {
+    _progress.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadAllFiles() async {
+    final files = await _vaultService.getAllFiles(isDecoy: false);
+    if (!mounted) return;
+    setState(() {
+      _allFiles = files;
+      _allFilesLoaded = true;
+    });
+  }
+
+  int get _targetFileCount =>
+      _backupSelectedFilesOnly ? _selectedFiles.length : _allFiles.length;
+
+  int get _targetBytes {
+    final files = _backupSelectedFilesOnly ? _selectedFiles : _allFiles;
+    return files.fold<int>(0, (sum, f) => sum + f.fileSize);
+  }
 
   Future<void> _chooseFilesForBackup() async {
     final selectedFiles = await Navigator.of(context).push<List<VaultedFile>>(
@@ -89,45 +133,40 @@ class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
   Future<void> _runBackupToPath(String destinationDirPath) async {
     if (!await _ensureSelectedFiles()) return;
     if (_isBackingUp) return;
-    setState(() => _isBackingUp = true);
+
+    final fileCount = _targetFileCount;
+    setState(() {
+      _isBackingUp = true;
+      _progress.value = null;
+    });
 
     if (!mounted) return;
     showDialog(
       context: context,
       barrierDismissible: false,
-      builder: (context) => AlertDialog(
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const CircularProgressIndicator(
-              valueColor: AlwaysStoppedAnimation<Color>(AppColors.accent),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Backing up...',
-              style: TextStyle(
-                fontFamily: 'ProductSans',
-                color: Theme.of(context).textTheme.bodyLarge?.color,
-              ),
-            ),
-          ],
-        ),
-      ),
+      builder: (_) => _BackupProgressDialog(progress: _progress),
     );
 
     final result = await _backupService.createBackup(
       destinationDirPath,
       files: _backupSelectedFilesOnly ? _selectedFiles : null,
+      onProgress: (current, total) => _progress.value = (current: current, total: total),
     );
 
     if (mounted) Navigator.of(context).pop();
 
-    if (mounted) setState(() => _isBackingUp = false);
+    if (mounted) {
+      setState(() {
+        _isBackingUp = false;
+        _progress.value = null;
+      });
+    }
 
     if (result.success && result.zipPath != null) {
-      ToastUtils.showSuccess(
-          'Backup saved: ${result.zipPath!.split('/').last}');
+      final size = _humanSize(File(result.zipPath!).lengthSync());
+      final name = result.zipPath!.split('/').last;
+      ToastUtils.showSuccess('Backed up $fileCount '
+          '${fileCount == 1 ? 'file' : 'files'} • $size • $name');
     } else {
       ToastUtils.showError(result.error ?? 'Backup failed');
     }
@@ -141,6 +180,195 @@ class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
     );
     if (path == null || path.isEmpty) return;
     await _runBackupToPath(path);
+  }
+
+  // ---- builders ----
+
+  Widget _sectionCard(BuildContext context, {required Widget child}) => Card(
+        elevation: 0,
+        color: context.backgroundSecondary,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        margin: EdgeInsets.zero,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: child,
+        ),
+      );
+
+  TextStyle _sectionLabel(BuildContext context) => TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 14,
+        color: context.textTertiary,
+      );
+
+  TextStyle _tileTitle(BuildContext context) => TextStyle(
+        fontFamily: 'ProductSans',
+        fontWeight: FontWeight.w500,
+        color: context.textPrimary,
+      );
+
+  TextStyle _tileSubtitle(BuildContext context) => TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 12,
+        color: context.textTertiary,
+      );
+
+  ChoiceChip _themedChoiceChip(
+    BuildContext context, {
+    required String label,
+    required bool selected,
+    required ValueChanged<bool> onSelected,
+  }) {
+    final accent = context.accentColor;
+    final onAccent = Theme.of(context).colorScheme.onPrimary;
+    return ChoiceChip(
+      label: Text(label),
+      selected: selected,
+      selectedColor: accent,
+      side: BorderSide(color: context.borderColor),
+      labelStyle: TextStyle(
+        fontFamily: 'ProductSans',
+        fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+        color: selected ? onAccent : context.textPrimary,
+      ),
+      checkmarkColor: onAccent,
+      onSelected: onSelected,
+    );
+  }
+
+  Widget _buildSummaryCard(BuildContext context) {
+    final count = _targetFileCount;
+    final size = _humanSize(_targetBytes);
+    return _sectionCard(
+      context,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Row(
+          children: [
+            Icon(Icons.archive_outlined, color: context.accentColor),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Ready to backup',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontWeight: FontWeight.w600,
+                      color: context.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    _allFilesLoaded
+                        ? '$count ${count == 1 ? 'file' : 'files'} • ~$size'
+                        : 'Counting files...',
+                    style: _tileSubtitle(context),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilesToIncludeCard(BuildContext context) {
+    return _sectionCard(
+      context,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 6, bottom: 8),
+            child: Text('Files to include', style: _sectionLabel(context)),
+          ),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _themedChoiceChip(
+                context,
+                label: 'All files',
+                selected: !_backupSelectedFilesOnly,
+                onSelected: (_) =>
+                    setState(() => _backupSelectedFilesOnly = false),
+              ),
+              _themedChoiceChip(
+                context,
+                label: 'Selected files',
+                selected: _backupSelectedFilesOnly,
+                onSelected: (_) =>
+                    setState(() => _backupSelectedFilesOnly = true),
+              ),
+            ],
+          ),
+          if (_backupSelectedFilesOnly) ...[
+            const SizedBox(height: 4),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.library_books_outlined,
+                  color: context.accentColor),
+              title: Text('Choose files', style: _tileTitle(context)),
+              subtitle: Text(
+                _selectedFilesSubtitle(),
+                style: _tileSubtitle(context),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              trailing:
+                  Icon(Icons.chevron_right, color: context.textTertiary),
+              onTap: _chooseFilesForBackup,
+            ),
+            if (_selectedFiles.isEmpty)
+              Padding(
+                padding: const EdgeInsets.only(left: 4, bottom: 4),
+                child: Text(
+                  'No files chosen yet — tap "Choose files".',
+                  style: _tileSubtitle(context),
+                ),
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSaveLocationCard(BuildContext context) {
+    return _sectionCard(
+      context,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 6, bottom: 4),
+            child: Text('Save backup ZIP to', style: _sectionLabel(context)),
+          ),
+          ..._saveLocations.map((loc) => _SaveLocationTile(
+                name: loc.name,
+                resolvePath: loc.resolvePath,
+                onTap: () async {
+                  final path = await loc.resolvePath();
+                  if (path == null || path.isEmpty) {
+                    ToastUtils.showError('Could not access ${loc.name}');
+                    return;
+                  }
+                  await _runBackupToPath(path);
+                },
+              )),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: Icon(Icons.folder_open_outlined, color: context.accentColor),
+            title: Text('Choose folder...', style: _tileTitle(context)),
+            subtitle: Text('Pick any folder on device',
+                style: _tileSubtitle(context)),
+            onTap: _pickFolderAndBackup,
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -160,116 +388,58 @@ class _LocalBackupScreenState extends ConsumerState<LocalBackupScreen> {
         elevation: 0,
         iconTheme: IconThemeData(color: context.textPrimary),
       ),
-      body: _isBackingUp
-          ? const Center(
-              child: CircularProgressIndicator(color: AppColors.accent))
-          : ListView(
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 12),
-                  child: Text(
-                    'Files to include',
-                    style: TextStyle(
-                      fontFamily: 'ProductSans',
-                      fontSize: 14,
-                      color: context.textTertiary,
-                    ),
-                  ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+        children: [
+          _buildSummaryCard(context),
+          const SizedBox(height: 16),
+          _buildFilesToIncludeCard(context),
+          const SizedBox(height: 16),
+          _buildSaveLocationCard(context),
+        ],
+      ),
+    );
+  }
+}
+
+/// Backup progress dialog driven by a [ValueNotifier] so it updates live
+/// without rebuilding the parent route.
+class _BackupProgressDialog extends StatelessWidget {
+  final ValueListenable<({int current, int total})?> progress;
+
+  const _BackupProgressDialog({required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      content: ValueListenableBuilder<({int current, int total})?>(
+        valueListenable: progress,
+        builder: (context, p, _) {
+          final value = (p != null && p.total > 0) ? p.current / p.total : null;
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              LinearProgressIndicator(
+                value: value,
+                color: AppColors.accent,
+                backgroundColor: context.borderColor,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                p == null
+                    ? 'Preparing backup...'
+                    : 'Backing up file ${p.current} of ${p.total}',
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  color: context.textPrimary,
                 ),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: [
-                    ChoiceChip(
-                      label: const Text('All files'),
-                      selected: !_backupSelectedFilesOnly,
-                      onSelected: (_) {
-                        setState(() => _backupSelectedFilesOnly = false);
-                      },
-                    ),
-                    ChoiceChip(
-                      label: const Text('Selected files'),
-                      selected: _backupSelectedFilesOnly,
-                      onSelected: (_) {
-                        setState(() => _backupSelectedFilesOnly = true);
-                      },
-                    ),
-                  ],
-                ),
-                if (_backupSelectedFilesOnly)
-                  ListTile(
-                    contentPadding: EdgeInsets.zero,
-                    leading: Icon(Icons.library_books_outlined,
-                        color: context.accentColor),
-                    title: Text(
-                      'Choose files',
-                      style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        fontWeight: FontWeight.w500,
-                        color: context.textPrimary,
-                      ),
-                    ),
-                    subtitle: Text(
-                      _selectedFilesSubtitle(),
-                      style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        fontSize: 12,
-                        color: context.textTertiary,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    trailing:
-                        Icon(Icons.chevron_right, color: context.textTertiary),
-                    onTap: _chooseFilesForBackup,
-                  ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 12),
-                  child: Text(
-                    'Save backup ZIP to',
-                    style: TextStyle(
-                      fontFamily: 'ProductSans',
-                      fontSize: 14,
-                      color: context.textTertiary,
-                    ),
-                  ),
-                ),
-                ..._saveLocations.map((loc) => _SaveLocationTile(
-                      name: loc.name,
-                      resolvePath: loc.resolvePath,
-                      onTap: () async {
-                        final path = await loc.resolvePath();
-                        if (path == null || path.isEmpty) {
-                          ToastUtils.showError('Could not access ${loc.name}');
-                          return;
-                        }
-                        await _runBackupToPath(path);
-                      },
-                    )),
-                ListTile(
-                  leading: Icon(Icons.folder_open_outlined,
-                      color: context.accentColor),
-                  title: Text(
-                    'Choose folder...',
-                    style: TextStyle(
-                      fontFamily: 'ProductSans',
-                      fontWeight: FontWeight.w500,
-                      color: context.textPrimary,
-                    ),
-                  ),
-                  subtitle: Text(
-                    'Pick any folder on device',
-                    style: TextStyle(
-                      fontFamily: 'ProductSans',
-                      fontSize: 12,
-                      color: context.textTertiary,
-                    ),
-                  ),
-                  onTap: _pickFolderAndBackup,
-                ),
-              ],
-            ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          );
+        },
+      ),
     );
   }
 }
@@ -320,4 +490,26 @@ class _SaveLocationTile extends StatelessWidget {
       },
     );
   }
+}
+
+// ponytail: standard 1024-base size formatter. Known outputs:
+// _humanSize(0)=="0 B", _humanSize(1023)=="1023 B", _humanSize(1024)=="1.0 KB",
+// _humanSize(1048576)=="1.0 MB".
+String _humanSize(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  var size = bytes / 1024;
+  var unit = 0;
+  while (size >= 1024 && unit < units.length - 1) {
+    size /= 1024;
+    unit++;
+  }
+  return '${size.toStringAsFixed(size >= 100 ? 0 : 1)} ${units[unit]}';
+}
+
+void _selfCheckHumanSize() {
+  assert(_humanSize(0) == '0 B');
+  assert(_humanSize(1023) == '1023 B');
+  assert(_humanSize(1024) == '1.0 KB');
+  assert(_humanSize(1048576) == '1.0 MB');
 }

--- a/lib/screens/tags_screen.dart
+++ b/lib/screens/tags_screen.dart
@@ -5,6 +5,7 @@ import 'package:locker/models/album.dart';
 import 'package:open_filex/open_filex.dart';
 import '../utils/path_utils.dart';
 import '../models/vaulted_file.dart';
+import '../widgets/encrypted_thumbnail.dart';
 import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
 import '../themes/app_colors.dart';
@@ -492,6 +493,9 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
 
   Widget _buildFileThumbnail(VaultedFile file) {
     if (file.isImage) {
+      if (file.isEncrypted) {
+        return EncryptedThumbnail(file: file);
+      }
       final imageFile = File(file.vaultPath);
       return Image.file(
         imageFile,
@@ -503,6 +507,20 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
     }
 
     if (file.isVideo) {
+      if (file.isEncrypted) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            EncryptedThumbnail(file: file),
+            Container(
+              color: Colors.black26,
+              child: const Center(
+                child: Icon(Icons.play_circle_outline, size: 48, color: Colors.white70),
+              ),
+            ),
+          ],
+        );
+      }
       return Container(
         color: Colors.black87,
         child: const Center(

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -11,6 +11,8 @@ import '../models/encryption_algorithm.dart';
 import 'encryption_service.dart';
 import 'compression_service.dart';
 import 'crypto_isolate_pool.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:video_compress/video_compress.dart';
 
 class FileProgressInfo {
   final int current;
@@ -54,6 +56,12 @@ class _BatchPreparationResult {
   });
 }
 
+class _StoredThumb {
+  final String path;
+  final String iv;
+  const _StoredThumb(this.path, this.iv);
+}
+
 /// Service for managing vaulted files storage
 class VaultService {
   VaultService._();
@@ -85,6 +93,17 @@ class VaultService {
   List<VaultFolder>? _cachedFolders;
   List<TagInfo>? _cachedTags;
   VaultSettings? _cachedSettings;
+
+  // ponytail: in-memory encrypted-thumb cache + in-flight dedupe. Mirrors the
+  // accepted security model (plaintext persists like _decryptedFileCache /
+  // master key until process death); cleared in clearVault.
+  final Map<String, Uint8List> _thumbnailCache = {};
+  final Map<String, Future<Uint8List?>> _thumbnailInFlight = {};
+  static const int _thumbnailCacheLimit = 200;
+  // ponytail: single-flight lock over thumbnail generation — only one full-file
+  // decrypt + image decode runs at a time so a grid of N encrypted files can't
+  // OOM/ANR the app. Fan out (small semaphore) only if first-load latency bites.
+  Future<void> _thumbGenLock = Future.value();
 
   /// Initialize the vault service
   Future<void> initialize() async {
@@ -799,6 +818,48 @@ class VaultService {
           .toString()
           .substring(0, 24);
 
+      // Generate an encrypted thumbnail at import (images + videos). Failure is
+      // non-fatal — the grid falls back to lazy regen via getThumbnailBytes.
+      String? thumbPath;
+      String? thumbIv;
+      if (shouldEncrypt &&
+          derivedKey != null &&
+          (type == VaultedFileType.image ||
+              type == VaultedFileType.video)) {
+        String? reconstructedTemp;
+        try {
+          File? plainFile;
+          if (await File(sourcePathToUse).exists()) {
+            plainFile = File(sourcePathToUse);
+          } else if (compressedImageBytes != null) {
+            final tmp = await getTemporaryDirectory();
+            reconstructedTemp =
+                '${tmp.path}/lkr_thumb_src_${DateTime.now().microsecondsSinceEpoch}';
+            plainFile = File(reconstructedTemp);
+            await plainFile.writeAsBytes(compressedImageBytes);
+          }
+          if (plainFile != null) {
+            final thumbBytes = await _generateThumbBytes(plainFile, type);
+            if (thumbBytes != null) {
+              final stored = await _encryptAndStoreThumbnail(
+                thumbBytes,
+                fileId: fileId,
+                derivedKey: derivedKey,
+                isDecoy: isDecoy,
+              );
+              thumbPath = stored?.path;
+              thumbIv = stored?.iv;
+            }
+          }
+        } catch (e) {
+          debugPrint('[Vault] import-time thumbnail generation failed: $e');
+        } finally {
+          if (reconstructedTemp != null) {
+            await _deleteFileIfExists(reconstructedTemp);
+          }
+        }
+      }
+
       return _PreparedVaultAddition(
         vaultedFile: VaultedFile(
           id: fileId,
@@ -818,6 +879,8 @@ class VaultService {
           isDecoy: isDecoy,
           tags: normalizedTags,
           albumIds: normalizedAlbumIds,
+          thumbnailPath: thumbPath,
+          thumbnailIv: thumbIv,
         ),
       );
     } catch (e) {
@@ -1207,6 +1270,177 @@ class VaultService {
     }
 
     return file;
+  }
+
+  // ---- Encrypted thumbnails ----
+  // Thumbs are GCM-encrypted with the file's per-file derived key + a fresh IV
+  // (stored in thumbnailIv), independent of the file's own algorithm. GCM auth
+  // lets us detect a stale thumb (e.g. after re-encrypt changed the key) and
+  // transparently regenerate. No plaintext thumb is ever at rest.
+
+  /// Decrypt (or lazily generate) the encrypted thumbnail bytes for [file].
+  /// Returns null for unencrypted files (callers render vaultPath directly) or
+  /// when no thumb can be produced.
+  Future<Uint8List?> getThumbnailBytes(VaultedFile file) async {
+    if (!file.isEncrypted) return null;
+    final cached = _thumbnailCache[file.id];
+    if (cached != null) return cached;
+    // ponytail: dedupe concurrent fetches so a fast scroll doesn't kick off
+    // N parallel full-decrypts for the same file.
+    final inFlight = _thumbnailInFlight[file.id];
+    if (inFlight != null) return inFlight;
+    final fut = _loadOrRegenerateThumbnail(file);
+    _thumbnailInFlight[file.id] = fut;
+    try {
+      final bytes = await fut;
+      if (bytes != null) _cacheThumbnail(file.id, bytes);
+      return bytes;
+    } finally {
+      _thumbnailInFlight.remove(file.id);
+    }
+  }
+
+  void _cacheThumbnail(String id, Uint8List bytes) {
+    _thumbnailCache[id] = bytes;
+    // ponytail: naive FIFO eviction — Map preserves insertion order, so
+    // dropping the first entry bounds the cache. Real LRU if hit-rate matters.
+    if (_thumbnailCache.length > _thumbnailCacheLimit) {
+      _thumbnailCache.remove(_thumbnailCache.keys.first);
+    }
+  }
+
+  Future<Uint8List?> _loadOrRegenerateThumbnail(VaultedFile file) {
+    // ponytail: serialize to one-at-a-time (see _thumbGenLock). Prevents a grid
+    // of N encrypted files from decrypting N full images concurrently (OOM/ANR).
+    final prev = _thumbGenLock;
+    final result = prev.then((_) => _loadOrRegenerateThumbnailLocked(file));
+    _thumbGenLock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  Future<Uint8List?> _loadOrRegenerateThumbnailLocked(VaultedFile file) async {
+    if (file.thumbnailPath != null && file.thumbnailIv != null) {
+      final thumbFile = File(file.thumbnailPath!);
+      if (await thumbFile.exists()) {
+        final derivedKey = await _deriveKeyForFile(file);
+        final res = await _encryptionService.decryptStreamedFileToMemoryGcm(
+          file.thumbnailPath!,
+          file.thumbnailIv!,
+          isDecoy: file.isDecoy,
+          derivedKey: derivedKey,
+        );
+        if (res.success && res.data != null) return res.data;
+        // Auth failure / stale key (e.g. post re-encrypt): fall through to regen.
+      }
+    }
+    return _regenerateThumbnail(file);
+  }
+
+  Future<Uint8List?> _regenerateThumbnail(VaultedFile file) async {
+    final plaintext = await getVaultedFile(file.id, isDecoy: file.isDecoy);
+    if (plaintext == null) return null;
+    try {
+      final thumbBytes = await _generateThumbBytes(plaintext, file.type);
+      if (thumbBytes == null) return null;
+      final derivedKey = await _deriveKeyForFile(file);
+      if (derivedKey != null) {
+        final stored = await _encryptAndStoreThumbnail(
+          thumbBytes,
+          fileId: file.id,
+          derivedKey: derivedKey,
+          isDecoy: file.isDecoy,
+        );
+        if (stored != null) {
+          await _persistThumbnailRecord(
+            file.id,
+            stored.path,
+            stored.iv,
+            isDecoy: file.isDecoy,
+          );
+        }
+      }
+      return thumbBytes;
+    } finally {
+      try {
+        if (await plaintext.exists()) await plaintext.delete();
+      } catch (_) {}
+    }
+  }
+
+  /// Produce small JPEG bytes for an image or the first frame of a video.
+  /// Both plugins are platform-channel backed -> only callable on a device.
+  Future<Uint8List?> _generateThumbBytes(
+    File plaintext,
+    VaultedFileType type,
+  ) async {
+    try {
+      if (type == VaultedFileType.video) {
+        return await VideoCompress.getByteThumbnail(plaintext.path, quality: 70);
+      }
+      return await FlutterImageCompress.compressWithFile(
+        plaintext.path,
+        minWidth: 300,
+        minHeight: 300,
+        quality: 70,
+      );
+    } catch (e) {
+      debugPrint('[Vault] thumbnail generation failed: $e');
+      return null;
+    }
+  }
+
+  /// Encrypt [thumbBytes] to `thumbnails/<fileId>.thumb.enc` with a fresh IV.
+  /// Reuses the isolate encrypt path so the on-disk format matches the GCM
+  /// decrypt-to-memory reader. Returns null on failure.
+  Future<_StoredThumb?> _encryptAndStoreThumbnail(
+    Uint8List thumbBytes, {
+    required String fileId,
+    required Uint8List derivedKey,
+    required bool isDecoy,
+  }) async {
+    final dir = isDecoy
+        ? await _ensureDecoyDirectory()
+        : await _ensureVaultDirectory();
+    final thumbPath = '${dir.path}/thumbnails/$fileId.thumb.enc';
+    final tempDir = await getTemporaryDirectory();
+    final tempPath =
+        '${tempDir.path}/lkr_thumb_${DateTime.now().microsecondsSinceEpoch}';
+    await File(tempPath).writeAsBytes(thumbBytes);
+    try {
+      final res = await _encryptionService.encryptFileInIsolate(
+        tempPath,
+        thumbPath,
+        isDecoy: isDecoy,
+        useGcm: true,
+        derivedKey: derivedKey,
+      );
+      if (!res.success || res.iv == null) return null;
+      return _StoredThumb(thumbPath, res.iv!);
+    } catch (e) {
+      debugPrint('[Vault] thumbnail encrypt failed: $e');
+      return null;
+    } finally {
+      await _deleteFileIfExists(tempPath);
+    }
+  }
+
+  Future<void> _persistThumbnailRecord(
+    String fileId,
+    String path,
+    String iv, {
+    required bool isDecoy,
+  }) async {
+    final files = await _loadFileIndex(isDecoy: isDecoy);
+    final idx = files.indexWhere((f) => f.id == fileId);
+    if (idx == -1) return;
+    files[idx] = files[idx].copyWith(thumbnailPath: path, thumbnailIv: iv);
+    await _saveFileIndex(isDecoy: isDecoy);
+  }
+
+  /// Drop the in-memory thumbnail cache. Called on vault clear / logout flows.
+  void clearThumbnailCache() {
+    _thumbnailCache.clear();
+    _thumbnailInFlight.clear();
   }
 
   /// Get decrypted file data in memory (for viewing)
@@ -2368,6 +2602,14 @@ class VaultService {
 
         final fileIndex = files.indexWhere((f) => f.id == file.id);
         if (fileIndex >= 0) {
+          // ponytail: per-file key changed → the stored thumb ciphertext is
+          // undecryptable. Delete it; getThumbnailBytes lazily regenerates with
+          // the new key. In-memory cache (still the correct image) is left as-is.
+          if (file.thumbnailPath != null) {
+            try {
+              await File(file.thumbnailPath!).delete();
+            } catch (_) {}
+          }
           files[fileIndex] = file.copyWith(
             encryptionIv: newIv,
             encryptionAlgorithm: targetAlgorithm,
@@ -2530,6 +2772,14 @@ class VaultService {
         final idx = files.indexWhere((f) => f.id == file.id);
         if (idx >= 0) {
           // copyWith can't null out fields, so rebuild clearing the crypto ones.
+          // ponytail: file is now plaintext, grids render vaultPath directly and
+          // getThumbnailBytes returns null for unencrypted files — so drop the
+          // thumb field and delete the now-orphaned ciphertext thumb.
+          if (file.thumbnailPath != null) {
+            try {
+              await File(file.thumbnailPath!).delete();
+            } catch (_) {}
+          }
           files[idx] = VaultedFile(
             id: file.id,
             originalName: file.originalName,
@@ -2540,7 +2790,6 @@ class VaultService {
             fileSize: file.fileSize,
             dateAdded: file.dateAdded,
             dateModified: DateTime.now(),
-            thumbnailPath: file.thumbnailPath,
             metadata: file.metadata,
             tags: file.tags,
             isFavorite: file.isFavorite,
@@ -2595,6 +2844,7 @@ class VaultService {
         await _storage.delete(key: _tagsKey);
         _vaultDirectory = null;
       }
+      clearThumbnailCache();
     } catch (e) {
       debugPrint('Error clearing vault: $e');
     }

--- a/lib/widgets/encrypted_thumbnail.dart
+++ b/lib/widgets/encrypted_thumbnail.dart
@@ -1,0 +1,107 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/vaulted_file.dart';
+import '../providers/vault_providers.dart';
+
+class EncryptedThumbnail extends ConsumerStatefulWidget {
+  final VaultedFile file;
+
+  const EncryptedThumbnail({super.key, required this.file});
+
+  @override
+  ConsumerState<EncryptedThumbnail> createState() => _EncryptedThumbnailState();
+}
+
+class _EncryptedThumbnailState extends ConsumerState<EncryptedThumbnail> {
+  late final Future<Uint8List?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = ref.read(vaultServiceProvider).getThumbnailBytes(widget.file);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Uint8List?>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const _ThumbLoading();
+        }
+        final bytes = snapshot.data;
+        if (bytes == null || bytes.isEmpty) {
+          return _ThumbPlaceholder(type: widget.file.type);
+        }
+        return Image.memory(
+          bytes,
+          fit: BoxFit.cover,
+          gaplessPlayback: true,
+          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+            if (wasSynchronouslyLoaded || frame != null) return child;
+            return const _ThumbLoading();
+          },
+          errorBuilder: (context, error, stackTrace) {
+            debugPrint('EncryptedThumbnail decode error: ${widget.file.originalName} - $error');
+            return _ThumbPlaceholder(type: widget.file.type);
+          },
+        );
+      },
+    );
+  }
+}
+
+class _ThumbLoading extends StatelessWidget {
+  const _ThumbLoading();
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.grey.shade200,
+      child: const Center(
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      ),
+    );
+  }
+}
+
+class _ThumbPlaceholder extends StatelessWidget {
+  final VaultedFileType type;
+  const _ThumbPlaceholder({required this.type});
+
+  @override
+  Widget build(BuildContext context) {
+    IconData icon;
+    Color color;
+    switch (type) {
+      case VaultedFileType.image:
+        icon = Icons.image;
+        color = Colors.blueGrey;
+        break;
+      case VaultedFileType.video:
+        icon = Icons.videocam;
+        color = Colors.red;
+        break;
+      case VaultedFileType.song:
+        icon = Icons.music_note;
+        color = Colors.purple;
+        break;
+      case VaultedFileType.document:
+        icon = Icons.description;
+        color = Colors.amber;
+        break;
+      case VaultedFileType.other:
+        icon = Icons.insert_drive_file;
+        color = Colors.grey;
+        break;
+    }
+    return Container(
+      color: Colors.grey.shade100,
+      child: Center(child: Icon(icon, color: color)),
+    );
+  }
+}

--- a/lib/widgets/explorer_file_grid.dart
+++ b/lib/widgets/explorer_file_grid.dart
@@ -15,6 +15,7 @@ import '../utils/responsive_utils.dart';
 import '../utils/toast_utils.dart';
 import '../widgets/file_info_sheet.dart';
 import '../widgets/media_hold_action_sheet.dart';
+import 'encrypted_thumbnail.dart';
 import 'optimized_image_widget.dart';
 
 class ExplorerFileGrid extends ConsumerWidget {
@@ -626,12 +627,17 @@ class ExplorerFileGrid extends ConsumerWidget {
 
   Widget _buildFileThumbnail(VaultedFile file, BuildContext context) {
     if (file.isImage) {
+      if (file.isEncrypted) {
+        return EncryptedThumbnail(file: file);
+      }
       final path = file.thumbnailPath ?? file.vaultPath;
       return OptimizedImageWidget(
         imageFile: File(path),
         fit: BoxFit.cover,
         errorWidget: _buildFilePlaceholder(file, context),
       );
+    } else if (file.isEncrypted) {
+      return EncryptedThumbnail(file: file);
     } else if (file.thumbnailPath != null) {
       return OptimizedImageWidget(
         imageFile: File(file.thumbnailPath!),

--- a/lib/widgets/media_hold_action_sheet.dart
+++ b/lib/widgets/media_hold_action_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../models/vaulted_file.dart';
 import '../themes/app_colors.dart';
+import 'encrypted_thumbnail.dart';
 
 /// A contextual bottom sheet shown when long-pressing a media file.
 /// Provides quick one-tap actions without entering selection mode.
@@ -147,17 +148,29 @@ class MediaHoldActionSheet extends StatelessWidget {
 
   Widget _buildPreview(BuildContext context) {
     final size = 100.0;
-    if (file.isImage && File(file.vaultPath).existsSync()) {
-      return ClipRRect(
-        borderRadius: BorderRadius.circular(16),
-        child: Image.file(
-          File(file.vaultPath),
-          width: size,
-          height: size,
-          fit: BoxFit.cover,
-          errorBuilder: (_, __, ___) => _buildFallbackPreview(context),
-        ),
-      );
+    if (file.isImage) {
+      if (file.isEncrypted) {
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(16),
+          child: SizedBox(
+            width: size,
+            height: size,
+            child: EncryptedThumbnail(file: file),
+          ),
+        );
+      }
+      if (File(file.vaultPath).existsSync()) {
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(16),
+          child: Image.file(
+            File(file.vaultPath),
+            width: size,
+            height: size,
+            fit: BoxFit.cover,
+            errorBuilder: (_, __, ___) => _buildFallbackPreview(context),
+          ),
+        );
+      }
     }
     return _buildFallbackPreview(context);
   }

--- a/lib/widgets/permission_warning_banner.dart
+++ b/lib/widgets/permission_warning_banner.dart
@@ -175,16 +175,23 @@ class _PermissionWarningBannerState extends ConsumerState<PermissionWarningBanne
                     ),
                   ),
                   // Dismiss button
-                  GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        _isDismissed = true;
-                      });
-                    },
-                    child: Icon(
-                      Icons.close,
-                      color: Colors.white.withValues(alpha: 0.7),
-                      size: 20,
+                  Semantics(
+                    button: true,
+                    label: 'Dismiss warning',
+                    child: GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          _isDismissed = true;
+                        });
+                      },
+                      child: const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: Icon(
+                          Icons.close,
+                          color: Color(0xB3FFFFFF),
+                          size: 20,
+                        ),
+                      ),
                     ),
                   ),
                 ],

--- a/test/thumbnail_roundtrip_test.dart
+++ b/test/thumbnail_roundtrip_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/services/encryption_service.dart';
+
+// Verifies the crypto invariant the encrypted-thumbnail system relies on:
+// a GCM-encrypted thumb (same wire format VaultService._encryptAndStoreThumbnail
+// writes) round-trips through decryptStreamedFileToMemoryGcm, and a wrong/stale
+// key is rejected by GCM auth — which is what drives lazy regeneration after a
+// re-encrypt changes the per-file key.
+void main() {
+  final key = Uint8List.fromList(List.generate(32, (i) => i));
+  final wrongKey = Uint8List.fromList(List.generate(32, (i) => i + 1));
+  final thumbBytes = Uint8List.fromList(List.generate(2048, (i) => i & 0xFF));
+
+  test('encrypted thumbnail round-trips through the thumb decrypt path',
+      () async {
+    final tmpDir = await Directory.systemTemp.createTemp('latch_thumb_test');
+    final encPath = '${tmpDir.path}/thumb.enc';
+
+    final enc = await EncryptionService.instance
+        .encryptBytesStreamedGcm(thumbBytes, encPath, derivedKey: key);
+    expect(enc.success, true);
+    expect(enc.iv, isNotNull);
+
+    final dec = await EncryptionService.instance.decryptStreamedFileToMemoryGcm(
+      encPath,
+      enc.iv!,
+      derivedKey: key,
+    );
+    expect(dec.success, true);
+    expect(dec.data, thumbBytes);
+
+    await tmpDir.delete(recursive: true);
+  });
+
+  test('stale thumb (wrong key) is rejected → triggers lazy regeneration',
+      () async {
+    final tmpDir = await Directory.systemTemp.createTemp('latch_thumb_stale');
+    final encPath = '${tmpDir.path}/thumb.enc';
+
+    final enc = await EncryptionService.instance
+        .encryptBytesStreamedGcm(thumbBytes, encPath, derivedKey: key);
+    expect(enc.success, true);
+
+    final dec = await EncryptionService.instance.decryptStreamedFileToMemoryGcm(
+      encPath,
+      enc.iv!,
+      derivedKey: wrongKey,
+    );
+    expect(dec.success, false);
+
+    await tmpDir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
# Summary

Adds encrypted thumbnail generation during file import with in-memory caching (FIFO eviction), lazy regeneration on cache miss, and display across all vault screens. Thumbnails are GCM-encrypted with per-file derived keys for stale detection after key rotation.

# Changes

## Encrypted Thumbnails

- Generate encrypted thumbnails during file import for images and videos
- Cache thumbnails in memory with FIFO eviction
- Lazy-regenerate on cache miss
- GCM-encrypt with per-file derived key for stale detection after key rotation
- Single-flight lock prevents OOM from concurrent full-decrypts in grid views
- Clear cache on vault logout
- Add encrypted thumbnail widget for vaulted files
- Show encrypted thumbnails across all screens: gallery vault, favorites, tags, and image previews

## Data Model

- Add `thumbnailIv` field to `VaultedFile` model

## Testing

- Add thumbnail roundtrip tests for GCM encryption invariants

## UI

- Replace `BackdropFilter` with `AnimatedContainer` and add haptic feedback
- Refactor local backup screen for consistency and progress tracking
- Add accessibility label and larger tap target to dismiss button