### PR TITLE
Fix ReorderableListView reorder logic and add missing final modifiers

### DIFF
--- a/lib/screens/folder_detail_screen.dart
+++ b/lib/screens/folder_detail_screen.dart
@@ -1636,7 +1636,7 @@ class _FolderImportPickerScreen extends StatefulWidget {
 
 class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
   String? _currentPath;
-  List<String> _pathStack = [];
+  final List<String> _pathStack = [];
   List<FileSystemEntity> _subdirs = [];
   bool _isLoading = true;
   String? _error;

--- a/lib/screens/folders_screen.dart
+++ b/lib/screens/folders_screen.dart
@@ -916,7 +916,7 @@ class _FolderImportPickerScreen extends StatefulWidget {
 
 class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
   String? _currentPath;
-  List<String> _pathStack = [];
+  final List<String> _pathStack = [];
   List<FileSystemEntity> _subdirs = [];
   bool _isLoading = true;
   String? _error;

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -641,11 +641,10 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
                     buildDefaultDragHandles: false,
                     padding: const EdgeInsets.symmetric(vertical: 8),
                     itemCount: order.length,
-                    onReorder: (oldIndex, newIndex) {
+                    onReorderItem: (oldIndex, newIndex) {
                       apply(setSheetState, () {
-                        final to = newIndex > oldIndex ? newIndex - 1 : newIndex;
                         final item = order.removeAt(oldIndex);
-                        order.insert(to, item);
+                        order.insert(newIndex, item);
                       });
                     },
                     itemBuilder: (context, i) {
@@ -4321,7 +4320,7 @@ class _FolderImportPickerScreen extends StatefulWidget {
 
 class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
   String? _currentPath;
-  List<String> _pathStack = [];
+  final List<String> _pathStack = [];
   List<FileSystemEntity> _subdirs = [];
   bool _isLoading = true;
   String? _error;


### PR DESCRIPTION
# Summary

Fixes the `ReorderableListView` reorder logic and adds a missing `final` modifier to `_pathStack` for correctness.

# Changes

- Fix `ReorderableListView` reorder logic
- Make `_pathStack` final