### PR TITLE
Split VaultService into facade over domain services with centralized VaultStore

### DIFF
--- a/docs/refactor_roadmap.md
+++ b/docs/refactor_roadmap.md
@@ -1,0 +1,301 @@
+# Latch Refactor & Hardening Roadmap
+
+Born from an architecture + security audit (2026-07). Phases are ordered
+by dependency. Phases 0 and 1 are independent and shippable immediately.
+Phase 2 unblocks Phase 4. Phase 3 is independent of Phase 2. Phase 5
+(tests) weaves through all of them.
+
+## Locked decisions
+
+- **Lockout default (Phase 0.1):** `failedUnlockProtectionEnabled = true`
+  for **new installs only**. Existing users' stored setting is preserved
+  because `toJson` already writes the field explicitly; the `fromJson`
+  fallback only applies to absent keys.
+- **Service wiring (Phase 2):** **constructor injection**. Each split
+  service takes its dependencies via the constructor and is
+  Riverpod-provided. This makes Phase 4 (dropping singletons) nearly free.
+  First step of Phase 2 is auditing every `.instance` call site.
+
+## Execution order
+
+```
+Week 1:  Phase 0 (ship) + Phase 1 (ship), in parallel
+         Phase 5 tests for these land first
+Week 2-3: Phase 2 (vault_service split) + Phase 3 (screen split), parallel
+Week 4:   Phase 4 (Riverpod) — cheap once services are split
+```
+
+---
+
+## Phase 0 — Quick hardening (low risk)
+
+| # | Change | Location | Status |
+|---|---|---|---|
+| 0.1 | Default `failedUnlockProtectionEnabled = true` (new installs only) | `services/vault_service.dart:3093`, `:3197` | **Done** |
+| 0.3 | Fix stale doc comment "AES-256-CBC with PKCS7" → GCM/CTR | `services/encryption_service.dart:23-24` | **Done** |
+| 0.2 | ~~`evictCachedKeys()` wired to lock/logout~~ | — | **Dropped** |
+| 0.4 | ~~Dispose dialog `TextEditingController`s~~ | — | **Dropped** |
+
+**Why 0.2 was dropped:** there is **no in-session lock flow**. The app
+unlocks once at `UnlockScreen`, stays unlocked for the process, and
+"auto-kill" = the OS kills the whole process on background (memory
+reclaimed automatically). There is no "lock now" button, no
+relock-on-background, no relock timer — so `evictCachedKeys()` would have
+**no caller** (YAGNI). `resetKeys()` (`encryption_service.dart:1873`)
+remains the nuclear wipe path. **Re-add `evictCachedKeys()` only when an
+in-session lock/relock feature lands** (lock-now button, app-inactive
+timer, or relock-on-background).
+
+**Why 0.4 was dropped:** the flagged controllers are **local ephemeral**
+variables inside dialog methods, not fields. When the dialog closes and
+the method returns, they become unreachable and are GC'd cleanly —
+`TextEditingController`'s listener is removed when its `TextField`
+disposes. Not a real leak. The only field controller
+(`unlock_screen._passwordController`) is already disposed correctly.
+
+**0.1 correctness:** `_loadSettings()` (`vault_service.dart:417`) builds a
+fresh `const VaultSettings()` when storage is empty (new installs →
+constructor default `true`) and reads `VaultSettings.fromJson(...)` when
+JSON exists (existing users' explicit `false` is preserved; the `?? true`
+fallback only hits pre-feature installs whose blob lacks the key).
+
+**Verify:** `flutter analyze`, unlock a few times (confirm lockout kicks
+in at 5 attempts on a fresh install), decrypt roundtrip after lock→unlock.
+
+---
+
+## Phase 1 — Move heavy work off the main isolate ✅ DONE
+
+### 1a. Legacy main-isolate streaming crypto — LEAVE (verified already isolated)
+`encryption_service.dart:418, 492, 548, 725, 890, 1144, 1214`. Caller audit:
+- **Full-file viewing** (`getVaultedFile` :1209) already routes modern
+  **GCM/CTR files → `decryptFileInIsolate`** (crypto pool, off main). Only
+  **legacy CBC files** (`format==0||3`) hit the main-isolate `decryptFile`.
+  CBC is a diminishing legacy format; the fix is migration (re-encrypt →
+  GCM), not isolate-ifying a dead format.
+- **Notes/passwords** (`note_service`, `password_service`) — tiny text
+  blobs; `compute()` spawn cost (~50ms+) exceeds the sub-ms crypto.
+- **Thumbnails** (`vault_service:1326`) — small images, serialized by
+  `_thumbGenLock`.
+
+No change. The risk section below already called this out.
+
+### 1b. `compression_service` image resize — DONE
+Swapped sync `BicubicResizer.resizeJpeg` → isolate-backed
+`resizeJpegAsync` (the package ships the `Isolate.run` wrapper; FFI
+`DynamicLibrary.open` works per-isolate, proven by the package's own
+`getImageInfoAsync`). One-line change at `:62`. This is on the import hot
+path (`vault_service:678`). Video path (ffmpeg subprocess) unchanged —
+already off-thread.
+
+### 1c. `office_converter_service` off main — DONE
+`convertToPdf` now runs the ZIP-decode + XML-parse + Syncfusion PDF layout
+in `Isolate.run`. Made the 7 heavy private methods `static` (no `this`
+capture sent across). `rootBundle.load` (platform-channel, unavailable in
+isolate) replaced by a main-isolate font pre-load (`_loadFontBytes`, cached)
+passed into the worker as `Uint8List? fontBytes`. docx/odt/rtf only.
+
+### 1d. `backup_service` ZIP building — LEAVE (disk-safety design)
+The expensive part (decryption per file) already runs in the crypto isolate
+pool. The remaining main-thread work is `ZipFileEncoder.addFile` deflate.
+Moving it to an isolate requires staging *all* decrypted files on disk
+simultaneously (doubles transient disk usage) or a complex incremental
+delegate. The current streaming design (decrypt → stage → zip → delete per
+file) **bounds disk usage** — a safety property for a vault that can hold
+GB. Keeping it; re-evaluate if backup jank is reported on very large vaults.
+
+**Verify:** `flutter analyze` = No issues. `flutter test` = 52/52 passed.
+Profile-mode timeline validation deferred to a device session.
+
+**Risk (realized):** `compute()`/`Isolate.run` has message-copy overhead —
+net negative for tiny payloads. Confirmed why note/password encryption
+stays on main.
+
+---
+
+## Phase 2 — Split `vault_service.dart` (was 3209L, 101 methods) ✅ DONE
+
+Keystone refactor. Phase 4 depends on it. Result: `vault_service.dart`
+3034L → 534L facade wrapping 8 split services + 1 state holder. All 72
+tests pass, `flutter analyze` clean.
+
+### Steps
+
+| Step | Status | Detail |
+|---|---|---|
+| 2.1 Data classes → `models/` | **Done** | `VaultSettings` → `models/vault_settings.dart`; `FileToVault` + `FolderImportResult` → `models/file_to_vault.dart`. `vault_service.dart` trimmed 3209→3019 lines. 6 callers updated with model imports. `flutter analyze` clean, 52 tests pass. |
+| 2.2 Behavioral test net | **Done** | 20 tests in `test/vault_service_test.dart`: settings (defaults, persist+reload, fromJson), albums (cross-mutation, delete, remove, favorites), folders (create, addFile, **deleteFolder clears folderId**), tags (add, remove), favorites (toggle, filter), search (by name, by tag), sort (name, date), stats (counts, storage), clearVault. Mocks secure storage + path provider via MethodChannel. `flutter analyze` clean, 72 tests pass. |
+| 2.3 Bug fix | **Done** | `VaultedFile.removeFromFolder()` (`vaulted_file.dart:252`) was broken — `copyWith(folderId: null)` is a no-op because copyWith uses `??` (treats null as "not provided"). Fixed with JSON round-trip that correctly nulls folderId. **Genuine production bug**: files kept orphaned folderIds after folder deletion/removal. |
+| 2.4 Extract `VaultStore` | **Done** | `services/vault_store.dart` (~340L). Owns `FlutterSecureStorage`, all `cached*` public fields, `vaultDirectory`/`decoyDirectory`, all `load*`/`save*` methods, `ensureVaultDirectory`/`ensureDecoyDirectory`, `streamCopyFile`, `deleteFileIfExists`, `getFileSizeIfExists`, `generateVaultFilename`, `getSubdirectory`, `read`/`write`/`delete` (secure storage passthrough), `reloadAll`, `wipe`. Static key constants exported: `vaultIndexKey`, `decoyIndexKey`, `albumsKey`, `tagsKey`, `settingsKey`, `foldersKey`, `reEncryptJournalKey`, `vaultFolderName`, `decoyFolderName`. Fields public (dropped `_` prefix). |
+| 2.5 Extract domain services | **Done** | 8 new service files (see "New files" below). Each takes `VaultStore` + deps via constructor. `FileProgressInfo` kept public (used by `file_import_service`). `_deriveKeyForFile` → public `deriveKeyForFile` (called by `ThumbnailService`). `_StoredThumb` → public `StoredThumb`. `_updateTagUsage` → public `updateTagUsage` (called by `FileService` via late wire). File↔Thumbnail construction cycle broken with `late FileService fileService` field set by `VaultService._wire()` post-construction. Album↔File cycle broken with late-bound `removeFileFromAlbumFn` function ref on `FileService`. |
+| 2.6 `VaultService` facade + verify | **Done** | `vault_service.dart` (534L) composes 8 services, forwards ~100 public methods. `_wire()` called from `initialize()` and `loadIndexesForTesting()`. `sortFiles` kept inline (pure, no deps). `clearVault` = `_store.wipe` + `clearThumbnailCache`. `refresh` = atomic reload into `cached*` fields. `flutter analyze lib/` = No issues found. `flutter test` = 72/72 passed. |
+
+### Key finding: deeper coupling than the roadmap assumed
+
+The original plan assumed clean comment-banner seams. **Reality**: all
+caches (`_cachedFiles` ×25 refs, `_cachedAlbums` ×28, `_cachedFolders`
+×40, `_cachedTags` ×29, `_cachedSettings` ×22) are read **inline** across
+every seam. Even `SettingsService` isn't independent — file ops read
+`_cachedSettings?.encryptionEnabled / .compressionEnabled / .secureDelete`
+inline (lines 552, 576, 676, 706, 716, 966, 1020, 1091, 2566, 2668). No
+single service extracts cleanly without a shared state holder first.
+This is why `VaultStore` (2.4) had to land before any domain service.
+
+### Approach (locked, as executed)
+
+Centralize state into a `VaultStore` (owns `_storage`, directories,
+all `_cached*` maps, all `_load*`/`_save*` methods,
+`_ensureVaultDirectory`). Domain services depend on `VaultStore` +
+`EncryptionService` via constructor. `VaultService` becomes a thin
+facade composing all services + forwarding method calls, preserving
+`VaultService.instance` so the 11 direct callers + providers don't
+break. Phase 4 (Riverpod) removes the facade. Pattern = strangler fig.
+
+### New files this phase
+
+```
+lib/services/vault_store.dart          ~340L (state + persistence + dir methods)
+lib/services/file_service.dart        ~1400L (file CRUD, import, export, re-encrypt, notes/password)
+lib/services/thumbnail_service.dart    ~185L (encrypted thumbnails)
+lib/services/album_service.dart        ~250L (album CRUD + cross-mutation)
+lib/services/folder_service.dart       ~310L (folder CRUD + importDeviceFolder)
+lib/services/tag_service.dart          ~170L (tag + favorites ops)
+lib/services/search_service.dart        ~55L (read-only search)
+lib/services/settings_service.dart      ~25L (settings load/save)
+lib/services/stats_service.dart         ~25L (read-only stats)
+```
+
+### Files changed this phase
+
+```
+lib/models/vault_settings.dart         NEW (2.1)
+lib/models/file_to_vault.dart          NEW (2.1)
+lib/models/vaulted_file.dart           removeFromFolder() bug fix (2.3)
+lib/services/vault_store.dart          NEW (2.4)
+lib/services/settings_service.dart     NEW (2.4)
+lib/services/stats_service.dart        NEW (2.4)
+lib/services/search_service.dart       NEW (2.4)
+lib/services/album_service.dart        NEW (2.5)
+lib/services/folder_service.dart       NEW (2.5)
+lib/services/tag_service.dart          NEW (2.5)
+lib/services/file_service.dart         NEW (2.5)
+lib/services/thumbnail_service.dart    NEW (2.5)
+lib/services/vault_service.dart        3034→534L facade (2.6)
+test/vault_service_test.dart           NEW (2.2, 20 tests)
+lib/services/auth_service.dart         vault_settings import added (2.1)
+lib/providers/vault_providers.dart     vault_settings import added (2.1)
+lib/services/file_import_service.dart  file_to_vault import added (2.1)
+lib/screens/encryption_settings_screen.dart  vault_settings import added (2.1)
+lib/screens/vault_settings_screen.dart       vault_settings import added (2.1)
+```
+
+### Cycle-breaking notes
+
+- **File↔Thumbnail**: `ThumbnailService` constructor takes no
+  `FileService`; `VaultService._wire()` sets
+  `_thumbnails.fileService = _files` after both exist. Neither reads
+  the other during construction, only at runtime.
+- **File↔Tag**: `FileService` calls
+  `_tags.updateTagUsage(...)` during import via a late-bound function
+  ref (`_files.updateTagUsage`) set by `_wire()`.
+- **File↔Album**: `FileService.removeFile` calls
+  `_albums.removeFileFromAlbum(fileId, albumId)` via a late-bound
+  function ref (`_files.removeFileFromAlbumFn`) set by `_wire()`.
+- `_wire()` is guarded by `bool _wired`, called once from
+  `initialize()` (end) and `loadIndexesForTesting()` (start).
+
+**Risk (realized):** ~200 cache-field references rewritten; test net
+caught behavioral regressions that `flutter analyze` couldn't (cache
+consistency, missing forwarding, state init bugs). Album/folder/tag
+logic covered by 20 tests. All 72 tests pass post-split.
+
+---
+
+## Phase 3 — Split `gallery_vault_screen.dart` (4557L) (~3-4 days, independent of Phase 2)
+
+### 3a. Collapse the 10 `_importXxx` methods → one parameterized importer
+`_importImagesFromGallery`, `_importVideosFromGallery`,
+`_importMediaFromGallery`, `_importDocuments`, `_importSongs`,
+`_importAnyFiles`, `_importFolderFromDevice`, … → one
+`_import({required VaultCategory category, required ImportSource source})`.
+Biggest single win in the file.
+
+### 3b. Extract sheets to `widgets/`
+Each `_showXxxSheet` builds a sheet inline. Move to widget files:
+- `_showMultiSelectActionSheet` (`:1134`)
+- `_showFileOptionsSheet` (`:1458`)
+- `_showAddToAlbumSheet` (`:2413`)
+- `_showAddTagsSheet` (`:2519`, 476L)
+- `_showCustomizeBarSheet` (`:555`)
+- `_showSortOptions` (`:2340`)
+- `_showDecoyModeSheet` (`:3004`)
+- `_showSetDecoyPinDialog` (`:3132`, **902 lines** — promote to its own screen/dialog)
+- `media_hold_action_sheet.dart` already exists at 345L — delegate to it
+
+### 3c. Extract drawer
+`_buildDrawer` (`:1965`) + header/section/item helpers →
+`widgets/app_drawer.dart`. Self-contained.
+
+### 3d. Extract customize bar
+`_buildBottomBar`, `_buildImportBarItem`, `_buildCategoryItem` →
+`widgets/customize_bar.dart`.
+
+**Target after 3a–3d:** screen is ~800–1200 lines (grid + state + delegation).
+
+**Verify:** manual walkthrough of every import source, sheet, drawer,
+multi-select, decoy setup. Widget smoke test that mounts the screen.
+
+**Risk:** screen holds lots of `ConsumerState` state (selection, sliding
+selection, current tab). Extracted widgets take callbacks + read
+providers directly; keep state in parent, pass callbacks.
+
+---
+
+## Phase 4 — Riverpod modernization (~2-3 days, depends on Phase 2)
+
+**Problem:** 12 hand-rolled `instance` singletons wrapped in providers
+that just re-expose them. Pay singleton cost (global state, untestable)
++ provider cost (indirection) with neither's benefit.
+
+**Approach:**
+1. Each split service (from Phase 2) becomes Riverpod-provided with
+   constructor deps:
+   ```dart
+   final fileServiceProvider = Provider((ref) =>
+     FileService(ref.read(encryptionServiceProvider)));
+   ```
+2. Delete `instance = X._()` from all 12 services.
+3. Migrate `flutter_riverpod/legacy.dart` → modern `Notifier` API.
+   Replace `StateProvider<int>` for sort/filter with `Notifier<int>`
+   where state has business meaning; keep `StateProvider` for trivial
+   ephemeral UI flags only.
+4. Remove the legacy import from all provider files.
+
+**Verify:** `flutter analyze` clean (no legacy import warnings). Each
+provider testable with an injected fake.
+
+**Risk:** services currently relying on `VaultService.instance` from
+non-widget code (isolates, MethodChannel handlers, `main.dart`) need the
+provider container or a top-level `ProviderContainer`. Audit before
+migrating.
+
+---
+
+## Phase 5 — Test suite (ongoing, weaves through all phases)
+
+Current: 8 test files, crypto-only. No tests for services, providers, or
+screens.
+
+**Priority order:**
+1. **Phase 0/1 tests first** — lock/evict roundtrip, compression-in-isolate
+   parity, office-convert output equality. Lock in behavior *before*
+   refactoring.
+2. **Phase 2 tests** — one test per split service, primary method
+   (create/get/delete roundtrip). Regression net during the split.
+3. **Phase 3 tests** — widget smoke test for the screen + one test per
+   extracted sheet/dialog.
+4. **Phase 4 tests** — provider tests with overridden fakes.
+
+**Test discipline:** no per-method suites, no fixtures unless needed. One
+test per public method's happy path + one failure path for anything
+security-touching. Don't build a test framework.

--- a/lib/models/file_to_vault.dart
+++ b/lib/models/file_to_vault.dart
@@ -1,0 +1,39 @@
+import 'vaulted_file.dart';
+import 'vault_folder.dart';
+import 'encryption_algorithm.dart';
+
+/// Helper class for batch file import
+class FileToVault {
+  final String sourcePath;
+  final String originalName;
+  final VaultedFileType type;
+  final String mimeType;
+  final bool? encrypt;
+  final EncryptionAlgorithm? encryptionAlgorithm;
+  final int? kdfIterations;
+
+  const FileToVault({
+    required this.sourcePath,
+    required this.originalName,
+    required this.type,
+    required this.mimeType,
+    this.encrypt,
+    this.encryptionAlgorithm,
+    this.kdfIterations,
+  });
+}
+
+/// Result of importing a device folder
+class FolderImportResult {
+  final int foldersCreated;
+  final int filesImported;
+  final List<String> errors;
+  final VaultFolder? rootFolder;
+
+  const FolderImportResult({
+    required this.foldersCreated,
+    required this.filesImported,
+    this.errors = const [],
+    this.rootFolder,
+  });
+}

--- a/lib/models/vault_settings.dart
+++ b/lib/models/vault_settings.dart
@@ -1,0 +1,156 @@
+import 'encryption_algorithm.dart';
+import 'album.dart';
+
+/// Vault settings
+class VaultSettings {
+  final bool encryptionEnabled;
+  final EncryptionAlgorithm encryptionAlgorithm;
+  final int kdfIterations;
+  final bool secureDelete;
+  final bool screenshotProtectionEnabled;
+  final int autoKillDelaySeconds;
+  final SortOption defaultSort;
+  final bool showHiddenFiles;
+  final bool autoBackup;
+  final int? maxStorageMB;
+  final bool decoyModeEnabled;
+  final String? decoyPin;
+  final bool compressionEnabled;
+  final bool failedUnlockProtectionEnabled;
+  final int maxFailedAttemptsBeforeLockout;
+  final int lockoutDurationSeconds;
+  final bool wipeVaultOnMaxFailedAttempts;
+  final int maxFailedAttemptsBeforeWipe;
+  final bool showPermissionWarning;
+
+  const VaultSettings({
+    this.encryptionEnabled = false,
+    this.encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
+    this.kdfIterations = 600000,
+    this.secureDelete = true,
+    this.screenshotProtectionEnabled = false,
+    this.autoKillDelaySeconds = 0,
+    this.defaultSort = SortOption.dateAddedNewest,
+    this.showHiddenFiles = false,
+    this.autoBackup = false,
+    this.maxStorageMB,
+    this.decoyModeEnabled = false,
+    this.decoyPin,
+    this.compressionEnabled = false,
+    this.failedUnlockProtectionEnabled = true,
+    this.maxFailedAttemptsBeforeLockout = 5,
+    this.lockoutDurationSeconds = 30,
+    this.wipeVaultOnMaxFailedAttempts = false,
+    this.maxFailedAttemptsBeforeWipe = 12,
+    this.showPermissionWarning = true,
+  });
+
+  VaultSettings copyWith({
+    bool? encryptionEnabled,
+    EncryptionAlgorithm? encryptionAlgorithm,
+    int? kdfIterations,
+    bool? secureDelete,
+    bool? screenshotProtectionEnabled,
+    int? autoKillDelaySeconds,
+    SortOption? defaultSort,
+    bool? showHiddenFiles,
+    bool? autoBackup,
+    int? maxStorageMB,
+    bool? decoyModeEnabled,
+    String? decoyPin,
+    bool? compressionEnabled,
+    bool? failedUnlockProtectionEnabled,
+    int? maxFailedAttemptsBeforeLockout,
+    int? lockoutDurationSeconds,
+    bool? wipeVaultOnMaxFailedAttempts,
+    int? maxFailedAttemptsBeforeWipe,
+    bool? showPermissionWarning,
+  }) {
+    return VaultSettings(
+      encryptionEnabled: encryptionEnabled ?? this.encryptionEnabled,
+      encryptionAlgorithm: encryptionAlgorithm ?? this.encryptionAlgorithm,
+      kdfIterations: kdfIterations ?? this.kdfIterations,
+      secureDelete: secureDelete ?? this.secureDelete,
+      screenshotProtectionEnabled:
+          screenshotProtectionEnabled ?? this.screenshotProtectionEnabled,
+      autoKillDelaySeconds: autoKillDelaySeconds ?? this.autoKillDelaySeconds,
+      defaultSort: defaultSort ?? this.defaultSort,
+      showHiddenFiles: showHiddenFiles ?? this.showHiddenFiles,
+      autoBackup: autoBackup ?? this.autoBackup,
+      maxStorageMB: maxStorageMB ?? this.maxStorageMB,
+      decoyModeEnabled: decoyModeEnabled ?? this.decoyModeEnabled,
+      decoyPin: decoyPin ?? this.decoyPin,
+      compressionEnabled: compressionEnabled ?? this.compressionEnabled,
+      failedUnlockProtectionEnabled:
+          failedUnlockProtectionEnabled ?? this.failedUnlockProtectionEnabled,
+      maxFailedAttemptsBeforeLockout:
+          maxFailedAttemptsBeforeLockout ?? this.maxFailedAttemptsBeforeLockout,
+      lockoutDurationSeconds:
+          lockoutDurationSeconds ?? this.lockoutDurationSeconds,
+      wipeVaultOnMaxFailedAttempts:
+          wipeVaultOnMaxFailedAttempts ?? this.wipeVaultOnMaxFailedAttempts,
+      maxFailedAttemptsBeforeWipe:
+          maxFailedAttemptsBeforeWipe ?? this.maxFailedAttemptsBeforeWipe,
+      showPermissionWarning:
+          showPermissionWarning ?? this.showPermissionWarning,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'encryptionEnabled': encryptionEnabled,
+        'encryptionAlgorithm': encryptionAlgorithm.name,
+        'kdfIterations': kdfIterations,
+        'secureDelete': secureDelete,
+        'screenshotProtectionEnabled': screenshotProtectionEnabled,
+        'autoKillDelaySeconds': autoKillDelaySeconds,
+        'defaultSort': defaultSort.name,
+        'showHiddenFiles': showHiddenFiles,
+        'autoBackup': autoBackup,
+        'maxStorageMB': maxStorageMB,
+        'decoyModeEnabled': decoyModeEnabled,
+        'decoyPin': decoyPin,
+        'compressionEnabled': compressionEnabled,
+        'failedUnlockProtectionEnabled': failedUnlockProtectionEnabled,
+        'maxFailedAttemptsBeforeLockout': maxFailedAttemptsBeforeLockout,
+        'lockoutDurationSeconds': lockoutDurationSeconds,
+        'wipeVaultOnMaxFailedAttempts': wipeVaultOnMaxFailedAttempts,
+        'maxFailedAttemptsBeforeWipe': maxFailedAttemptsBeforeWipe,
+        'showPermissionWarning': showPermissionWarning,
+      };
+
+  factory VaultSettings.fromJson(Map<String, dynamic> json) {
+    return VaultSettings(
+      encryptionEnabled: json['encryptionEnabled'] as bool? ?? false,
+      encryptionAlgorithm: EncryptionAlgorithm.values.firstWhere(
+        (a) => a.name == (json['encryptionAlgorithm'] as String? ?? 'aes256Gcm'),
+        orElse: () => EncryptionAlgorithm.aes256Gcm,
+      ),
+      kdfIterations: json['kdfIterations'] as int? ?? 600000,
+      secureDelete: json['secureDelete'] as bool? ?? true,
+      screenshotProtectionEnabled:
+          json['screenshotProtectionEnabled'] as bool? ?? false,
+      autoKillDelaySeconds: json['autoKillDelaySeconds'] as int? ?? 0,
+      defaultSort: SortOption.values.firstWhere(
+        (s) => s.name == (json['defaultSort'] as String? ?? 'dateAddedNewest'),
+        orElse: () => SortOption.dateAddedNewest,
+      ),
+      showHiddenFiles: json['showHiddenFiles'] as bool? ?? false,
+      autoBackup: json['autoBackup'] as bool? ?? false,
+      maxStorageMB: json['maxStorageMB'] as int?,
+      decoyModeEnabled: json['decoyModeEnabled'] as bool? ?? false,
+      decoyPin: json['decoyPin'] as String?,
+      compressionEnabled: json['compressionEnabled'] as bool? ?? false,
+      failedUnlockProtectionEnabled:
+          json['failedUnlockProtectionEnabled'] as bool? ?? true,
+      maxFailedAttemptsBeforeLockout:
+          json['maxFailedAttemptsBeforeLockout'] as int? ?? 5,
+      lockoutDurationSeconds: json['lockoutDurationSeconds'] as int? ?? 30,
+      wipeVaultOnMaxFailedAttempts:
+          json['wipeVaultOnMaxFailedAttempts'] as bool? ?? false,
+      maxFailedAttemptsBeforeWipe:
+          json['maxFailedAttemptsBeforeWipe'] as int? ?? 12,
+      showPermissionWarning:
+          json['showPermissionWarning'] as bool? ?? true,
+    );
+  }
+}

--- a/lib/models/vaulted_file.dart
+++ b/lib/models/vaulted_file.dart
@@ -250,10 +250,10 @@ class VaultedFile {
 
   /// Remove from folder
   VaultedFile removeFromFolder() {
-    return copyWith(
-      folderId: null,
-      dateModified: DateTime.now(),
-    );
+    final map = toJson();
+    map['folderId'] = null;
+    map['dateModified'] = DateTime.now().toIso8601String();
+    return VaultedFile.fromJson(map);
   }
 
   /// Check if file has a specific tag

--- a/lib/providers/vault_providers.dart
+++ b/lib/providers/vault_providers.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/legacy.dart';
 import '../models/album.dart';
 import '../models/vault_folder.dart';
 import '../models/vaulted_file.dart';
+import '../models/vault_settings.dart';
 import '../services/vault_service.dart';
 import '../services/decoy_service.dart';
 import '../services/encryption_service.dart';

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -581,6 +581,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
                 blurRadius: 10,
                 offset: const Offset(0, 2),
               ),
+              scrollPhysics: const ClampingScrollPhysics(),
               viewerOverlayBuilder: (context, size, handleLinkTap) => [
                 PdfViewerScrollThumb(
                   controller: _pdfController!,
@@ -627,6 +628,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
           blurRadius: 10,
           offset: const Offset(0, 2),
         ),
+        scrollPhysics: const ClampingScrollPhysics(),
         viewerOverlayBuilder: (context, size, handleLinkTap) => [
           PdfViewerScrollThumb(
             controller: _pdfController!,

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -581,6 +581,13 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
                 blurRadius: 10,
                 offset: const Offset(0, 2),
               ),
+              viewerOverlayBuilder: (context, size, handleLinkTap) => [
+                PdfViewerScrollThumb(
+                  controller: _pdfController!,
+                  thumbBuilder: (context, thumbSize, pageNumber, controller) =>
+                      _buildScrollThumb(thumbSize, pageNumber),
+                ),
+              ],
               onViewerReady: (document, controller) {
                 setState(() {
                   _totalPages = document.pages.length;
@@ -620,6 +627,13 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
           blurRadius: 10,
           offset: const Offset(0, 2),
         ),
+        viewerOverlayBuilder: (context, size, handleLinkTap) => [
+          PdfViewerScrollThumb(
+            controller: _pdfController!,
+            thumbBuilder: (context, thumbSize, pageNumber, controller) =>
+                _buildScrollThumb(thumbSize, pageNumber),
+          ),
+        ],
         onViewerReady: (document, controller) {
           setState(() {
             _totalPages = document.pages.length;
@@ -735,6 +749,35 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
             ],
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildScrollThumb(Size thumbSize, int? pageNumber) {
+    return Container(
+      width: thumbSize.width,
+      height: thumbSize.height,
+      decoration: BoxDecoration(
+        color: context.backgroundColor,
+        borderRadius: BorderRadius.circular(5),
+        border: Border.all(color: context.dividerColor),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.2),
+            blurRadius: 4,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Center(
+        child: Text(
+          pageNumber?.toString() ?? '',
+          style: TextStyle(
+            fontSize: 12,
+            color: context.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -9,6 +9,7 @@ import '../models/vaulted_file.dart';
 import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
 import '../services/office_converter_service.dart';
+import '../services/vault_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 import '../widgets/conversion_warning_dialog.dart';
@@ -85,7 +86,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
 
   void _cleanupTempFiles() {
     try {
-      ref.read(vaultServiceProvider).cleanupTemp();
+      VaultService.instance.cleanupTemp();
     } catch (e) {
       debugPrint('Error cleaning up temp files: $e');
     }

--- a/lib/screens/encryption_settings_screen.dart
+++ b/lib/screens/encryption_settings_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/encryption_algorithm.dart';
+import '../models/vault_settings.dart';
 import '../providers/vault_providers.dart';
-import '../services/vault_service.dart';
 import '../themes/app_colors.dart';
 import 'encryption_manage_screen.dart';
 import 're_encrypt_file_picker_screen.dart';

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -3722,18 +3722,46 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
           (encrypt: s.encrypt, algorithm: s.algorithm);
     }
 
-    setState(() {
-      _isImporting = true;
-      _importProgress = 0;
-      _importTotal = selectedDocuments.length;
-    });
+    final progressState = ValueNotifier<OperationProgressState>(
+      OperationProgressState(
+        totalFiles: selectedDocuments.length,
+        currentFile: 0,
+        currentFileName: 'Preparing...',
+        totalSizeBytes: 0,
+        processedSizeBytes: 0,
+        statusMessage: 'Starting...',
+        isProcessing: true,
+      ),
+    );
+
+    if (!mounted) return;
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isDismissible: false,
+      enableDrag: false,
+      builder: (context) => ValueListenableBuilder<OperationProgressState>(
+        valueListenable: progressState,
+        builder: (context, state, _) => OperationProgressSheet(
+          operationType: OperationType.hide,
+          totalFiles: state.totalFiles,
+          currentFile: state.currentFile,
+          currentFileName: state.currentFileName,
+          totalSizeBytes: state.totalSizeBytes,
+          processedSizeBytes: state.processedSizeBytes,
+          statusMessage: state.statusMessage,
+          isProcessing: state.isProcessing,
+          isComplete: state.isComplete,
+          isEncrypting: state.isEncrypting,
+        ),
+      ),
+    );
 
     final result = await _importService.importFromDocumentFilesWithConversion(
       filePaths: selectedDocuments.map((d) => d.path).toList(),
       deleteOriginals: true,
       perFileEncryption: perFileEncryption,
       onConversionConfirmation: (officeFiles) async {
-        if (!mounted) return false;
         final confirmed = await showDialog<bool>(
           context: context,
           barrierDismissible: false,
@@ -3746,18 +3774,34 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
         return confirmed ?? false;
       },
       onProgress: (current, total) {
-        if (!mounted) return;
-        setState(() {
-          _importProgress = current;
-          _importTotal = total;
-        });
+        progressState.value = progressState.value.copyWith(
+          totalFiles: total,
+          currentFile: current,
+          statusMessage: current == 0
+              ? 'Preparing files...'
+              : 'Processing file $current of $total...',
+        );
+      },
+      onFileProgress: (fileInfo) {
+        progressState.value = progressState.value.copyWith(
+          totalFiles: fileInfo.total,
+          currentFile: fileInfo.current,
+          currentFileName: fileInfo.fileName,
+          statusMessage: fileInfo.status,
+          isEncrypting: fileInfo.isEncrypting,
+          processedSizeBytes:
+              fileInfo.isEncrypting ? fileInfo.encryptedBytes : null,
+          totalSizeBytes: fileInfo.isEncrypting ? fileInfo.totalBytes : null,
+        );
       },
       onStatusUpdate: (message) {
-        debugPrint('[Import] $message');
+        progressState.value = progressState.value.copyWith(
+          statusMessage: message,
+        );
       },
     );
 
-    if (mounted) setState(() => _isImporting = false);
+    if (!mounted) return;
 
     if (result.success && result.importedCount > 0) {
       final msgBuilder =
@@ -3775,6 +3819,8 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
     } else {
       ToastUtils.showInfo('No documents imported');
     }
+
+    Navigator.pop(context);
   }
 
   Future<void> _importSongs() async {

--- a/lib/screens/media_viewer_screen.dart
+++ b/lib/screens/media_viewer_screen.dart
@@ -11,6 +11,7 @@ import 'package:video_player/video_player.dart';
 import '../models/vaulted_file.dart';
 import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
+import '../services/vault_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 import '../widgets/file_info_sheet.dart';
@@ -106,7 +107,7 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
   /// Clean up temporary decrypted files to prevent disk space leaks
   void _cleanupTempFiles() {
     try {
-      ref.read(vaultServiceProvider).cleanupTemp();
+      VaultService.instance.cleanupTemp();
     } catch (e) {
       debugPrint('Error cleaning up temp files: $e');
     }

--- a/lib/screens/song_player_screen.dart
+++ b/lib/screens/song_player_screen.dart
@@ -11,6 +11,7 @@ import '../models/vaulted_file.dart';
 import '../services/flick_integration_service.dart';
 import '../providers/vault_providers.dart';
 import '../services/auto_kill_service.dart';
+import '../services/vault_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 
@@ -64,7 +65,7 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
 
   void _cleanupTempFiles() {
     try {
-      ref.read(vaultServiceProvider).cleanupTemp();
+      VaultService.instance.cleanupTemp();
     } catch (e) {
       debugPrint('Error cleaning up temp files: $e');
     }

--- a/lib/screens/vault_settings_screen.dart
+++ b/lib/screens/vault_settings_screen.dart
@@ -12,7 +12,7 @@ import '../services/auth_service.dart';
 import '../services/auto_kill_service.dart';
 import '../services/screenshot_protection_service.dart';
 import '../services/update_service.dart';
-import '../services/vault_service.dart';
+import '../models/vault_settings.dart';
 import '../services/whats_new_service.dart';
 import '../themes/app_colors.dart';
 import '../widgets/whats_new_bottom_sheet.dart';

--- a/lib/services/album_service.dart
+++ b/lib/services/album_service.dart
@@ -1,0 +1,238 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/album.dart';
+import '../models/vaulted_file.dart';
+import 'file_service.dart';
+import 'vault_store.dart';
+
+/// Album CRUD + file↔album cross-mutation. Splits out of `VaultService`.
+///
+/// ponytail: depends on FileService for `getFileById`/`updateFile`. The
+/// reverse direction (FileService.removeFile → removeFileFromAlbum) is wired
+/// via a late setter to avoid a constructor cycle.
+class AlbumService {
+  final VaultStore _store;
+  final FileService _fileService;
+
+  AlbumService(this._store, this._fileService);
+
+  Future<List<Album>> getAllAlbums() => _store.loadAlbums();
+
+  Future<Album?> getAlbumById(String albumId) async {
+    final albums = await _store.loadAlbums();
+    try {
+      return albums.firstWhere((a) => a.id == albumId);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  Future<Album?> createAlbum({
+    required String name,
+    String? description,
+    String? coverImageId,
+  }) async {
+    try {
+      final now = DateTime.now();
+      final id = sha256
+          .convert(utf8.encode('$name${now.millisecondsSinceEpoch}'))
+          .toString()
+          .substring(0, 16);
+
+      final album = Album(
+        id: id,
+        name: name,
+        description: description,
+        coverImageId: coverImageId,
+        createdAt: now,
+        updatedAt: now,
+        sortOrder: (_store.cachedAlbums?.length ?? 0) + 1,
+      );
+
+      _store.cachedAlbums ??= [];
+      _store.cachedAlbums!.add(album);
+      await _store.saveAlbums();
+
+      return album;
+    } catch (e) {
+      debugPrint('Error creating album: $e');
+      return null;
+    }
+  }
+
+  Future<Album?> updateAlbum(Album updatedAlbum) async {
+    try {
+      final albums = await _store.loadAlbums();
+      final index = albums.indexWhere((a) => a.id == updatedAlbum.id);
+
+      if (index == -1) return null;
+
+      _store.cachedAlbums![index] = updatedAlbum.copyWith(updatedAt: DateTime.now());
+      await _store.saveAlbums();
+
+      return _store.cachedAlbums![index];
+    } catch (e) {
+      debugPrint('Error updating album: $e');
+      return null;
+    }
+  }
+
+  Future<bool> deleteAlbum(String albumId) async {
+    try {
+      final albums = await _store.loadAlbums();
+      final album = albums.firstWhere(
+        (a) => a.id == albumId,
+        orElse: () => throw Exception('Album not found'),
+      );
+
+      if (album.isDefault) {
+        debugPrint('Cannot delete default album');
+        return false;
+      }
+
+      for (final fileId in album.fileIds) {
+        final file = await _fileService.getFileById(fileId);
+        if (file != null) {
+          await _fileService.updateFile(file.removeFromAlbum(albumId));
+        }
+      }
+
+      _store.cachedAlbums!.removeWhere((a) => a.id == albumId);
+      await _store.saveAlbums();
+
+      return true;
+    } catch (e) {
+      debugPrint('Error deleting album: $e');
+      return false;
+    }
+  }
+
+  Future<bool> addFileToAlbum(String fileId, String albumId) async {
+    try {
+      final file = await _fileService.getFileById(fileId);
+      if (file == null) return false;
+
+      final albums = await _store.loadAlbums();
+      final albumIndex = albums.indexWhere((a) => a.id == albumId);
+      if (albumIndex == -1) return false;
+
+      _store.cachedAlbums![albumIndex] = _store.cachedAlbums![albumIndex].addFile(fileId);
+      await _store.saveAlbums();
+
+      VaultedFile updatedFile = file.addToAlbum(albumId);
+      if (albumId == 'favorites') {
+        updatedFile = updatedFile.copyWith(isFavorite: true);
+      }
+      await _fileService.updateFile(updatedFile);
+
+      return true;
+    } catch (e) {
+      debugPrint('Error adding file to album: $e');
+      return false;
+    }
+  }
+
+  Future<bool> addFilesToAlbum(List<String> fileIds, String albumId) async {
+    try {
+      final albums = await _store.loadAlbums();
+      final albumIndex = albums.indexWhere((a) => a.id == albumId);
+      if (albumIndex == -1) return false;
+
+      final files = await _store.loadFileIndex();
+      bool changed = false;
+
+      for (final fileId in fileIds) {
+        final fileIdx = files.indexWhere((f) => f.id == fileId);
+        if (fileIdx == -1) continue;
+
+        _store.cachedAlbums![albumIndex] = _store.cachedAlbums![albumIndex].addFile(fileId);
+
+        VaultedFile updatedFile = files[fileIdx].addToAlbum(albumId);
+        if (albumId == 'favorites') {
+          updatedFile = updatedFile.copyWith(isFavorite: true);
+        }
+        _store.cachedFiles![fileIdx] = updatedFile;
+        changed = true;
+      }
+
+      if (changed) {
+        await _store.saveAlbums();
+        await _store.saveFileIndex();
+      }
+      return true;
+    } catch (e) {
+      debugPrint('Error adding files to album: $e');
+      return false;
+    }
+  }
+
+  Future<bool> removeFilesFromAlbum(List<String> fileIds, String albumId) async {
+    try {
+      final albums = await _store.loadAlbums();
+      final albumIndex = albums.indexWhere((a) => a.id == albumId);
+      if (albumIndex == -1) return false;
+
+      final files = await _store.loadFileIndex();
+      bool changed = false;
+
+      for (final fileId in fileIds) {
+        _store.cachedAlbums![albumIndex] = _store.cachedAlbums![albumIndex].removeFile(fileId);
+
+        final fileIdx = files.indexWhere((f) => f.id == fileId);
+        if (fileIdx != -1) {
+          VaultedFile updatedFile = files[fileIdx].removeFromAlbum(albumId);
+          if (albumId == 'favorites') {
+            updatedFile = updatedFile.copyWith(isFavorite: false);
+          }
+          _store.cachedFiles![fileIdx] = updatedFile;
+        }
+        changed = true;
+      }
+
+      if (changed) {
+        await _store.saveAlbums();
+        await _store.saveFileIndex();
+      }
+      return true;
+    } catch (e) {
+      debugPrint('Error removing files from album: $e');
+      return false;
+    }
+  }
+
+  Future<bool> removeFileFromAlbum(String fileId, String albumId) async {
+    try {
+      final albums = await _store.loadAlbums();
+      final albumIndex = albums.indexWhere((a) => a.id == albumId);
+      if (albumIndex == -1) return false;
+
+      _store.cachedAlbums![albumIndex] = _store.cachedAlbums![albumIndex].removeFile(fileId);
+      await _store.saveAlbums();
+
+      final file = await _fileService.getFileById(fileId);
+      if (file != null) {
+        VaultedFile updatedFile = file.removeFromAlbum(albumId);
+        if (albumId == 'favorites') {
+          updatedFile = updatedFile.copyWith(isFavorite: false);
+        }
+        await _fileService.updateFile(updatedFile);
+      }
+
+      return true;
+    } catch (e) {
+      debugPrint('Error removing file from album: $e');
+      return false;
+    }
+  }
+
+  Future<List<VaultedFile>> getFilesInAlbum(String albumId) async {
+    final album = await getAlbumById(albumId);
+    if (album == null) return [];
+
+    final files = await _fileService.getAllFiles();
+    return files.where((f) => album.fileIds.contains(f.id)).toList();
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -13,6 +13,7 @@ import 'auto_kill_service.dart';
 import 'decoy_service.dart';
 import 'encryption_service.dart';
 import 'vault_service.dart';
+import '../models/vault_settings.dart';
 
 /// Authentication service that handles password and biometric authentication
 class AuthService {

--- a/lib/services/compression_service.dart
+++ b/lib/services/compression_service.dart
@@ -59,7 +59,10 @@ class CompressionService {
 
   Future<Uint8List?> _compressJpegKeepOriginalSize(Uint8List bytes) async {
     try {
-      final result = BicubicResizer.resizeJpeg(
+      // ponytail: resizeJpegAsync runs the native FFI pipeline in an isolate
+      // (package ships the wrapper). Keeps the decode→resize→encode off the UI
+      // thread during image import.
+      final result = await BicubicResizer.resizeJpegAsync(
         jpegBytes: bytes,
         outputWidth: 4096,
         outputHeight: 4096,

--- a/lib/services/encryption_service.dart
+++ b/lib/services/encryption_service.dart
@@ -20,8 +20,10 @@ import 'crypto_isolate_pool.dart';
 // in-memory key cache, the isolate pool, and the file streaming orchestration.
 const int _streamChunkSize = 1024 * 1024;
 
-/// AES-256 Encryption Service for secure file encryption
-/// Uses AES-256-CBC mode with PKCS7 padding
+/// AES-256 Encryption Service for secure file encryption.
+/// Default: AES-256-GCM (authenticated); AES-256-CTR is selectable.
+/// CBC is decrypt-only legacy for migration. Per-file keys via PBKDF2,
+/// master key wrapped with Argon2id.
 class EncryptionService {
   EncryptionService._();
   static final EncryptionService instance = EncryptionService._();

--- a/lib/services/file_import_service.dart
+++ b/lib/services/file_import_service.dart
@@ -9,6 +9,7 @@ import 'package:photo_manager/photo_manager.dart';
 import '../models/encryption_algorithm.dart';
 import '../models/vaulted_file.dart';
 import '../models/vault_folder.dart';
+import '../models/file_to_vault.dart';
 import 'auto_kill_service.dart';
 import 'decoy_service.dart';
 import 'media_scanner_service.dart';

--- a/lib/services/file_import_service.dart
+++ b/lib/services/file_import_service.dart
@@ -1004,6 +1004,7 @@ class FileImportService {
         onConversionConfirmation,
     bool deleteOriginals = true,
     Function(int current, int total)? onProgress,
+    Function(FileProgressInfo)? onFileProgress,
     Function(String message)? onStatusUpdate,
     Map<String, ({bool encrypt, EncryptionAlgorithm algorithm})>? perFileEncryption,
   }) async {
@@ -1091,6 +1092,13 @@ class FileImportService {
           pathsToDelete.add(path);
           processed++;
           onProgress?.call(processed, totalFiles);
+          onFileProgress?.call(FileProgressInfo(
+            current: processed,
+            total: totalFiles,
+            fileName: fileName,
+            fileSize: 0,
+            status: 'Preparing...',
+          ));
 
           debugPrint(
               '[FileImport] Prepared regular document for import: $fileName');
@@ -1125,6 +1133,13 @@ class FileImportService {
             pathsToDelete.add(officeFile.path);
             processed++;
             onProgress?.call(processed, totalFiles);
+            onFileProgress?.call(FileProgressInfo(
+              current: processed,
+              total: totalFiles,
+              fileName: officeFile.fileName,
+              fileSize: 0,
+              status: 'Preparing...',
+            ));
             continue;
           }
 
@@ -1137,6 +1152,13 @@ class FileImportService {
             skippedFiles.add(officeFile.fileName);
             processed++;
             onProgress?.call(processed, totalFiles);
+            onFileProgress?.call(FileProgressInfo(
+              current: processed,
+              total: totalFiles,
+              fileName: officeFile.fileName,
+              fileSize: 0,
+              status: 'File not found, skipping...',
+            ));
             continue;
           }
 
@@ -1196,6 +1218,13 @@ class FileImportService {
 
           processed++;
           onProgress?.call(processed, totalFiles);
+          onFileProgress?.call(FileProgressInfo(
+            current: processed,
+            total: totalFiles,
+            fileName: officeFile.fileName,
+            fileSize: 0,
+            status: result.success ? 'Converted' : 'Conversion failed, using original',
+          ));
         } catch (e) {
           debugPrint(
               '[FileImport] Error converting/importing ${officeFile.fileName}: $e');
@@ -1215,6 +1244,13 @@ class FileImportService {
           }
           processed++;
           onProgress?.call(processed, totalFiles);
+          onFileProgress?.call(FileProgressInfo(
+            current: processed,
+            total: totalFiles,
+            fileName: officeFile.fileName,
+            fileSize: 0,
+            status: 'Importing original...',
+          ));
         }
       }
 
@@ -1244,6 +1280,7 @@ class FileImportService {
         deleteOriginals: false,
         isDecoy: _decoyService.isDecoyModeActive,
         onProgress: onProgress,
+        onFileProgress: onFileProgress,
       );
 
       debugPrint('[FileImport] Imported ${imported.length} documents to vault');

--- a/lib/services/file_service.dart
+++ b/lib/services/file_service.dart
@@ -1,0 +1,1395 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../models/encryption_algorithm.dart';
+import '../models/file_to_vault.dart';
+import '../models/vaulted_file.dart';
+import 'compression_service.dart';
+import 'crypto_isolate_pool.dart';
+import 'encryption_service.dart';
+import 'thumbnail_service.dart';
+import 'vault_store.dart';
+
+class FileProgressInfo {
+  final int current;
+  final int total;
+  final String fileName;
+  final int fileSize;
+  final String status;
+  final bool isEncrypting;
+  final int encryptedBytes;
+  final int totalBytes;
+
+  const FileProgressInfo({
+    required this.current,
+    required this.total,
+    required this.fileName,
+    required this.fileSize,
+    required this.status,
+    this.isEncrypting = false,
+    this.encryptedBytes = 0,
+    this.totalBytes = 0,
+  });
+}
+
+class _PreparedVaultAddition {
+  final VaultedFile vaultedFile;
+  const _PreparedVaultAddition({required this.vaultedFile});
+}
+
+class _BatchPreparationResult {
+  final int index;
+  final FileToVault file;
+  final int fileSize;
+  final _PreparedVaultAddition? prepared;
+
+  const _BatchPreparationResult({
+    required this.index,
+    required this.file,
+    required this.fileSize,
+    required this.prepared,
+  });
+}
+
+/// File CRUD, import, export, re-encrypt, notes/password registration.
+/// Splits out of `VaultService`.
+///
+/// ponytail: the big one. Holds a back-reference to TagService (late-set,
+/// breaks the File↔Tag cycle) for tag-usage updates during import, and to
+/// AlbumService for `removeFile`'s album cleanup. The ThumbnailService is a
+/// constructor dep because thumbnail generation needs file decrypt (which
+/// lives here) so the cycle is broken by passing `this` into ThumbnailService.
+class FileService {
+  static const int _maxConcurrentBatchAdds = 3;
+
+  final VaultStore _store;
+  final EncryptionService _encryptionService;
+  final ThumbnailService _thumbnailService;
+
+  FileService(this._store, this._encryptionService, this._thumbnailService);
+
+  /// Late-bound to break a constructor cycle (TagService → FileService →
+  /// TagService for tag-usage updates on import).
+  late final Future<void> Function(List<String> tags)? updateTagUsage;
+
+  /// Late-bound so `removeFile` can clean album memberships without a
+  /// constructor cycle (AlbumService → FileService → AlbumService).
+  late final Future<bool> Function(String fileId, String albumId)?
+      removeFileFromAlbumFn;
+
+  Future<Uint8List?> deriveKeyForFile(VaultedFile file,
+      {bool isDecoy = false}) async {
+    if (file.keyDerivationSalt == null || file.kdfIterations == null) {
+      return null;
+    }
+    final masterKey =
+        await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
+    final salt = base64Decode(file.keyDerivationSalt!);
+    return _encryptionService.deriveFileKeyAsync(
+        masterKey, salt, file.kdfIterations!);
+  }
+
+  Future<VaultedFile?> addFile({
+    required String sourcePath,
+    required String originalName,
+    required VaultedFileType type,
+    required String mimeType,
+    bool deleteOriginal = false,
+    bool encrypt = false,
+    bool isDecoy = false,
+    List<String>? tags,
+    List<String>? albumIds,
+    EncryptionAlgorithm? encryptionAlgorithm,
+    int? kdfIterations,
+  }) async {
+    final prepared = await _prepareVaultAddition(
+      sourcePath: sourcePath,
+      originalName: originalName,
+      type: type,
+      mimeType: mimeType,
+      encrypt: encrypt,
+      isDecoy: isDecoy,
+      tags: tags,
+      albumIds: albumIds,
+      encryptionAlgorithm: encryptionAlgorithm,
+      kdfIterations: kdfIterations,
+    );
+
+    if (prepared == null) return null;
+
+    await _storePreparedVaultAddition(prepared, deleteOriginal: deleteOriginal);
+
+    return prepared.vaultedFile;
+  }
+
+  Future<List<VaultedFile>> addFiles({
+    required List<FileToVault> files,
+    bool deleteOriginals = false,
+    bool encrypt = false,
+    bool isDecoy = false,
+    Function(int current, int total)? onProgress,
+    Function(FileProgressInfo)? onFileProgress,
+  }) async {
+    _store.cachedSettings ??= await _store.loadSettings();
+    final results = <VaultedFile>[];
+
+    int completed = 0;
+
+    for (int start = 0; start < files.length; start += _maxConcurrentBatchAdds) {
+      final chunk = files
+          .sublist(
+            start,
+            start + _maxConcurrentBatchAdds > files.length
+                ? files.length
+                : start + _maxConcurrentBatchAdds,
+          )
+          .asMap()
+          .entries
+          .map((entry) => (index: start + entry.key, file: entry.value))
+          .toList();
+
+      final preparedChunk = await Future.wait(
+        chunk.map((entry) async {
+          final fileSize = await _store.getFileSizeIfExists(entry.file.sourcePath);
+          final fileEncrypt = entry.file.encrypt ?? encrypt;
+          final fileShouldEncrypt =
+              fileEncrypt || _store.cachedSettings?.encryptionEnabled == true;
+
+          onFileProgress?.call(FileProgressInfo(
+            current: entry.index + 1,
+            total: files.length,
+            fileName: entry.file.originalName,
+            fileSize: fileSize,
+            status: fileShouldEncrypt ? 'Encrypting 0%...' : 'Processing...',
+            isEncrypting: fileShouldEncrypt,
+            totalBytes: fileShouldEncrypt ? fileSize : 0,
+          ));
+
+          final prepared = await _prepareVaultAddition(
+            sourcePath: entry.file.sourcePath,
+            originalName: entry.file.originalName,
+            type: entry.file.type,
+            mimeType: entry.file.mimeType,
+            encrypt: fileEncrypt,
+            isDecoy: isDecoy,
+            encryptionAlgorithm: entry.file.encryptionAlgorithm,
+            kdfIterations: entry.file.kdfIterations,
+            onEncryptionProgress: fileShouldEncrypt
+                ? (processed, total) {
+                    final pct = total > 0
+                        ? (processed / total * 100).toStringAsFixed(0)
+                        : '0';
+                    onFileProgress?.call(FileProgressInfo(
+                      current: entry.index + 1,
+                      total: files.length,
+                      fileName: entry.file.originalName,
+                      fileSize: fileSize,
+                      status: 'Encrypting $pct%...',
+                      isEncrypting: true,
+                      encryptedBytes: processed,
+                      totalBytes: total,
+                    ));
+                  }
+                : null,
+          );
+
+          return _BatchPreparationResult(
+            index: entry.index,
+            file: entry.file,
+            fileSize: fileSize,
+            prepared: prepared,
+          );
+        }),
+      );
+
+      for (final preparedResult in preparedChunk) {
+        if (preparedResult.prepared != null) {
+          await _storePreparedVaultAddition(
+            preparedResult.prepared!,
+            deleteOriginal: deleteOriginals,
+          );
+          results.add(preparedResult.prepared!.vaultedFile);
+        }
+
+        completed++;
+        onProgress?.call(completed, files.length);
+
+        onFileProgress?.call(FileProgressInfo(
+          current: preparedResult.index + 1,
+          total: files.length,
+          fileName: preparedResult.file.originalName,
+          fileSize: preparedResult.fileSize,
+          status: preparedResult.prepared != null ? 'Complete' : 'Failed',
+          isEncrypting: false,
+        ));
+      }
+    }
+
+    return results;
+  }
+
+  Future<_PreparedVaultAddition?> _prepareVaultAddition({
+    required String sourcePath,
+    required String originalName,
+    required VaultedFileType type,
+    required String mimeType,
+    required bool encrypt,
+    required bool isDecoy,
+    Function(int processed, int total)? onEncryptionProgress,
+    List<String>? tags,
+    List<String>? albumIds,
+    EncryptionAlgorithm? encryptionAlgorithm,
+    int? kdfIterations,
+  }) async {
+    String? sourcePathToUse;
+    String? vaultPath;
+    Uint8List? compressedImageBytes;
+
+    try {
+      final sourceFile = File(sourcePath);
+      if (!await sourceFile.exists()) {
+        debugPrint('Source file does not exist: $sourcePath');
+        return null;
+      }
+
+      sourcePathToUse = sourcePath;
+      _store.cachedSettings ??= await _store.loadSettings();
+
+      if (_store.cachedSettings?.compressionEnabled == true) {
+        if (type == VaultedFileType.image) {
+          final bytes = await CompressionService.instance
+              .compressImageToBytes(sourcePath);
+          if (bytes != null) {
+            compressedImageBytes = bytes;
+            debugPrint(
+                '[Vault] Using compressed image bytes (${bytes.length} bytes)');
+          }
+        } else if (type == VaultedFileType.video) {
+          final compressedPath =
+              await CompressionService.instance.compressVideo(sourcePath);
+          if (compressedPath != null) {
+            sourcePathToUse = compressedPath;
+            debugPrint('[Vault] Using compressed video: $compressedPath');
+          }
+        }
+      }
+
+      final directory = isDecoy
+          ? await _store.ensureDecoyDirectory()
+          : await _store.ensureVaultDirectory();
+
+      final vaultFilename = _store.generateVaultFilename(originalName);
+      final subdirectory = _store.getSubdirectory(type);
+      vaultPath = '${directory.path}/$subdirectory/$vaultFilename';
+
+      final shouldEncrypt = encrypt || _store.cachedSettings?.encryptionEnabled == true;
+      String? encryptionIv;
+      int fileSize;
+      EncryptionAlgorithm? usedAlgorithm;
+      String? usedSalt;
+      int? usedKdfIterations;
+
+      Uint8List? derivedKey;
+      if (shouldEncrypt) {
+        final algorithm = encryptionAlgorithm ??
+            _store.cachedSettings?.encryptionAlgorithm ??
+            EncryptionAlgorithm.aes256Ctr;
+        final iterations = kdfIterations ??
+            _store.cachedSettings?.kdfIterations ??
+            100000;
+        final salt = _encryptionService.generateFileSalt();
+        final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy);
+        derivedKey = await _encryptionService.deriveFileKeyAsync(masterKey, salt, iterations);
+        usedAlgorithm = algorithm;
+        usedSalt = base64Encode(salt);
+        usedKdfIterations = iterations;
+      }
+
+      if (compressedImageBytes != null) {
+        fileSize = compressedImageBytes.length;
+
+        if (shouldEncrypt) {
+          onEncryptionProgress?.call(0, fileSize);
+          final useGcm = usedAlgorithm == EncryptionAlgorithm.aes256Gcm;
+
+          final tempDir = await getTemporaryDirectory();
+          final tempPath =
+              '${tempDir.path}/lkr_enc_${DateTime.now().microsecondsSinceEpoch}';
+          await File(tempPath).writeAsBytes(compressedImageBytes);
+
+          try {
+            final encResult = await _encryptionService.encryptFileInIsolate(
+              tempPath,
+              vaultPath,
+              isDecoy: isDecoy,
+              useGcm: useGcm,
+              derivedKey: derivedKey,
+              onProgress: (processed, total) {
+                onEncryptionProgress?.call(processed, total);
+              },
+            );
+            onEncryptionProgress?.call(fileSize, fileSize);
+
+            if (!encResult.success) {
+              debugPrint('Encryption failed: ${encResult.error}');
+              await _store.deleteFileIfExists(vaultPath);
+              return null;
+            }
+
+            encryptionIv = encResult.iv;
+            fileSize = encResult.originalSize ?? fileSize;
+          } finally {
+            await _store.deleteFileIfExists(tempPath);
+          }
+        } else {
+          await File(vaultPath).writeAsBytes(compressedImageBytes);
+        }
+      } else {
+        final sourceFileForProcessing = File(sourcePathToUse);
+        if (!await sourceFileForProcessing.exists()) {
+          debugPrint('Processed file does not exist: $sourcePathToUse');
+          return null;
+        }
+
+        fileSize = await sourceFileForProcessing.length();
+
+        if (shouldEncrypt) {
+          onEncryptionProgress?.call(0, fileSize);
+          final useGcm = usedAlgorithm == EncryptionAlgorithm.aes256Gcm;
+          final encResult = await _encryptionService.encryptFileInIsolate(
+            sourcePathToUse,
+            vaultPath,
+            isDecoy: isDecoy,
+            useGcm: useGcm,
+            derivedKey: derivedKey,
+            onProgress: (processed, total) {
+              onEncryptionProgress?.call(processed, total);
+            },
+          );
+          onEncryptionProgress?.call(fileSize, fileSize);
+
+          if (!encResult.success) {
+            debugPrint('Encryption failed: ${encResult.error}');
+            await _store.deleteFileIfExists(vaultPath);
+            return null;
+          }
+
+          encryptionIv = encResult.iv;
+          fileSize = encResult.originalSize ?? fileSize;
+        } else {
+          await _store.streamCopyFile(sourceFileForProcessing, File(vaultPath));
+        }
+      }
+
+      final normalizedTags = (tags ?? [])
+          .map((tag) => tag.toLowerCase().trim())
+          .where((tag) => tag.isNotEmpty)
+          .toSet()
+          .toList();
+      final normalizedAlbumIds = (albumIds ?? []).toSet().toList();
+      final now = DateTime.now();
+      final fileId = sha256
+          .convert(utf8.encode('$vaultPath${now.millisecondsSinceEpoch}'))
+          .toString()
+          .substring(0, 24);
+
+      String? thumbPath;
+      String? thumbIv;
+      if (shouldEncrypt &&
+          derivedKey != null &&
+          (type == VaultedFileType.image || type == VaultedFileType.video)) {
+        String? reconstructedTemp;
+        try {
+          File? plainFile;
+          if (await File(sourcePathToUse).exists()) {
+            plainFile = File(sourcePathToUse);
+          } else if (compressedImageBytes != null) {
+            final tmp = await getTemporaryDirectory();
+            reconstructedTemp =
+                '${tmp.path}/lkr_thumb_src_${DateTime.now().microsecondsSinceEpoch}';
+            plainFile = File(reconstructedTemp);
+            await plainFile.writeAsBytes(compressedImageBytes);
+          }
+          if (plainFile != null) {
+            final thumbBytes = await _thumbnailService.generateThumbBytes(plainFile, type);
+            if (thumbBytes != null) {
+              final stored = await _thumbnailService.encryptAndStoreThumbnail(
+                thumbBytes,
+                fileId: fileId,
+                derivedKey: derivedKey,
+                isDecoy: isDecoy,
+              );
+              thumbPath = stored?.path;
+              thumbIv = stored?.iv;
+            }
+          }
+        } catch (e) {
+          debugPrint('[Vault] import-time thumbnail generation failed: $e');
+        } finally {
+          if (reconstructedTemp != null) {
+            await _store.deleteFileIfExists(reconstructedTemp);
+          }
+        }
+      }
+
+      return _PreparedVaultAddition(
+        vaultedFile: VaultedFile(
+          id: fileId,
+          originalName: originalName,
+          vaultPath: vaultPath,
+          originalPath: sourcePath,
+          type: type,
+          mimeType: mimeType,
+          fileSize: fileSize,
+          dateAdded: now,
+          isFavorite: normalizedAlbumIds.contains('favorites'),
+          isEncrypted: shouldEncrypt,
+          encryptionIv: encryptionIv,
+          encryptionAlgorithm: usedAlgorithm,
+          keyDerivationSalt: usedSalt,
+          kdfIterations: usedKdfIterations,
+          isDecoy: isDecoy,
+          tags: normalizedTags,
+          albumIds: normalizedAlbumIds,
+          thumbnailPath: thumbPath,
+          thumbnailIv: thumbIv,
+        ),
+      );
+    } catch (e) {
+      if (vaultPath != null) {
+        await _store.deleteFileIfExists(vaultPath);
+      }
+      debugPrint('Error adding file to vault: $e');
+      return null;
+    } finally {
+      if (sourcePathToUse != null && sourcePathToUse != sourcePath) {
+        try {
+          await File(sourcePathToUse).delete();
+          debugPrint('[Vault] Cleaned up compressed temp file: $sourcePathToUse');
+        } catch (e) {
+          debugPrint('[Vault] Could not delete temp compressed file: $e');
+        }
+      }
+    }
+  }
+
+  Future<void> _storePreparedVaultAddition(
+    _PreparedVaultAddition prepared, {
+    required bool deleteOriginal,
+  }) async {
+    final vaultedFile = prepared.vaultedFile;
+
+    if (vaultedFile.isDecoy) {
+      _store.cachedDecoyFiles ??= await _store.loadFileIndex(isDecoy: true);
+      _store.cachedDecoyFiles!.add(vaultedFile);
+      await _store.saveFileIndex(isDecoy: true);
+    } else {
+      _store.cachedFiles ??= await _store.loadFileIndex();
+      _store.cachedFiles!.add(vaultedFile);
+      await _store.saveFileIndex();
+
+      if (vaultedFile.albumIds.isNotEmpty) {
+        _store.cachedAlbums ??= await _store.loadAlbums();
+
+        for (final albumId in vaultedFile.albumIds) {
+          final albumIndex =
+              _store.cachedAlbums!.indexWhere((album) => album.id == albumId);
+          if (albumIndex != -1) {
+            _store.cachedAlbums![albumIndex] =
+                _store.cachedAlbums![albumIndex].addFile(vaultedFile.id);
+          }
+        }
+
+        await _store.saveAlbums();
+      }
+
+      if (vaultedFile.tags.isNotEmpty) {
+        await updateTagUsage?.call(vaultedFile.tags);
+      }
+    }
+
+    if (!deleteOriginal || vaultedFile.originalPath == null) {
+      return;
+    }
+
+    final originalFile = File(vaultedFile.originalPath!);
+    bool deleted = false;
+
+    try {
+      if (await originalFile.exists()) {
+        await originalFile.delete();
+        deleted = true;
+      } else {
+        deleted = true;
+      }
+    } catch (e) {
+      debugPrint('Could not delete original file: $e');
+    }
+
+    if (!deleted) {
+      try {
+        if (await originalFile.exists()) {
+          debugPrint(
+              'Original file still exists, attempting secure delete: ${vaultedFile.originalPath}');
+          if (_store.cachedSettings?.secureDelete == true) {
+            await _encryptionService.secureDelete(vaultedFile.originalPath!);
+          } else {
+            await originalFile.delete();
+          }
+        }
+      } catch (_) {}
+    }
+
+    try {
+      if (await originalFile.exists()) {
+        debugPrint(
+            'WARNING: Could not delete original file from device storage: ${vaultedFile.originalPath}');
+      }
+    } catch (_) {}
+  }
+
+  Future<VaultedFile?> updateFile(VaultedFile updatedFile) async {
+    try {
+      final files = await _store.loadFileIndex(isDecoy: updatedFile.isDecoy);
+      final index = files.indexWhere((f) => f.id == updatedFile.id);
+
+      if (index == -1) return null;
+
+      if (updatedFile.isDecoy) {
+        _store.cachedDecoyFiles![index] = updatedFile;
+        await _store.saveFileIndex(isDecoy: true);
+      } else {
+        _store.cachedFiles![index] = updatedFile;
+        await _store.saveFileIndex();
+      }
+
+      return updatedFile;
+    } catch (e) {
+      debugPrint('Error updating file: $e');
+      return null;
+    }
+  }
+
+  Future<bool> removeFile(String fileId, {bool isDecoy = false}) async {
+    try {
+      final files = await _store.loadFileIndex(isDecoy: isDecoy);
+      final fileIndex = files.indexWhere((f) => f.id == fileId);
+
+      if (fileIndex == -1) return false;
+
+      final file = files[fileIndex];
+
+      final vaultFile = File(file.vaultPath);
+      if (await vaultFile.exists()) {
+        if (_store.cachedSettings?.secureDelete == true) {
+          await _encryptionService.secureDelete(file.vaultPath);
+        } else {
+          await vaultFile.delete();
+        }
+      }
+
+      if (file.thumbnailPath != null) {
+        final thumbFile = File(file.thumbnailPath!);
+        if (await thumbFile.exists()) {
+          await thumbFile.delete();
+        }
+      }
+
+      if (!isDecoy && file.albumIds.isNotEmpty) {
+        for (final albumId in file.albumIds) {
+          await removeFileFromAlbumFn?.call(fileId, albumId);
+        }
+      }
+
+      if (!isDecoy && file.folderId != null) {
+        _store.cachedFolders ??= await _store.loadFolders();
+        final folderIndex =
+            _store.cachedFolders!.indexWhere((f) => f.id == file.folderId);
+        if (folderIndex != -1) {
+          _store.cachedFolders![folderIndex] =
+              _store.cachedFolders![folderIndex].removeFile(fileId);
+          await _store.saveFolders();
+        }
+      }
+
+      if (isDecoy) {
+        _store.cachedDecoyFiles!.removeAt(fileIndex);
+        await _store.saveFileIndex(isDecoy: true);
+      } else {
+        _store.cachedFiles!.removeAt(fileIndex);
+        await _store.saveFileIndex();
+      }
+
+      return true;
+    } catch (e) {
+      debugPrint('Error removing file from vault: $e');
+      return false;
+    }
+  }
+
+  Future<int> removeFiles(
+    List<String> fileIds, {
+    bool isDecoy = false,
+    void Function(int current, int total, {int currentSize, int totalSize})?
+        onProgress,
+  }) async {
+    final fileIndex = await _store.loadFileIndex(isDecoy: isDecoy);
+    final idSet = fileIds.toSet();
+    final filesToDelete = fileIndex.where((f) => idSet.contains(f.id)).toList();
+    final totalSize = filesToDelete.fold<int>(0, (s, f) => s + f.fileSize);
+
+    final albumUpdates = <String, Set<String>>{};
+    final folderUpdates = <String, Set<String>>{};
+    int removed = 0;
+    int currentSize = 0;
+
+    for (final file in filesToDelete) {
+      try {
+        final vaultFile = File(file.vaultPath);
+        if (await vaultFile.exists()) {
+          if (_store.cachedSettings?.secureDelete == true) {
+            await _encryptionService.secureDelete(file.vaultPath);
+          } else {
+            await vaultFile.delete();
+          }
+        }
+
+        if (file.thumbnailPath != null) {
+          final thumbFile = File(file.thumbnailPath!);
+          if (await thumbFile.exists()) {
+            await thumbFile.delete();
+          }
+        }
+
+        if (!isDecoy && file.albumIds.isNotEmpty) {
+          for (final albumId in file.albumIds) {
+            albumUpdates.putIfAbsent(albumId, () => {}).add(file.id);
+          }
+        }
+
+        if (!isDecoy && file.folderId != null) {
+          folderUpdates.putIfAbsent(file.folderId!, () => {}).add(file.id);
+        }
+
+        removed++;
+        currentSize += file.fileSize;
+        onProgress?.call(removed, fileIds.length,
+            currentSize: currentSize, totalSize: totalSize);
+      } catch (e) {
+        debugPrint('Error deleting file ${file.id}: $e');
+      }
+    }
+
+    if (!isDecoy && albumUpdates.isNotEmpty) {
+      final albums = await _store.loadAlbums();
+      bool albumsChanged = false;
+      for (final entry in albumUpdates.entries) {
+        final albumIdx = albums.indexWhere((a) => a.id == entry.key);
+        if (albumIdx != -1) {
+          var album = albums[albumIdx];
+          for (final fid in entry.value) {
+            album = album.removeFile(fid);
+          }
+          albums[albumIdx] = album;
+          albumsChanged = true;
+        }
+      }
+      if (albumsChanged) await _store.saveAlbums();
+    }
+
+    if (!isDecoy && folderUpdates.isNotEmpty) {
+      _store.cachedFolders ??= await _store.loadFolders();
+      bool foldersChanged = false;
+      for (final entry in folderUpdates.entries) {
+        final folderIdx = _store.cachedFolders!.indexWhere((f) => f.id == entry.key);
+        if (folderIdx != -1) {
+          var folder = _store.cachedFolders![folderIdx];
+          for (final fid in entry.value) {
+            folder = folder.removeFile(fid);
+          }
+          _store.cachedFolders![folderIdx] = folder;
+          foldersChanged = true;
+        }
+      }
+      if (foldersChanged) await _store.saveFolders();
+    }
+
+    final deleteIdSet = filesToDelete.map((f) => f.id).toSet();
+    if (isDecoy) {
+      _store.cachedDecoyFiles!.removeWhere((f) => deleteIdSet.contains(f.id));
+      await _store.saveFileIndex(isDecoy: true);
+    } else {
+      _store.cachedFiles!.removeWhere((f) => deleteIdSet.contains(f.id));
+      await _store.saveFileIndex();
+    }
+
+    return removed;
+  }
+
+  Future<List<VaultedFile>> getAllFiles({bool isDecoy = false}) async {
+    return await _store.loadFileIndex(isDecoy: isDecoy);
+  }
+
+  Future<List<VaultedFile>> getFilesByType(VaultedFileType type,
+      {bool isDecoy = false}) async {
+    final files = await _store.loadFileIndex(isDecoy: isDecoy);
+    return files.where((f) => f.type == type).toList();
+  }
+
+  Future<VaultedFile?> getFileById(String fileId, {bool isDecoy = false}) async {
+    final files = await _store.loadFileIndex(isDecoy: isDecoy);
+    try {
+      return files.firstWhere((f) => f.id == fileId);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Get the actual file from vault (decrypts if needed).
+  Future<File?> getVaultedFile(
+    String fileId, {
+    bool isDecoy = false,
+    Function(int processed, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) async {
+    final vaultedFile = await getFileById(fileId, isDecoy: isDecoy);
+    if (vaultedFile == null) return null;
+
+    final file = File(vaultedFile.vaultPath);
+    if (!await file.exists()) return null;
+
+    if (vaultedFile.isEncrypted && vaultedFile.encryptionIv != null) {
+      final tempDir = await _store.ensureVaultDirectory();
+      final tempPath = '${tempDir.path}/temp/${vaultedFile.id}_${vaultedFile.originalName}';
+
+      final format = _encryptionService.detectFileFormat(vaultedFile.vaultPath);
+      final isLegacyCbc = (format == 0 || format == 3);
+      final derivedKey = await deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
+
+      if (cancelToken?.isCancelled == true) return null;
+
+      FileDecryptionResult result;
+      if (isLegacyCbc) {
+        result = await _encryptionService.decryptFile(
+          vaultedFile.vaultPath,
+          tempPath,
+          vaultedFile.encryptionIv!,
+          isDecoy: isDecoy,
+          derivedKey: derivedKey,
+          onProgress: onProgress == null
+              ? null
+              : (current, total) {
+                  final estimatedProcessed = total > 0
+                      ? (current / total * vaultedFile.fileSize).round()
+                      : 0;
+                  onProgress(estimatedProcessed, vaultedFile.fileSize);
+                },
+        );
+      } else {
+        result = await _encryptionService.decryptFileInIsolate(
+          vaultedFile.vaultPath,
+          tempPath,
+          vaultedFile.encryptionIv!,
+          isDecoy: isDecoy,
+          derivedKey: derivedKey,
+          onProgress: onProgress,
+          cancelToken: cancelToken,
+        );
+      }
+
+      if (cancelToken?.isCancelled == true) return null;
+
+      if (result.success && result.decryptedPath != null) {
+        return File(result.decryptedPath!);
+      }
+      return null;
+    }
+
+    return file;
+  }
+
+  Future<Uint8List?> getDecryptedFileData(String fileId,
+      {bool isDecoy = false}) async {
+    final vaultedFile = await getFileById(fileId, isDecoy: isDecoy);
+    if (vaultedFile == null) return null;
+
+    if (vaultedFile.isEncrypted && vaultedFile.encryptionIv != null) {
+      final derivedKey = await deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
+      final result = await _encryptionService.decryptStreamedFileToMemory(
+        vaultedFile.vaultPath,
+        vaultedFile.encryptionIv!,
+        isDecoy: isDecoy,
+        derivedKey: derivedKey,
+      );
+
+      if (result.success && result.data != null) {
+        await updateFile(vaultedFile.markViewed());
+        return result.data;
+      }
+      return null;
+    }
+
+    final file = File(vaultedFile.vaultPath);
+    if (!await file.exists()) return null;
+
+    await updateFile(vaultedFile.markViewed());
+    return await file.readAsBytes();
+  }
+
+  Future<File?> exportFile(
+    String fileId,
+    String destinationPath, {
+    bool isDecoy = false,
+    Function(int processed, int total)? onProgress,
+  }) async {
+    try {
+      final vaultedFile = await getFileById(fileId, isDecoy: isDecoy);
+      if (vaultedFile == null) return null;
+
+      final sourceFile = File(vaultedFile.vaultPath);
+      if (!await sourceFile.exists()) return null;
+
+      if (vaultedFile.isEncrypted && vaultedFile.encryptionIv != null) {
+        final format = _encryptionService.detectFileFormat(vaultedFile.vaultPath);
+        final isLegacyCbc = (format == 0 || format == 3);
+        final derivedKey = await deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
+
+        FileDecryptionResult result;
+        if (isLegacyCbc) {
+          result = await _encryptionService.decryptFile(
+            vaultedFile.vaultPath,
+            destinationPath,
+            vaultedFile.encryptionIv!,
+            derivedKey: derivedKey,
+            onProgress: onProgress == null
+                ? null
+                : (current, total) {
+                    final estimatedProcessed = total > 0
+                        ? (current / total * vaultedFile.fileSize).round()
+                        : 0;
+                    onProgress(estimatedProcessed, vaultedFile.fileSize);
+                  },
+          );
+        } else {
+          result = await _encryptionService.decryptFileInIsolate(
+            vaultedFile.vaultPath,
+            destinationPath,
+            vaultedFile.encryptionIv!,
+            isDecoy: isDecoy,
+            derivedKey: derivedKey,
+            onProgress: onProgress == null
+                ? null
+                : (bytesProcessed, totalBytes) {
+                    onProgress(bytesProcessed, totalBytes);
+                  },
+          );
+        }
+
+        if (result.success && result.decryptedPath != null) {
+          return File(result.decryptedPath!);
+        }
+        return null;
+      }
+
+      await _store.streamCopyFile(sourceFile, File(destinationPath),
+          onProgress: onProgress);
+      return File(destinationPath);
+    } catch (e) {
+      debugPrint('Error exporting file: $e');
+      return null;
+    }
+  }
+
+  Future<int> reEncryptVault(
+    EncryptionAlgorithm targetAlgorithm, {
+    bool isDecoy = false,
+    Function(int current, int total, String currentFileName, int processedBytes,
+            int totalBytes)?
+        onProgress,
+    Set<String>? fileFilter,
+  }) async {
+    try {
+      final files = isDecoy
+          ? (await getAllFiles(isDecoy: true))
+          : (await getAllFiles(isDecoy: false));
+      var encryptedFiles = files.where((f) => f.isEncrypted).toList();
+
+      if (fileFilter != null && fileFilter.isNotEmpty) {
+        encryptedFiles =
+            encryptedFiles.where((f) => fileFilter.contains(f.id)).toList();
+      }
+
+      if (encryptedFiles.isEmpty) return 0;
+
+      final journalIvs = <String, String>{};
+      String? priorInProgress;
+
+      final journalStr = await _store.read(VaultStore.reEncryptJournalKey);
+      if (journalStr != null) {
+        try {
+          final journal = jsonDecode(journalStr) as Map<String, dynamic>;
+          final savedIvs =
+              (journal['ivs'] as Map<String, dynamic>?)?.cast<String, String>() ?? {};
+          journalIvs.addAll(savedIvs);
+          priorInProgress = journal['inProgress'] as String?;
+
+          for (final entry in journalIvs.entries) {
+            final idx = files.indexWhere((f) => f.vaultPath == entry.key);
+            if (idx >= 0) {
+              files[idx] = files[idx].copyWith(encryptionIv: entry.value);
+            }
+          }
+
+          if (priorInProgress != null) {
+            try {
+              await File('$priorInProgress.tmp').delete();
+            } catch (_) {}
+          }
+
+          encryptedFiles = files.where((f) => f.isEncrypted).toList();
+          if (fileFilter != null && fileFilter.isNotEmpty) {
+            encryptedFiles =
+                encryptedFiles.where((f) => fileFilter.contains(f.id)).toList();
+          }
+
+          if (isDecoy) {
+            _store.cachedDecoyFiles = files;
+          } else {
+            _store.cachedFiles = files;
+          }
+          await _store.saveFileIndex(isDecoy: isDecoy);
+        } catch (_) {}
+      }
+
+      final totalBytes = encryptedFiles.fold<int>(0, (s, f) => s + f.fileSize);
+      var processedBytes = 0;
+      int reEncryptedCount = 0;
+
+      for (int i = 0; i < encryptedFiles.length; i++) {
+        final file = encryptedFiles[i];
+        onProgress?.call(i, encryptedFiles.length, file.originalName,
+            processedBytes, totalBytes);
+
+        if (!await File(file.vaultPath).exists()) {
+          processedBytes += file.fileSize;
+          onProgress?.call(i + 1, encryptedFiles.length, file.originalName,
+              processedBytes, totalBytes);
+          continue;
+        }
+        if (file.encryptionIv == null || file.encryptionIv!.isEmpty) {
+          debugPrint(
+              'reEncryptVault: skipping ${file.originalName} (missing IV)');
+          processedBytes += file.fileSize;
+          onProgress?.call(i + 1, encryptedFiles.length, file.originalName,
+              processedBytes, totalBytes);
+          continue;
+        }
+
+        final currentFormat = _encryptionService.detectFileFormat(file.vaultPath);
+        final targetIsGcm = targetAlgorithm == EncryptionAlgorithm.aes256Gcm;
+        final currentIsGcm = (currentFormat == 1 || currentFormat == 4);
+
+        if (currentIsGcm == targetIsGcm && currentFormat != 0 && currentFormat != 3) {
+          processedBytes += file.fileSize;
+          onProgress?.call(i + 1, encryptedFiles.length, file.originalName,
+              processedBytes, totalBytes);
+          continue;
+        }
+
+        await _store.write(
+          VaultStore.reEncryptJournalKey,
+          jsonEncode({
+            'ivs': journalIvs,
+            'inProgress': file.vaultPath,
+          }),
+        );
+
+        final oldDerivedKey = await deriveKeyForFile(file, isDecoy: isDecoy);
+        final newSalt = _encryptionService.generateFileSalt();
+        final newIterations = _store.cachedSettings?.kdfIterations ?? 100000;
+        final masterKey =
+            await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
+        final newDerivedKey = await _encryptionService.deriveFileKeyAsync(
+            masterKey, newSalt, newIterations);
+
+        final baseBytes = processedBytes;
+        final halfBytes = file.fileSize ~/ 2;
+        final newIv = await _encryptionService.reEncryptFile(
+          file.vaultPath,
+          file.encryptionIv ?? '',
+          targetAlgorithm: targetAlgorithm,
+          isDecoy: isDecoy,
+          oldDerivedKey: oldDerivedKey,
+          newDerivedKey: newDerivedKey,
+          onProgress: onProgress == null
+              ? null
+              : (processed, _, isEnc) => onProgress(
+                    i,
+                    encryptedFiles.length,
+                    file.originalName,
+                    baseBytes +
+                        (isEnc
+                            ? halfBytes + (processed ~/ 2)
+                            : processed ~/ 2),
+                    totalBytes),
+        );
+
+        journalIvs[file.vaultPath] = newIv;
+        await _store.write(
+          VaultStore.reEncryptJournalKey,
+          jsonEncode({
+            'ivs': journalIvs,
+          }),
+        );
+
+        final fileIndex = files.indexWhere((f) => f.id == file.id);
+        if (fileIndex >= 0) {
+          if (file.thumbnailPath != null) {
+            try {
+              await File(file.thumbnailPath!).delete();
+            } catch (_) {}
+          }
+          files[fileIndex] = file.copyWith(
+            encryptionIv: newIv,
+            encryptionAlgorithm: targetAlgorithm,
+            keyDerivationSalt: base64Encode(newSalt),
+            kdfIterations: newIterations,
+          );
+          reEncryptedCount++;
+        }
+        processedBytes += file.fileSize;
+        onProgress?.call(i + 1, encryptedFiles.length, file.originalName,
+            processedBytes, totalBytes);
+      }
+
+      if (isDecoy) {
+        _store.cachedDecoyFiles = files;
+      } else {
+        _store.cachedFiles = files;
+      }
+
+      await _store.saveFileIndex(isDecoy: isDecoy);
+      await _store.delete(VaultStore.reEncryptJournalKey);
+      return reEncryptedCount;
+    } catch (e) {
+      debugPrint('Re-encryption error: $e');
+      return -1;
+    }
+  }
+
+  Future<int> encryptVaultFiles(
+    EncryptionAlgorithm algorithm, {
+    bool isDecoy = false,
+    Function(int current, int total, String currentFileName, int processedBytes,
+            int totalBytes)?
+        onProgress,
+    Set<String>? fileFilter,
+  }) async {
+    try {
+      final files = await getAllFiles(isDecoy: isDecoy);
+      var targets = files.where((f) => !f.isEncrypted).toList();
+      if (fileFilter != null && fileFilter.isNotEmpty) {
+        targets = targets.where((f) => fileFilter.contains(f.id)).toList();
+      }
+      if (targets.isEmpty) return 0;
+
+      final iterations = _store.cachedSettings?.kdfIterations ?? 100000;
+      final totalBytes = targets.fold<int>(0, (s, f) => s + f.fileSize);
+      var processedBytes = 0;
+      var count = 0;
+
+      for (int i = 0; i < targets.length; i++) {
+        final file = targets[i];
+        onProgress?.call(
+            i, targets.length, file.originalName, processedBytes, totalBytes);
+        if (!await File(file.vaultPath).exists()) {
+          processedBytes += file.fileSize;
+          continue;
+        }
+
+        final salt = _encryptionService.generateFileSalt();
+        final masterKey =
+            await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
+        final derivedKey =
+            await _encryptionService.deriveFileKeyAsync(masterKey, salt, iterations);
+
+        final baseBytes = processedBytes;
+        final newIv = await _encryptionService.encryptFileInPlace(
+          file.vaultPath,
+          useGcm: algorithm == EncryptionAlgorithm.aes256Gcm,
+          isDecoy: isDecoy,
+          derivedKey: derivedKey,
+          onProgress: onProgress == null
+              ? null
+              : (processed, _) => onProgress(i, targets.length,
+                  file.originalName, baseBytes + processed, totalBytes),
+        );
+
+        final idx = files.indexWhere((f) => f.id == file.id);
+        if (idx >= 0) {
+          files[idx] = file.copyWith(
+            isEncrypted: true,
+            encryptionIv: newIv,
+            encryptionAlgorithm: algorithm,
+            keyDerivationSalt: base64Encode(salt),
+            kdfIterations: iterations,
+          );
+          count++;
+        }
+        processedBytes += file.fileSize;
+        onProgress?.call(
+            i + 1, targets.length, file.originalName, processedBytes, totalBytes);
+      }
+
+      await _store.saveFileIndex(isDecoy: isDecoy);
+      return count;
+    } catch (e) {
+      try {
+        await _store.saveFileIndex(isDecoy: isDecoy);
+      } catch (_) {}
+      debugPrint('Encrypt-in-place error: $e');
+      return -1;
+    }
+  }
+
+  Future<int> removeEncryption({
+    bool isDecoy = false,
+    Function(int current, int total, String currentFileName, int processedBytes,
+            int totalBytes)?
+        onProgress,
+    Set<String>? fileFilter,
+  }) async {
+    try {
+      final files = await getAllFiles(isDecoy: isDecoy);
+      var targets = files.where((f) => f.isEncrypted).toList();
+      if (fileFilter != null && fileFilter.isNotEmpty) {
+        targets = targets.where((f) => fileFilter.contains(f.id)).toList();
+      }
+      if (targets.isEmpty) return 0;
+
+      final totalBytes = targets.fold<int>(0, (s, f) => s + f.fileSize);
+      var processedBytes = 0;
+      var count = 0;
+
+      for (int i = 0; i < targets.length; i++) {
+        final file = targets[i];
+        onProgress?.call(
+            i, targets.length, file.originalName, processedBytes, totalBytes);
+        if (!await File(file.vaultPath).exists()) {
+          processedBytes += file.fileSize;
+          continue;
+        }
+        if (file.encryptionIv == null) {
+          processedBytes += file.fileSize;
+          continue;
+        }
+
+        final derivedKey = await deriveKeyForFile(file, isDecoy: isDecoy);
+
+        final baseBytes = processedBytes;
+        await _encryptionService.decryptFileInPlace(
+          file.vaultPath,
+          file.encryptionIv!,
+          isDecoy: isDecoy,
+          derivedKey: derivedKey,
+          onProgress: onProgress == null
+              ? null
+              : (processed, _) => onProgress(i, targets.length,
+                  file.originalName, baseBytes + processed, totalBytes),
+        );
+
+        final idx = files.indexWhere((f) => f.id == file.id);
+        if (idx >= 0) {
+          if (file.thumbnailPath != null) {
+            try {
+              await File(file.thumbnailPath!).delete();
+            } catch (_) {}
+          }
+          files[idx] = VaultedFile(
+            id: file.id,
+            originalName: file.originalName,
+            vaultPath: file.vaultPath,
+            originalPath: file.originalPath,
+            type: file.type,
+            mimeType: file.mimeType,
+            fileSize: file.fileSize,
+            dateAdded: file.dateAdded,
+            dateModified: DateTime.now(),
+            metadata: file.metadata,
+            tags: file.tags,
+            isFavorite: file.isFavorite,
+            isEncrypted: false,
+            isDecoy: file.isDecoy,
+            lastViewed: file.lastViewed,
+            viewCount: file.viewCount,
+            notes: file.notes,
+            albumIds: file.albumIds,
+            folderId: file.folderId,
+          );
+          count++;
+        }
+        processedBytes += file.fileSize;
+        onProgress?.call(
+            i + 1, targets.length, file.originalName, processedBytes, totalBytes);
+      }
+
+      await _store.saveFileIndex(isDecoy: isDecoy);
+      return count;
+    } catch (e) {
+      try {
+        await _store.saveFileIndex(isDecoy: isDecoy);
+      } catch (_) {}
+      debugPrint('Remove-encryption error: $e');
+      return -1;
+    }
+  }
+
+  Future<void> cleanupTemp() async {
+    try {
+      final vaultDir = await _store.ensureVaultDirectory();
+      final tempDir = Directory('${vaultDir.path}/temp');
+
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+        await tempDir.create();
+      }
+    } catch (e) {
+      debugPrint('Error cleaning temp: $e');
+    }
+  }
+
+  // ---- Notes / password registration ----
+
+  Future<void> registerNoteEntry({
+    required String noteId,
+    required String title,
+    required String encryptedContentPath,
+    String fileExtension = 'txt',
+    bool isEncrypted = false,
+    EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
+    int kdfIterations = 0,
+    String? folderId,
+    bool isDecoy = false,
+  }) async {
+    final files = isDecoy
+        ? (_store.cachedDecoyFiles ??= await _store.loadFileIndex(isDecoy: true))
+        : (_store.cachedFiles ??= await _store.loadFileIndex());
+
+    final existingIndex = files.indexWhere((f) => f.metadata?['noteId'] == noteId);
+
+    final mimeType = switch (fileExtension) {
+      'md' => 'text/markdown',
+      'html' => 'text/html',
+      _ => 'text/plain',
+    };
+
+    final entry = VaultedFile(
+      id: existingIndex != -1 ? files[existingIndex].id : noteId,
+      originalName: '$title.$fileExtension',
+      vaultPath: encryptedContentPath,
+      type: VaultedFileType.document,
+      mimeType: mimeType,
+      fileSize: 0,
+      dateAdded:
+          existingIndex != -1 ? files[existingIndex].dateAdded : DateTime.now(),
+      dateModified: DateTime.now(),
+      tags: ['note'],
+      isEncrypted: isEncrypted,
+      encryptionAlgorithm: encryptionAlgorithm,
+      kdfIterations: kdfIterations,
+      folderId: folderId,
+      metadata: {'noteId': noteId},
+    );
+
+    if (existingIndex != -1) {
+      files[existingIndex] = entry;
+    } else {
+      files.insert(0, entry);
+    }
+
+    if (isDecoy) {
+      await _store.saveFileIndex(isDecoy: true);
+    } else {
+      await _store.saveFileIndex();
+    }
+  }
+
+  Future<void> removeNoteEntry(String noteId, {bool isDecoy = false}) async {
+    final files = isDecoy
+        ? (_store.cachedDecoyFiles ??= await _store.loadFileIndex(isDecoy: true))
+        : (_store.cachedFiles ??= await _store.loadFileIndex());
+
+    files.removeWhere((f) => f.metadata?['noteId'] == noteId);
+
+    if (isDecoy) {
+      await _store.saveFileIndex(isDecoy: true);
+    } else {
+      await _store.saveFileIndex();
+    }
+  }
+
+  Future<void> registerPasswordEntry({
+    required String passwordId,
+    required String title,
+    required String encryptedContentPath,
+    List<String> tags = const [],
+    bool isEncrypted = false,
+    EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
+    int kdfIterations = 0,
+    bool isDecoy = false,
+  }) async {
+    final files = isDecoy
+        ? (_store.cachedDecoyFiles ??= await _store.loadFileIndex(isDecoy: true))
+        : (_store.cachedFiles ??= await _store.loadFileIndex());
+
+    final existingIndex =
+        files.indexWhere((f) => f.metadata?['passwordId'] == passwordId);
+
+    final entry = VaultedFile(
+      id: existingIndex != -1 ? files[existingIndex].id : passwordId,
+      originalName: '$title.pwd',
+      vaultPath: encryptedContentPath,
+      type: VaultedFileType.document,
+      mimeType: 'application/octet-stream',
+      fileSize: 0,
+      dateAdded:
+          existingIndex != -1 ? files[existingIndex].dateAdded : DateTime.now(),
+      dateModified: DateTime.now(),
+      tags: ['password', ...tags],
+      isEncrypted: isEncrypted,
+      encryptionAlgorithm: encryptionAlgorithm,
+      kdfIterations: kdfIterations,
+      metadata: {'passwordId': passwordId},
+    );
+
+    if (existingIndex != -1) {
+      files[existingIndex] = entry;
+    } else {
+      files.insert(0, entry);
+    }
+
+    if (isDecoy) {
+      await _store.saveFileIndex(isDecoy: true);
+    } else {
+      await _store.saveFileIndex();
+    }
+  }
+
+  Future<void> removePasswordEntry(String passwordId, {bool isDecoy = false}) async {
+    final files = isDecoy
+        ? (_store.cachedDecoyFiles ??= await _store.loadFileIndex(isDecoy: true))
+        : (_store.cachedFiles ??= await _store.loadFileIndex());
+
+    files.removeWhere((f) => f.metadata?['passwordId'] == passwordId);
+
+    if (isDecoy) {
+      await _store.saveFileIndex(isDecoy: true);
+    } else {
+      await _store.saveFileIndex();
+    }
+  }
+}

--- a/lib/services/folder_service.dart
+++ b/lib/services/folder_service.dart
@@ -1,0 +1,348 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/file_to_vault.dart';
+import '../models/vault_folder.dart';
+import '../models/vaulted_file.dart';
+import 'file_service.dart';
+import 'vault_store.dart';
+
+/// Folder CRUD + importDeviceFolder. Splits out of `VaultService`.
+class FolderService {
+  final VaultStore _store;
+  final FileService _fileService;
+
+  FolderService(this._store, this._fileService);
+
+  Future<List<VaultFolder>> getAllFolders() => _store.loadFolders();
+
+  Future<VaultFolder?> getFolderById(String folderId) async {
+    final folders = await _store.loadFolders();
+    try {
+      return folders.firstWhere((f) => f.id == folderId);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  Future<List<VaultFolder>> getRootFolders() async {
+    final folders = await _store.loadFolders();
+    return folders.where((f) => f.isRoot).toList();
+  }
+
+  Future<List<VaultFolder>> getSubfolders(String parentId) async {
+    final folders = await _store.loadFolders();
+    return folders.where((f) => f.parentId == parentId).toList();
+  }
+
+  Future<VaultFolder?> createFolder({
+    required String name,
+    String? parentId,
+    String? description,
+  }) async {
+    try {
+      final now = DateTime.now();
+      final id = sha256
+          .convert(utf8.encode('$name${now.millisecondsSinceEpoch}'))
+          .toString()
+          .substring(0, 16);
+
+      final folder = VaultFolder(
+        id: id,
+        name: name,
+        parentId: parentId,
+        description: description,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      _store.cachedFolders ??= [];
+      _store.cachedFolders!.add(folder);
+
+      if (parentId != null) {
+        final parentIndex = _store.cachedFolders!.indexWhere((f) => f.id == parentId);
+        if (parentIndex != -1) {
+          _store.cachedFolders![parentIndex] =
+              _store.cachedFolders![parentIndex].addSubfolder(id);
+        }
+      }
+
+      await _store.saveFolders();
+
+      return folder;
+    } catch (e) {
+      debugPrint('Error creating folder: $e');
+      return null;
+    }
+  }
+
+  Future<VaultFolder?> updateFolder(VaultFolder updatedFolder) async {
+    try {
+      final folders = await _store.loadFolders();
+      final index = folders.indexWhere((f) => f.id == updatedFolder.id);
+
+      if (index == -1) return null;
+
+      _store.cachedFolders![index] = updatedFolder.copyWith(updatedAt: DateTime.now());
+      await _store.saveFolders();
+
+      return _store.cachedFolders![index];
+    } catch (e) {
+      debugPrint('Error updating folder: $e');
+      return null;
+    }
+  }
+
+  Future<bool> deleteFolder(String folderId, {bool deleteContents = false}) async {
+    try {
+      final folders = await _store.loadFolders();
+      final folder = folders.firstWhere(
+        (f) => f.id == folderId,
+        orElse: () => throw Exception('Folder not found'),
+      );
+
+      if (deleteContents) {
+        for (final subfolderId in folder.subfolderIds) {
+          await deleteFolder(subfolderId, deleteContents: true);
+        }
+
+        for (final fileId in folder.fileIds) {
+          await _fileService.removeFile(fileId);
+        }
+      } else {
+        for (final fileId in folder.fileIds) {
+          final file = await _fileService.getFileById(fileId);
+          if (file != null) {
+            await _fileService.updateFile(file.removeFromFolder());
+          }
+        }
+
+        for (final subfolderId in folder.subfolderIds) {
+          final subfolder = await getFolderById(subfolderId);
+          if (subfolder != null) {
+            await updateFolder(subfolder.copyWith(parentId: folder.parentId));
+            if (folder.parentId != null) {
+              final parentIndex = _store.cachedFolders!.indexWhere((f) => f.id == folder.parentId);
+              if (parentIndex != -1) {
+                _store.cachedFolders![parentIndex] =
+                    _store.cachedFolders![parentIndex].addSubfolder(subfolderId);
+              }
+            }
+          }
+        }
+      }
+
+      if (folder.parentId != null) {
+        final parentIndex = _store.cachedFolders!.indexWhere((f) => f.id == folder.parentId);
+        if (parentIndex != -1) {
+          _store.cachedFolders![parentIndex] =
+              _store.cachedFolders![parentIndex].removeSubfolder(folderId);
+        }
+      }
+
+      _store.cachedFolders!.removeWhere((f) => f.id == folderId);
+      await _store.saveFolders();
+
+      return true;
+    } catch (e) {
+      debugPrint('Error deleting folder: $e');
+      return false;
+    }
+  }
+
+  Future<bool> addFileToFolder(String fileId, String folderId) async {
+    try {
+      final file = await _fileService.getFileById(fileId);
+      if (file == null) return false;
+
+      final folders = await _store.loadFolders();
+      final folderIndex = folders.indexWhere((f) => f.id == folderId);
+      if (folderIndex == -1) return false;
+
+      if (file.folderId != null && file.folderId != folderId) {
+        final oldFolderIndex = _store.cachedFolders!.indexWhere((f) => f.id == file.folderId);
+        if (oldFolderIndex != -1) {
+          _store.cachedFolders![oldFolderIndex] =
+              _store.cachedFolders![oldFolderIndex].removeFile(fileId);
+        }
+      }
+
+      _store.cachedFolders![folderIndex] = _store.cachedFolders![folderIndex].addFile(fileId);
+      await _store.saveFolders();
+
+      final updatedFile = file.addToFolder(folderId);
+      await _fileService.updateFile(updatedFile);
+
+      return true;
+    } catch (e) {
+      debugPrint('Error adding file to folder: $e');
+      return false;
+    }
+  }
+
+  Future<bool> removeFileFromFolder(String fileId, String folderId) async {
+    try {
+      final folders = await _store.loadFolders();
+      final folderIndex = folders.indexWhere((f) => f.id == folderId);
+      if (folderIndex == -1) return false;
+
+      _store.cachedFolders![folderIndex] = _store.cachedFolders![folderIndex].removeFile(fileId);
+      await _store.saveFolders();
+
+      final file = await _fileService.getFileById(fileId);
+      if (file != null && file.folderId == folderId) {
+        await _fileService.updateFile(file.removeFromFolder());
+      }
+
+      return true;
+    } catch (e) {
+      debugPrint('Error removing file from folder: $e');
+      return false;
+    }
+  }
+
+  Future<List<VaultedFile>> getFilesInFolder(String folderId) async {
+    final folder = await getFolderById(folderId);
+    if (folder == null) return [];
+
+    final files = await _fileService.getAllFiles();
+    return files.where((f) => folder.fileIds.contains(f.id)).toList();
+  }
+
+  Future<FolderImportResult> importDeviceFolder(
+    String deviceFolderPath, {
+    String? parentFolderId,
+    bool recursive = true,
+    bool deleteOriginals = false,
+    bool encrypt = false,
+    bool isDecoy = false,
+    Function(int current, int total)? onProgress,
+    Function(String fileName, int fileNumber, int total)? onFileProgress,
+  }) async {
+    final deviceDir = Directory(deviceFolderPath);
+    if (!await deviceDir.exists()) {
+      return FolderImportResult(foldersCreated: 0, filesImported: 0, errors: ['Directory does not exist: $deviceFolderPath']);
+    }
+
+    final folderName = deviceDir.path.split('/').last;
+    final folder = await createFolder(name: folderName, parentId: parentFolderId);
+    if (folder == null) {
+      return FolderImportResult(foldersCreated: 0, filesImported: 0, errors: ['Failed to create folder']);
+    }
+
+    int foldersCreated = 1;
+    int filesImported = 0;
+    final errors = <String>[];
+
+    final allFiles = <FileToVault>[];
+    final subfolderPaths = <String>[];
+
+    await _collectFilesFromDirectory(
+      deviceDir,
+      allFiles: allFiles,
+      subfolderPaths: subfolderPaths,
+      recursive: recursive,
+    );
+
+    final totalFiles = allFiles.length;
+    if (totalFiles > 0) {
+      final importedFiles = await _fileService.addFiles(
+        files: allFiles,
+        deleteOriginals: deleteOriginals,
+        encrypt: encrypt,
+        isDecoy: isDecoy,
+        onProgress: onProgress,
+        onFileProgress: onFileProgress != null
+            ? (info) => onFileProgress(info.fileName, info.current, info.total)
+            : null,
+      );
+
+      for (final importedFile in importedFiles) {
+        await addFileToFolder(importedFile.id, folder.id);
+        filesImported++;
+      }
+    }
+
+    if (recursive) {
+      for (final subPath in subfolderPaths) {
+        final subResult = await importDeviceFolder(
+          subPath,
+          parentFolderId: folder.id,
+          recursive: true,
+          deleteOriginals: deleteOriginals,
+          encrypt: encrypt,
+          isDecoy: isDecoy,
+        );
+        foldersCreated += subResult.foldersCreated;
+        filesImported += subResult.filesImported;
+        errors.addAll(subResult.errors);
+      }
+    }
+
+    return FolderImportResult(
+      foldersCreated: foldersCreated,
+      filesImported: filesImported,
+      errors: errors,
+      rootFolder: folder,
+    );
+  }
+
+  Future<void> _collectFilesFromDirectory(
+    Directory dir, {
+    required List<FileToVault> allFiles,
+    required List<String> subfolderPaths,
+    required bool recursive,
+  }) async {
+    try {
+      await for (final entity in dir.list()) {
+        if (entity is File) {
+          final file = entity;
+          final fileName = file.path.split('/').last;
+          if (fileName.startsWith('.')) continue;
+
+          final extension = fileName.contains('.')
+              ? fileName.split('.').last.toLowerCase()
+              : '';
+          final mimeType = _getMimeTypeFromExtension(extension);
+          final fileType = getFileTypeFromExtension(extension);
+
+          allFiles.add(FileToVault(
+            sourcePath: file.path,
+            originalName: fileName,
+            type: fileType,
+            mimeType: mimeType,
+          ));
+        } else if (entity is Directory && recursive) {
+          final dirName = entity.path.split('/').last;
+          if (dirName.startsWith('.')) continue;
+          subfolderPaths.add(entity.path);
+        }
+      }
+    } catch (e) {
+      debugPrint('Error collecting files from directory: $e');
+    }
+  }
+
+  String _getMimeTypeFromExtension(String extension) {
+    const mimeMap = {
+      'jpg': 'image/jpeg', 'jpeg': 'image/jpeg', 'png': 'image/png',
+      'gif': 'image/gif', 'webp': 'image/webp', 'bmp': 'image/bmp',
+      'heic': 'image/heic', 'heif': 'image/heif',
+      'mp4': 'video/mp4', 'mov': 'video/quicktime', 'avi': 'video/x-msvideo',
+      'mkv': 'video/x-matroska', 'webm': 'video/webm',
+      'mp3': 'audio/mpeg', 'wav': 'audio/wav', 'flac': 'audio/flac',
+      'aac': 'audio/aac', 'ogg': 'audio/ogg', 'm4a': 'audio/mp4',
+      'pdf': 'application/pdf', 'doc': 'application/msword',
+      'docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'txt': 'text/plain', 'rtf': 'application/rtf',
+      'zip': 'application/zip', 'rar': 'application/x-rar-compressed',
+      '7z': 'application/x-7z-compressed',
+      'json': 'application/json', 'xml': 'application/xml',
+      'csv': 'text/csv', 'html': 'text/html', 'htm': 'text/html',
+    };
+    return mimeMap[extension.toLowerCase()] ?? 'application/octet-stream';
+  }
+}

--- a/lib/services/office_converter_service.dart
+++ b/lib/services/office_converter_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -58,6 +59,25 @@ class OfficeConverterService {
   static const List<String> convertibleExtensions = [
     'docx', 'odt', 'rtf', // Currently supported for on-device conversion
   ];
+
+  // ponytail: font loaded once on the main isolate (rootBundle is platform-
+  // channel-backed, unavailable in a spawned isolate) then passed into the
+  // conversion worker.
+  static Uint8List? _cachedFontBytes;
+  static bool _fontLoaded = false;
+
+  static Future<Uint8List?> _loadFontBytes() async {
+    if (_fontLoaded) return _cachedFontBytes;
+    _fontLoaded = true;
+    try {
+      final fontData = await rootBundle.load('fonts/productsans_regular.ttf');
+      _cachedFontBytes = fontData.buffer.asUint8List();
+    } catch (e) {
+      debugPrint('Could not load custom font for PDF: $e');
+      _cachedFontBytes = null;
+    }
+    return _cachedFontBytes;
+  }
 
   /// Check if a file extension is an Office document
   static bool isOfficeDocument(String extension) {
@@ -134,33 +154,45 @@ class OfficeConverterService {
   ) async {
     final fileType = getFileType(extension);
 
+    if (fileType == OfficeFileType.unknown) {
+      return ConversionResult(success: false, error: 'Unknown file format');
+    }
+
+    const requiresExternal = {
+      OfficeFileType.xlsx,
+      OfficeFileType.xls,
+      OfficeFileType.ods,
+      OfficeFileType.pptx,
+      OfficeFileType.ppt,
+      OfficeFileType.odp,
+      OfficeFileType.doc,
+    };
+    if (requiresExternal.contains(fileType)) {
+      return ConversionResult(
+        success: false,
+        requiresExternalApp: true,
+        error: 'This file format requires an external app to view.',
+      );
+    }
+
     try {
-      switch (fileType) {
-        case OfficeFileType.docx:
-          return await _convertDocxToPdf(fileData, fileName);
-        case OfficeFileType.odt:
-          return await _convertOdtToPdf(fileData, fileName);
-        case OfficeFileType.rtf:
-          return await _convertRtfToPdf(fileData, fileName);
-        case OfficeFileType.xlsx:
-        case OfficeFileType.xls:
-        case OfficeFileType.ods:
-        case OfficeFileType.pptx:
-        case OfficeFileType.ppt:
-        case OfficeFileType.odp:
-        case OfficeFileType.doc:
-          // These formats require external app opening
-          return ConversionResult(
-            success: false,
-            requiresExternalApp: true,
-            error: 'This file format requires an external app to view.',
-          );
-        case OfficeFileType.unknown:
-          return ConversionResult(
-            success: false,
-            error: 'Unknown file format',
-          );
-      }
+      final fontBytes = await _loadFontBytes();
+      // ponytail: ZIP decode + XML parse + PDF layout are pure Dart, so they
+      // run in an isolate to keep the UI thread free during docx/odt/rtf
+      // import. Static methods => no `this` capture sent across.
+      return await Isolate.run(() async {
+        switch (fileType) {
+          case OfficeFileType.docx:
+            return await _convertDocxToPdf(fileData, fileName, fontBytes);
+          case OfficeFileType.odt:
+            return await _convertOdtToPdf(fileData, fileName, fontBytes);
+          case OfficeFileType.rtf:
+            return await _convertRtfToPdf(fileData, fileName, fontBytes);
+          default:
+            return ConversionResult(
+                success: false, error: 'Unsupported file format');
+        }
+      });
     } catch (e) {
       debugPrint('Error converting document: $e');
       return ConversionResult(
@@ -171,8 +203,8 @@ class OfficeConverterService {
   }
 
   /// Convert DOCX to PDF
-  Future<ConversionResult> _convertDocxToPdf(
-      Uint8List fileData, String fileName) async {
+  static Future<ConversionResult> _convertDocxToPdf(
+      Uint8List fileData, String fileName, Uint8List? fontBytes) async {
     try {
       // Extract text content from DOCX
       final content = await _extractDocxContent(fileData);
@@ -185,7 +217,7 @@ class OfficeConverterService {
       }
 
       // Create PDF with extracted content
-      final pdfData = await _createPdfFromContent(content, fileName);
+      final pdfData = await _createPdfFromContent(content, fileName, fontBytes);
 
       return ConversionResult(
         success: true,
@@ -201,8 +233,8 @@ class OfficeConverterService {
   }
 
   /// Convert ODT to PDF
-  Future<ConversionResult> _convertOdtToPdf(
-      Uint8List fileData, String fileName) async {
+  static Future<ConversionResult> _convertOdtToPdf(
+      Uint8List fileData, String fileName, Uint8List? fontBytes) async {
     try {
       // Extract text content from ODT
       final content = await _extractOdtContent(fileData);
@@ -215,7 +247,7 @@ class OfficeConverterService {
       }
 
       // Create PDF with extracted content
-      final pdfData = await _createPdfFromContent(content, fileName);
+      final pdfData = await _createPdfFromContent(content, fileName, fontBytes);
 
       return ConversionResult(
         success: true,
@@ -231,8 +263,8 @@ class OfficeConverterService {
   }
 
   /// Convert RTF to PDF
-  Future<ConversionResult> _convertRtfToPdf(
-      Uint8List fileData, String fileName) async {
+  static Future<ConversionResult> _convertRtfToPdf(
+      Uint8List fileData, String fileName, Uint8List? fontBytes) async {
     try {
       // Extract plain text from RTF
       final content = _extractRtfContent(fileData);
@@ -245,7 +277,7 @@ class OfficeConverterService {
       }
 
       // Create PDF with extracted content
-      final pdfData = await _createPdfFromContent([content], fileName);
+      final pdfData = await _createPdfFromContent([content], fileName, fontBytes);
 
       return ConversionResult(
         success: true,
@@ -261,7 +293,7 @@ class OfficeConverterService {
   }
 
   /// Extract text content from DOCX file
-  Future<List<String>> _extractDocxContent(Uint8List fileData) async {
+  static Future<List<String>> _extractDocxContent(Uint8List fileData) async {
     final List<String> paragraphs = [];
 
     try {
@@ -314,7 +346,7 @@ class OfficeConverterService {
   }
 
   /// Extract text content from ODT file
-  Future<List<String>> _extractOdtContent(Uint8List fileData) async {
+  static Future<List<String>> _extractOdtContent(Uint8List fileData) async {
     final List<String> paragraphs = [];
 
     try {
@@ -347,7 +379,7 @@ class OfficeConverterService {
   }
 
   /// Extract plain text from RTF
-  String _extractRtfContent(Uint8List fileData) {
+  static String _extractRtfContent(Uint8List fileData) {
     try {
       final content = String.fromCharCodes(fileData);
 
@@ -388,8 +420,8 @@ class OfficeConverterService {
   }
 
   /// Create PDF from extracted text content
-  Future<Uint8List> _createPdfFromContent(
-      List<String> paragraphs, String fileName) async {
+  static Future<Uint8List> _createPdfFromContent(
+      List<String> paragraphs, String fileName, Uint8List? fontBytes) async {
     // Create a new PDF document
     final PdfDocument document = PdfDocument();
 
@@ -401,22 +433,18 @@ class OfficeConverterService {
     PdfPage page = document.pages.add();
     final pageSize = page.getClientSize();
 
-    // Try to load custom font, otherwise use standard
+    // Custom font pre-loaded on main isolate, else fall back to standard font
     PdfFont titleFont;
     PdfFont bodyFont;
     bool usingStandardFont = true;
 
-    try {
-      final fontData = await rootBundle.load('fonts/productsans_regular.ttf');
-      final fontBytes = fontData.buffer.asUint8List();
-
+    if (fontBytes != null) {
       titleFont = PdfTrueTypeFont(fontBytes, 14, style: PdfFontStyle.bold);
       bodyFont = PdfTrueTypeFont(fontBytes, 11);
       usingStandardFont = false;
-    } catch (e) {
-      debugPrint('Could not load custom font for PDF: $e');
-      titleFont = PdfStandardFont(PdfFontFamily.helvetica, 14,
-          style: PdfFontStyle.bold);
+    } else {
+      titleFont =
+          PdfStandardFont(PdfFontFamily.helvetica, 14, style: PdfFontStyle.bold);
       bodyFont = PdfStandardFont(PdfFontFamily.helvetica, 11);
     }
 

--- a/lib/services/search_service.dart
+++ b/lib/services/search_service.dart
@@ -1,0 +1,60 @@
+import '../models/vaulted_file.dart';
+import 'vault_store.dart';
+
+/// Read-only search over the file index. Splits out of `VaultService`.
+class SearchService {
+  final VaultStore _store;
+  SearchService(this._store);
+
+  Future<List<VaultedFile>> searchFiles(String query) async {
+    final files = await _store.loadFileIndex();
+    final lowerQuery = query.toLowerCase();
+    return files
+        .where((f) => f.originalName.toLowerCase().contains(lowerQuery))
+        .toList();
+  }
+
+  Future<List<VaultedFile>> searchFilesAdvanced({
+    String? query,
+    List<String>? tags,
+    VaultedFileType? type,
+    DateTime? dateFrom,
+    DateTime? dateTo,
+    bool? isFavorite,
+    String? albumId,
+  }) async {
+    var files = await _store.loadFileIndex();
+
+    if (query != null && query.isNotEmpty) {
+      final lowerQuery = query.toLowerCase();
+      files = files
+          .where((f) => f.originalName.toLowerCase().contains(lowerQuery))
+          .toList();
+    }
+
+    if (tags != null && tags.isNotEmpty) {
+      files = files.where((f) => tags.every((tag) => f.hasTag(tag))).toList();
+    }
+
+    if (type != null) {
+      files = files.where((f) => f.type == type).toList();
+    }
+
+    if (dateFrom != null) {
+      files = files.where((f) => f.dateAdded.isAfter(dateFrom)).toList();
+    }
+    if (dateTo != null) {
+      files = files.where((f) => f.dateAdded.isBefore(dateTo)).toList();
+    }
+
+    if (isFavorite != null) {
+      files = files.where((f) => f.isFavorite == isFavorite).toList();
+    }
+
+    if (albumId != null) {
+      files = files.where((f) => f.isInAlbum(albumId)).toList();
+    }
+
+    return files;
+  }
+}

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,0 +1,20 @@
+import '../models/vault_settings.dart';
+import 'vault_store.dart';
+
+/// Settings load/save. Splits out of `VaultService`.
+///
+/// ponytail: tiny — just delegating the load/save to the store. Exists as a
+/// separate service so Phase 4 Riverpod wiring has a clean injection point
+/// and so callers don't depend on the whole VaultService for a single
+/// getSettings call.
+class SettingsService {
+  final VaultStore _store;
+  SettingsService(this._store);
+
+  Future<VaultSettings> getSettings() => _store.loadSettings();
+
+  Future<void> updateSettings(VaultSettings settings) async {
+    _store.cachedSettings = settings;
+    await _store.saveSettings();
+  }
+}

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -1,0 +1,24 @@
+import '../models/vaulted_file.dart';
+import 'vault_store.dart';
+
+/// Read-only stats over the file index. Splits out of `VaultService`.
+class StatsService {
+  final VaultStore _store;
+  StatsService(this._store);
+
+  Future<Map<VaultedFileType, int>> getFileCounts() async {
+    final files = await _store.loadFileIndex();
+    final counts = <VaultedFileType, int>{};
+
+    for (final type in VaultedFileType.values) {
+      counts[type] = files.where((f) => f.type == type).length;
+    }
+
+    return counts;
+  }
+
+  Future<int> getTotalStorageUsed() async {
+    final files = await _store.loadFileIndex();
+    return files.fold<int>(0, (sum, file) => sum + file.fileSize);
+  }
+}

--- a/lib/services/tag_service.dart
+++ b/lib/services/tag_service.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/vaulted_file.dart';
+import 'album_service.dart';
+import 'file_service.dart';
+import 'vault_store.dart';
+
+/// Tag CRUD + favorites toggle. Splits out of `VaultService`.
+///
+/// ponytail: favorites live here (not in AlbumService) because toggling a
+/// favorite is a tag-like single-file op that delegates to the favorites
+/// album — keeping it here avoids a circular dep (AlbumService → FileService →
+/// AlbumService). FileService depends on TagService (for `addTagToFile`),
+/// so favorites-as-tag keeps the graph one-directional.
+class TagService {
+  final VaultStore _store;
+  final AlbumService _albumService;
+  final FileService _fileService;
+
+  TagService(this._store, this._albumService, this._fileService);
+
+  Future<List<TagInfo>> getAllTags() => _store.loadTags();
+
+  Future<List<VaultedFile>> getFilesByTag(String tag) async {
+    final files = await _fileService.getAllFiles();
+    return files.where((f) => f.hasTag(tag)).toList();
+  }
+
+  Future<VaultedFile?> addTagToFile(String fileId, String tag) async {
+    final file = await _fileService.getFileById(fileId);
+    if (file == null) return null;
+
+    final updatedFile = file.addTag(tag);
+    await _fileService.updateFile(updatedFile);
+    await updateTagUsage([tag]);
+
+    return updatedFile;
+  }
+
+  Future<VaultedFile?> removeTagFromFile(String fileId, String tag) async {
+    final file = await _fileService.getFileById(fileId);
+    if (file == null) return null;
+
+    final updatedFile = file.removeTag(tag);
+    await _fileService.updateFile(updatedFile);
+
+    return updatedFile;
+  }
+
+  Future<void> updateTagUsage(List<String> tags) async {
+    _store.cachedTags ??= [];
+
+    for (final tag in tags) {
+      final normalizedTag = tag.toLowerCase().trim();
+      if (normalizedTag.isEmpty) continue;
+
+      final existingIndex =
+          _store.cachedTags!.indexWhere((t) => t.name == normalizedTag);
+
+      if (existingIndex == -1) {
+        _store.cachedTags!.add(TagInfo(name: normalizedTag, usageCount: 1));
+      } else {
+        _store.cachedTags![existingIndex] = TagInfo(
+          name: normalizedTag,
+          colorValue: _store.cachedTags![existingIndex].colorValue,
+          usageCount: _store.cachedTags![existingIndex].usageCount + 1,
+        );
+      }
+    }
+
+    await _store.saveTags();
+  }
+
+  Future<TagInfo> createTag(String name, [int? colorValue]) async {
+    _store.cachedTags ??= await _store.loadTags();
+
+    final normalizedName = name.toLowerCase().trim();
+    final existingIndex =
+        _store.cachedTags!.indexWhere((t) => t.name == normalizedName);
+
+    if (existingIndex != -1) {
+      if (colorValue != null) {
+        _store.cachedTags![existingIndex] = TagInfo(
+          name: normalizedName,
+          colorValue: colorValue,
+          usageCount: _store.cachedTags![existingIndex].usageCount,
+        );
+        await _store.saveTags();
+      }
+      return _store.cachedTags![existingIndex];
+    }
+
+    final newTag = TagInfo(
+      name: normalizedName,
+      colorValue: colorValue ?? 0xFF1976D2,
+      usageCount: 0,
+    );
+    _store.cachedTags!.add(newTag);
+    await _store.saveTags();
+
+    return newTag;
+  }
+
+  Future<bool> updateTagColor(String tagName, int colorValue) async {
+    _store.cachedTags ??= await _store.loadTags();
+
+    final normalizedName = tagName.toLowerCase().trim();
+    final index = _store.cachedTags!.indexWhere((t) => t.name == normalizedName);
+
+    if (index == -1) return false;
+
+    _store.cachedTags![index] = TagInfo(
+      name: normalizedName,
+      colorValue: colorValue,
+      usageCount: _store.cachedTags![index].usageCount,
+    );
+    await _store.saveTags();
+
+    return true;
+  }
+
+  Future<bool> deleteTag(String tagName) async {
+    try {
+      final normalizedName = tagName.toLowerCase().trim();
+
+      final files = await _fileService.getAllFiles();
+      for (final file in files) {
+        if (file.hasTag(normalizedName)) {
+          await removeTagFromFile(file.id, normalizedName);
+        }
+      }
+
+      _store.cachedTags ??= await _store.loadTags();
+      _store.cachedTags!.removeWhere((t) => t.name == normalizedName);
+      await _store.saveTags();
+
+      return true;
+    } catch (e) {
+      debugPrint('Error deleting tag: $e');
+      return false;
+    }
+  }
+
+  // ---- Favorites ----
+
+  Future<VaultedFile?> toggleFavorite(String fileId) async {
+    final file = await _fileService.getFileById(fileId);
+    if (file == null) return null;
+
+    final favoritesAlbum = await _albumService.getAlbumById('favorites');
+    if (favoritesAlbum != null) {
+      if (file.isFavorite) {
+        await _albumService.removeFileFromAlbum(fileId, 'favorites');
+      } else {
+        await _albumService.addFileToAlbum(fileId, 'favorites');
+      }
+    } else {
+      final updatedFile = file.toggleFavorite();
+      await _fileService.updateFile(updatedFile);
+      return updatedFile;
+    }
+
+    return await _fileService.getFileById(fileId);
+  }
+
+  Future<List<VaultedFile>> getFavoriteFiles() async {
+    final files = await _fileService.getAllFiles();
+    return files.where((f) => f.isFavorite).toList();
+  }
+}

--- a/lib/services/thumbnail_service.dart
+++ b/lib/services/thumbnail_service.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:video_compress/video_compress.dart';
+
+import '../models/vaulted_file.dart';
+import 'encryption_service.dart';
+import 'file_service.dart';
+import 'vault_store.dart';
+
+class StoredThumb {
+  final String path;
+  final String iv;
+  const StoredThumb(this.path, this.iv);
+}
+
+/// Encrypted-thumbnail generation, caching, lazy regen. Splits out of
+/// `VaultService`.
+///
+/// ponytail: depends on FileService for `getVaultedFile` (decrypt-to-temp for
+/// regen) and `deriveKeyForFile`. The File↔Thumbnail cycle is broken by a
+/// late non-final `fileService` field set after both are constructed —
+/// neither reads the other during construction, only at runtime.
+class ThumbnailService {
+  final VaultStore _store;
+  final EncryptionService _encryptionService;
+  late FileService fileService;
+
+  ThumbnailService(this._store, this._encryptionService);
+
+  final Map<String, Uint8List> _cache = {};
+  final Map<String, Future<Uint8List?>> _inFlight = {};
+  static const int _cacheLimit = 200;
+  Future<void> _genLock = Future.value();
+
+  Future<Uint8List?> getThumbnailBytes(VaultedFile file) async {
+    if (!file.isEncrypted) return null;
+    final cached = _cache[file.id];
+    if (cached != null) return cached;
+    final inFlight = _inFlight[file.id];
+    if (inFlight != null) return inFlight;
+    final fut = _loadOrRegenerateThumbnail(file);
+    _inFlight[file.id] = fut;
+    try {
+      final bytes = await fut;
+      if (bytes != null) _cacheThumbnail(file.id, bytes);
+      return bytes;
+    } finally {
+      _inFlight.remove(file.id);
+    }
+  }
+
+  void _cacheThumbnail(String id, Uint8List bytes) {
+    _cache[id] = bytes;
+    if (_cache.length > _cacheLimit) {
+      _cache.remove(_cache.keys.first);
+    }
+  }
+
+  Future<Uint8List?> _loadOrRegenerateThumbnail(VaultedFile file) {
+    final prev = _genLock;
+    final result = prev.then((_) => _loadOrRegenerateThumbnailLocked(file));
+    _genLock = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  Future<Uint8List?> _loadOrRegenerateThumbnailLocked(VaultedFile file) async {
+    if (file.thumbnailPath != null && file.thumbnailIv != null) {
+      final thumbFile = File(file.thumbnailPath!);
+      if (await thumbFile.exists()) {
+        final derivedKey = await fileService.deriveKeyForFile(file);
+        final res = await _encryptionService.decryptStreamedFileToMemoryGcm(
+          file.thumbnailPath!,
+          file.thumbnailIv!,
+          isDecoy: file.isDecoy,
+          derivedKey: derivedKey,
+        );
+        if (res.success && res.data != null) return res.data;
+      }
+    }
+    return _regenerateThumbnail(file);
+  }
+
+  Future<Uint8List?> _regenerateThumbnail(VaultedFile file) async {
+    final plaintext = await fileService.getVaultedFile(file.id, isDecoy: file.isDecoy);
+    if (plaintext == null) return null;
+    try {
+      final thumbBytes = await generateThumbBytes(plaintext, file.type);
+      if (thumbBytes == null) return null;
+      final derivedKey = await fileService.deriveKeyForFile(file);
+      if (derivedKey != null) {
+        final stored = await encryptAndStoreThumbnail(
+          thumbBytes,
+          fileId: file.id,
+          derivedKey: derivedKey,
+          isDecoy: file.isDecoy,
+        );
+        if (stored != null) {
+          await _persistThumbnailRecord(
+            file.id,
+            stored.path,
+            stored.iv,
+            isDecoy: file.isDecoy,
+          );
+        }
+      }
+      return thumbBytes;
+    } finally {
+      try {
+        if (await plaintext.exists()) await plaintext.delete();
+      } catch (_) {}
+    }
+  }
+
+  Future<Uint8List?> generateThumbBytes(File plaintext, VaultedFileType type) async {
+    try {
+      if (type == VaultedFileType.video) {
+        return await VideoCompress.getByteThumbnail(plaintext.path, quality: 70);
+      }
+      return await FlutterImageCompress.compressWithFile(
+        plaintext.path,
+        minWidth: 300,
+        minHeight: 300,
+        quality: 70,
+      );
+    } catch (e) {
+      debugPrint('[Vault] thumbnail generation failed: $e');
+      return null;
+    }
+  }
+
+  Future<StoredThumb?> encryptAndStoreThumbnail(
+    Uint8List thumbBytes, {
+    required String fileId,
+    required Uint8List derivedKey,
+    required bool isDecoy,
+  }) async {
+    final dir = isDecoy
+        ? await _store.ensureDecoyDirectory()
+        : await _store.ensureVaultDirectory();
+    final thumbPath = '${dir.path}/thumbnails/$fileId.thumb.enc';
+    final tempDir = await getTemporaryDirectory();
+    final tempPath =
+        '${tempDir.path}/lkr_thumb_${DateTime.now().microsecondsSinceEpoch}';
+    await File(tempPath).writeAsBytes(thumbBytes);
+    try {
+      final res = await _encryptionService.encryptFileInIsolate(
+        tempPath,
+        thumbPath,
+        isDecoy: isDecoy,
+        useGcm: true,
+        derivedKey: derivedKey,
+      );
+      if (!res.success || res.iv == null) return null;
+      return StoredThumb(thumbPath, res.iv!);
+    } catch (e) {
+      debugPrint('[Vault] thumbnail encrypt failed: $e');
+      return null;
+    } finally {
+      await _store.deleteFileIfExists(tempPath);
+    }
+  }
+
+  Future<void> _persistThumbnailRecord(
+    String fileId,
+    String path,
+    String iv, {
+    required bool isDecoy,
+  }) async {
+    final files = await _store.loadFileIndex(isDecoy: isDecoy);
+    final idx = files.indexWhere((f) => f.id == fileId);
+    if (idx == -1) return;
+    files[idx] = files[idx].copyWith(thumbnailPath: path, thumbnailIv: iv);
+    await _store.saveFileIndex(isDecoy: isDecoy);
+  }
+
+  void clearCache() {
+    _cache.clear();
+    _inFlight.clear();
+  }
+}

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -1,504 +1,99 @@
-import 'dart:convert';
 import 'dart:io';
+
 import 'package:flutter/foundation.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:crypto/crypto.dart';
-import '../models/vaulted_file.dart';
+
 import '../models/album.dart';
-import '../models/vault_folder.dart';
 import '../models/encryption_algorithm.dart';
-import 'encryption_service.dart';
-import 'compression_service.dart';
+import '../models/file_to_vault.dart';
+import '../models/vault_folder.dart';
+import '../models/vault_settings.dart';
+import '../models/vaulted_file.dart';
+import 'album_service.dart';
 import 'crypto_isolate_pool.dart';
-import 'package:flutter_image_compress/flutter_image_compress.dart';
-import 'package:video_compress/video_compress.dart';
+import 'encryption_service.dart';
+import 'file_service.dart';
+import 'folder_service.dart';
+import 'search_service.dart';
+import 'settings_service.dart';
+import 'stats_service.dart';
+import 'tag_service.dart';
+import 'thumbnail_service.dart';
+import 'vault_store.dart';
 
-class FileProgressInfo {
-  final int current;
-  final int total;
-  final String fileName;
-  final int fileSize;
-  final String status;
-  final bool isEncrypting;
-  final int encryptedBytes;
-  final int totalBytes;
+export 'file_service.dart' show FileProgressInfo;
 
-  const FileProgressInfo({
-    required this.current,
-    required this.total,
-    required this.fileName,
-    required this.fileSize,
-    required this.status,
-    this.isEncrypting = false,
-    this.encryptedBytes = 0,
-    this.totalBytes = 0,
-  });
-}
-
-class _PreparedVaultAddition {
-  final VaultedFile vaultedFile;
-
-  const _PreparedVaultAddition({required this.vaultedFile});
-}
-
-class _BatchPreparationResult {
-  final int index;
-  final FileToVault file;
-  final int fileSize;
-  final _PreparedVaultAddition? prepared;
-
-  const _BatchPreparationResult({
-    required this.index,
-    required this.file,
-    required this.fileSize,
-    required this.prepared,
-  });
-}
-
-class _StoredThumb {
-  final String path;
-  final String iv;
-  const _StoredThumb(this.path, this.iv);
-}
-
-/// Service for managing vaulted files storage
+/// Facade over the split vault services. Preserves the original `VaultService`
+/// API surface so the 11 direct `VaultService.instance` callers + Riverpod
+/// providers keep working. Phase 4 (Riverpod) removes this facade in favor of
+/// per-service providers.
+///
+/// ponytail: facade + forwarding. The real logic now lives in the split
+/// services (FileService, AlbumService, FolderService, TagService,
+/// ThumbnailService, SearchService, StatsService, SettingsService). This
+/// class solely composes them + forwards ~100 public methods. No behavioral
+/// changes from pre-split — same delegate order, same cache (now in VaultStore).
 class VaultService {
-  VaultService._();
-  static final VaultService instance = VaultService._();
+  @visibleForTesting
+  VaultService();
+  static final VaultService instance = VaultService();
 
-  static const int _maxConcurrentBatchAdds = 3;
+  late final VaultStore _store = VaultStore();
+  late final EncryptionService _encryptionService = EncryptionService.instance;
 
-  static const _storage = FlutterSecureStorage(
-    aOptions: AndroidOptions(),
-    iOptions: IOSOptions(accessibility: KeychainAccessibility.unlocked_this_device),
-  );
+  // ponytail: File↔Thumbnail form a construction cycle (each calls the other
+  // at runtime, never at construction). Break it with a late non-final
+  // back-reference on ThumbnailService that's wired after both exist.
+  late final ThumbnailService _thumbnails =
+      ThumbnailService(_store, _encryptionService);
+  late final FileService _files =
+      FileService(_store, _encryptionService, _thumbnails);
+  late final AlbumService _albums = AlbumService(_store, _files);
+  late final FolderService _folders = FolderService(_store, _files);
+  late final TagService _tags = TagService(_store, _albums, _files);
+  late final SearchService _search = SearchService(_store);
+  late final StatsService _stats = StatsService(_store);
+  late final SettingsService _settings = SettingsService(_store);
 
-  static const String _vaultIndexKey = 'vault_file_index';
-  static const String _decoyIndexKey = 'vault_decoy_index';
-  static const String _albumsKey = 'vault_albums';
-  static const String _tagsKey = 'vault_tags';
-  static const String _settingsKey = 'vault_settings';
-  static const String _vaultFolderName = '.locker_vault';
-  static const String _decoyFolderName = '.locker_decoy';
-  static const String _foldersKey = 'vault_folders';
+  // Wire late back-edges once everything's constructed. Tests hit this via
+  // the implicit first call to any forwarded method.
+  bool _wired = false;
+  void _wire() {
+    if (_wired) return;
+    _thumbnails.fileService = _files;
+    _files.updateTagUsage = _tags.updateTagUsage;
+    _files.removeFileFromAlbumFn = _albums.removeFileFromAlbum;
+    _wired = true;
+  }
 
-  final EncryptionService _encryptionService = EncryptionService.instance;
+  // ---- Lifecycle ----
 
-  Directory? _vaultDirectory;
-  Directory? _decoyDirectory;
-  List<VaultedFile>? _cachedFiles;
-  List<VaultedFile>? _cachedDecoyFiles;
-  List<Album>? _cachedAlbums;
-  List<VaultFolder>? _cachedFolders;
-  List<TagInfo>? _cachedTags;
-  VaultSettings? _cachedSettings;
-
-  // ponytail: in-memory encrypted-thumb cache + in-flight dedupe. Mirrors the
-  // accepted security model (plaintext persists like _decryptedFileCache /
-  // master key until process death); cleared in clearVault.
-  final Map<String, Uint8List> _thumbnailCache = {};
-  final Map<String, Future<Uint8List?>> _thumbnailInFlight = {};
-  static const int _thumbnailCacheLimit = 200;
-  // ponytail: single-flight lock over thumbnail generation — only one full-file
-  // decrypt + image decode runs at a time so a grid of N encrypted files can't
-  // OOM/ANR the app. Fan out (small semaphore) only if first-load latency bites.
-  Future<void> _thumbGenLock = Future.value();
-
-  /// Initialize the vault service
   Future<void> initialize() async {
     await _encryptionService.initialize();
-    await _ensureVaultDirectory();
-    await _loadFileIndex();
-    await _loadAlbums();
-    await _loadFolders();
-    await _loadTags();
-    await _loadSettings();
+    await _store.ensureVaultDirectory();
+    await _store.loadFileIndex();
+    await _store.loadAlbums();
+    await _store.loadFolders();
+    await _store.loadTags();
+    await _store.loadSettings();
+    _wire();
   }
 
-  /// Get the vault directory
-  Future<Directory> _ensureVaultDirectory() async {
-    if (_vaultDirectory != null && await _vaultDirectory!.exists()) {
-      await _ensureNoMediaFile(_vaultDirectory!.path);
-      return _vaultDirectory!;
-    }
-
-    final appDir = await getApplicationDocumentsDirectory();
-    _vaultDirectory = Directory('${appDir.path}/$_vaultFolderName');
-
-    if (!await _vaultDirectory!.exists()) {
-      await _vaultDirectory!.create(recursive: true);
-    }
-
-    // Create subdirectories for different file types
-    await Directory('${_vaultDirectory!.path}/images').create(recursive: true);
-    await Directory('${_vaultDirectory!.path}/videos').create(recursive: true);
-    await Directory('${_vaultDirectory!.path}/songs').create(recursive: true);
-    await Directory('${_vaultDirectory!.path}/documents')
-        .create(recursive: true);
-    await Directory('${_vaultDirectory!.path}/thumbnails')
-        .create(recursive: true);
-    await Directory('${_vaultDirectory!.path}/temp').create(recursive: true);
-
-    // Prevent system gallery/media scanner from indexing vault contents
-    await _ensureNoMediaFile(_vaultDirectory!.path);
-
-    return _vaultDirectory!;
+  /// Loads indexes without initializing encryption (test-only).
+  @visibleForTesting
+  Future<void> loadIndexesForTesting() async {
+    _wire();
+    await _store.ensureVaultDirectory();
+    _store.cachedFiles = await _store.loadFileIndex(forceReload: true);
+    _store.cachedDecoyFiles =
+        await _store.loadFileIndex(isDecoy: true, forceReload: true);
+    _store.cachedAlbums = await _store.loadAlbums(forceReload: true);
+    _store.cachedFolders = await _store.loadFolders(forceReload: true);
+    _store.cachedTags = await _store.loadTags(forceReload: true);
+    _store.cachedSettings = await _store.loadSettings();
   }
 
-  /// Get the decoy directory
-  Future<Directory> _ensureDecoyDirectory() async {
-    if (_decoyDirectory != null && await _decoyDirectory!.exists()) {
-      await _ensureNoMediaFile(_decoyDirectory!.path);
-      return _decoyDirectory!;
-    }
+  // ---- Files ----
 
-    final appDir = await getApplicationDocumentsDirectory();
-    _decoyDirectory = Directory('${appDir.path}/$_decoyFolderName');
-
-    if (!await _decoyDirectory!.exists()) {
-      await _decoyDirectory!.create(recursive: true);
-    }
-
-    await Directory('${_decoyDirectory!.path}/images').create(recursive: true);
-    await Directory('${_decoyDirectory!.path}/videos').create(recursive: true);
-    await Directory('${_decoyDirectory!.path}/songs').create(recursive: true);
-    await Directory('${_decoyDirectory!.path}/documents')
-        .create(recursive: true);
-
-    // Prevent media scanner from indexing decoy vault
-    await _ensureNoMediaFile(_decoyDirectory!.path);
-
-    return _decoyDirectory!;
-  }
-
-  /// Ensure a .nomedia marker exists to hide from gallery/media scanners
-  Future<void> _ensureNoMediaFile(String directoryPath) async {
-    final noMediaFile = File('$directoryPath/.nomedia');
-    if (!await noMediaFile.exists()) {
-      await noMediaFile.create();
-    }
-  }
-
-  /// Get subdirectory path for file type
-  String _getSubdirectory(VaultedFileType type) {
-    switch (type) {
-      case VaultedFileType.image:
-        return 'images';
-      case VaultedFileType.video:
-        return 'videos';
-      case VaultedFileType.song:
-        return 'songs';
-      case VaultedFileType.document:
-      case VaultedFileType.other:
-        return 'documents';
-    }
-  }
-
-  /// Load file index from secure storage
-  Future<List<VaultedFile>> _loadFileIndex({
-    bool isDecoy = false,
-    bool forceReload = false,
-  }) async {
-    if (!forceReload && !isDecoy && _cachedFiles != null) {
-      return _cachedFiles!;
-    }
-    if (!forceReload && isDecoy && _cachedDecoyFiles != null) {
-      return _cachedDecoyFiles!;
-    }
-
-    try {
-      final key = isDecoy ? _decoyIndexKey : _vaultIndexKey;
-      final indexJson = await _storage.read(key: key);
-      if (indexJson == null || indexJson.isEmpty) {
-        if (isDecoy) {
-          _cachedDecoyFiles = [];
-          return _cachedDecoyFiles!;
-        }
-        _cachedFiles = [];
-        return _cachedFiles!;
-      }
-
-      final List<dynamic> jsonList = jsonDecode(indexJson);
-      final files = <VaultedFile>[];
-      for (int i = 0; i < jsonList.length; i++) {
-        try {
-          files.add(
-            VaultedFile.fromJson(jsonList[i] as Map<String, dynamic>),
-          );
-        } catch (e) {
-          debugPrint('Error parsing vault entry $i: $e');
-        }
-      }
-
-      if (files.length < jsonList.length) {
-        debugPrint(
-          'Vault index: recovered ${files.length}/${jsonList.length} entries',
-        );
-        await _storage.write(
-          key: key,
-          value: jsonEncode(files.map((f) => f.toJson()).toList()),
-        );
-      }
-
-      if (isDecoy) {
-        _cachedDecoyFiles = files;
-        return _cachedDecoyFiles!;
-      }
-      _cachedFiles = files;
-      return _cachedFiles!;
-    } catch (e) {
-      debugPrint('Error loading vault index: $e');
-      if (isDecoy) {
-        _cachedDecoyFiles = [];
-        return _cachedDecoyFiles!;
-      }
-      _cachedFiles = [];
-      return _cachedFiles!;
-    }
-  }
-
-  /// Save file index to secure storage
-  Future<void> _saveFileIndex({bool isDecoy = false}) async {
-    try {
-      final files = isDecoy ? _cachedDecoyFiles : _cachedFiles;
-      final key = isDecoy ? _decoyIndexKey : _vaultIndexKey;
-      final jsonList = files?.map((file) => file.toJson()).toList() ?? [];
-
-      if (jsonList.isEmpty) {
-        final existing = await _storage.read(key: key);
-        if (existing != null && existing.isNotEmpty) {
-          final existingCount =
-              (jsonDecode(existing) as List<dynamic>).length;
-          if (existingCount > 0) {
-            debugPrint(
-              'WARNING: Attempted to save empty index over $existingCount existing entries. Aborting save.',
-            );
-            return;
-          }
-        }
-      }
-
-      await _storage.write(key: key, value: jsonEncode(jsonList));
-    } catch (e) {
-      debugPrint('Error saving vault index: $e');
-    }
-  }
-
-  /// Load albums from secure storage
-  Future<List<Album>> _loadAlbums({bool forceReload = false}) async {
-    if (!forceReload && _cachedAlbums != null) return _cachedAlbums!;
-
-    try {
-      final albumsJson = await _storage.read(key: _albumsKey);
-      if (albumsJson == null || albumsJson.isEmpty) {
-        _cachedAlbums = _createDefaultAlbums();
-        await _saveAlbums();
-        return _cachedAlbums!;
-      }
-
-      final List<dynamic> jsonList = jsonDecode(albumsJson);
-      _cachedAlbums = jsonList
-          .map((json) => Album.fromJson(json as Map<String, dynamic>))
-          .toList();
-
-      return _cachedAlbums!;
-    } catch (e) {
-      debugPrint('Error loading albums: $e');
-      _cachedAlbums = _createDefaultAlbums();
-      return _cachedAlbums!;
-    }
-  }
-
-  /// Create default albums
-  List<Album> _createDefaultAlbums() {
-    final now = DateTime.now();
-    return [
-      Album(
-        id: 'favorites',
-        name: 'Favorites',
-        createdAt: now,
-        updatedAt: now,
-        isDefault: true,
-        type: AlbumType.favorites,
-        sortOrder: 0,
-      ),
-      Album(
-        id: 'recent',
-        name: 'Recent',
-        createdAt: now,
-        updatedAt: now,
-        isDefault: true,
-        type: AlbumType.recent,
-        sortOrder: 1,
-      ),
-    ];
-  }
-
-  /// Save albums to secure storage
-  Future<void> _saveAlbums() async {
-    try {
-      final jsonList = _cachedAlbums?.map((a) => a.toJson()).toList() ?? [];
-      await _storage.write(key: _albumsKey, value: jsonEncode(jsonList));
-    } catch (e) {
-      debugPrint('Error saving albums: $e');
-    }
-  }
-
-  /// Load folders from secure storage
-  Future<List<VaultFolder>> _loadFolders({bool forceReload = false}) async {
-    if (!forceReload && _cachedFolders != null) return _cachedFolders!;
-
-    try {
-      final foldersJson = await _storage.read(key: _foldersKey);
-      if (foldersJson == null || foldersJson.isEmpty) {
-        _cachedFolders = [];
-        return _cachedFolders!;
-      }
-
-      final List<dynamic> jsonList = jsonDecode(foldersJson);
-      _cachedFolders = jsonList
-          .map((json) => VaultFolder.fromJson(json as Map<String, dynamic>))
-          .toList();
-
-      return _cachedFolders!;
-    } catch (e) {
-      debugPrint('Error loading folders: $e');
-      _cachedFolders = [];
-      return _cachedFolders!;
-    }
-  }
-
-  /// Save folders to secure storage
-  Future<void> _saveFolders() async {
-    try {
-      final jsonList = _cachedFolders?.map((f) => f.toJson()).toList() ?? [];
-      await _storage.write(key: _foldersKey, value: jsonEncode(jsonList));
-    } catch (e) {
-      debugPrint('Error saving folders: $e');
-    }
-  }
-
-  /// Load tags from secure storage
-  Future<List<TagInfo>> _loadTags({bool forceReload = false}) async {
-    if (!forceReload && _cachedTags != null) return _cachedTags!;
-
-    try {
-      final tagsJson = await _storage.read(key: _tagsKey);
-      if (tagsJson == null || tagsJson.isEmpty) {
-        _cachedTags = [];
-        return _cachedTags!;
-      }
-
-      final List<dynamic> jsonList = jsonDecode(tagsJson);
-      _cachedTags = jsonList
-          .map((json) => TagInfo.fromJson(json as Map<String, dynamic>))
-          .toList();
-
-      return _cachedTags!;
-    } catch (e) {
-      debugPrint('Error loading tags: $e');
-      _cachedTags = [];
-      return _cachedTags!;
-    }
-  }
-
-  /// Save tags to secure storage
-  Future<void> _saveTags() async {
-    try {
-      final jsonList = _cachedTags?.map((t) => t.toJson()).toList() ?? [];
-      await _storage.write(key: _tagsKey, value: jsonEncode(jsonList));
-    } catch (e) {
-      debugPrint('Error saving tags: $e');
-    }
-  }
-
-  /// Load settings from secure storage
-  Future<VaultSettings> _loadSettings() async {
-    if (_cachedSettings != null) return _cachedSettings!;
-
-    try {
-      final settingsJson = await _storage.read(key: _settingsKey);
-      if (settingsJson == null || settingsJson.isEmpty) {
-        _cachedSettings = const VaultSettings();
-        return _cachedSettings!;
-      }
-
-      _cachedSettings = VaultSettings.fromJson(
-        jsonDecode(settingsJson) as Map<String, dynamic>,
-      );
-      return _cachedSettings!;
-    } catch (e) {
-      debugPrint('Error loading settings: $e');
-      _cachedSettings = const VaultSettings();
-      return _cachedSettings!;
-    }
-  }
-
-  /// Save settings to secure storage
-  Future<void> _saveSettings() async {
-    try {
-      await _storage.write(
-        key: _settingsKey,
-        value: jsonEncode(_cachedSettings?.toJson() ?? {}),
-      );
-    } catch (e) {
-      debugPrint('Error saving settings: $e');
-    }
-  }
-
-  /// Stream copy a file in chunks (memory-efficient for large files)
-  Future<void> _streamCopyFile(
-    File source,
-    File destination, {
-    Function(int processed, int total)? onProgress,
-  }) async {
-    final totalBytes = await source.length();
-    var processedBytes = 0;
-    final sink = destination.openWrite();
-
-    onProgress?.call(0, totalBytes);
-
-    await for (final chunk in source.openRead()) {
-      sink.add(chunk);
-      processedBytes += chunk.length;
-      onProgress?.call(processedBytes, totalBytes);
-    }
-
-    await sink.flush();
-    await sink.close();
-  }
-
-  Future<void> _deleteFileIfExists(String path) async {
-    try {
-      final file = File(path);
-      if (await file.exists()) {
-        await file.delete();
-      }
-    } catch (_) {}
-  }
-
-  Future<int> _getFileSizeIfExists(String path) async {
-    try {
-      return await File(path).length();
-    } catch (_) {
-      return 0;
-    }
-  }
-
-  /// Generate a unique encrypted filename
-  String _generateVaultFilename(String originalName) {
-    final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final randomBytes = utf8.encode('$originalName$timestamp${DateTime.now()}');
-    final hash = sha256.convert(randomBytes).toString().substring(0, 16);
-
-    final extension =
-        originalName.contains('.') ? originalName.split('.').last : '';
-
-    return extension.isNotEmpty ? '$hash.$extension' : hash;
-  }
-
-  /// Add a file to the vault
   Future<VaultedFile?> addFile({
     required String sourcePath,
     required String originalName,
@@ -511,33 +106,21 @@ class VaultService {
     List<String>? albumIds,
     EncryptionAlgorithm? encryptionAlgorithm,
     int? kdfIterations,
-  }) async {
-    final prepared = await _prepareVaultAddition(
-      sourcePath: sourcePath,
-      originalName: originalName,
-      type: type,
-      mimeType: mimeType,
-      encrypt: encrypt,
-      isDecoy: isDecoy,
-      tags: tags,
-      albumIds: albumIds,
-      encryptionAlgorithm: encryptionAlgorithm,
-      kdfIterations: kdfIterations,
-    );
+  }) =>
+      _files.addFile(
+        sourcePath: sourcePath,
+        originalName: originalName,
+        type: type,
+        mimeType: mimeType,
+        deleteOriginal: deleteOriginal,
+        encrypt: encrypt,
+        isDecoy: isDecoy,
+        tags: tags,
+        albumIds: albumIds,
+        encryptionAlgorithm: encryptionAlgorithm,
+        kdfIterations: kdfIterations,
+      );
 
-    if (prepared == null) {
-      return null;
-    }
-
-    await _storePreparedVaultAddition(
-      prepared,
-      deleteOriginal: deleteOriginal,
-    );
-
-    return prepared.vaultedFile;
-  }
-
-  /// Add multiple files to the vault (batch import)
   Future<List<VaultedFile>> addFiles({
     required List<FileToVault> files,
     bool deleteOriginals = false,
@@ -545,1394 +128,251 @@ class VaultService {
     bool isDecoy = false,
     Function(int current, int total)? onProgress,
     Function(FileProgressInfo)? onFileProgress,
-  }) async {
-    // Load settings once before processing the batch
-    _cachedSettings ??= await _loadSettings();
-    final results = <VaultedFile>[];
-
-    int completed = 0;
-
-    for (int start = 0;
-        start < files.length;
-        start += _maxConcurrentBatchAdds) {
-      final chunk = files
-          .sublist(
-            start,
-            start + _maxConcurrentBatchAdds > files.length
-                ? files.length
-                : start + _maxConcurrentBatchAdds,
-          )
-          .asMap()
-          .entries
-          .map((entry) => (index: start + entry.key, file: entry.value))
-          .toList();
-
-      final preparedChunk = await Future.wait(
-        chunk.map((entry) async {
-          final fileSize = await _getFileSizeIfExists(entry.file.sourcePath);
-          final fileEncrypt = entry.file.encrypt ?? encrypt;
-          final fileShouldEncrypt = fileEncrypt || _cachedSettings?.encryptionEnabled == true;
-
-          onFileProgress?.call(FileProgressInfo(
-            current: entry.index + 1,
-            total: files.length,
-            fileName: entry.file.originalName,
-            fileSize: fileSize,
-            status: fileShouldEncrypt ? 'Encrypting 0%...' : 'Processing...',
-            isEncrypting: fileShouldEncrypt,
-            totalBytes: fileShouldEncrypt ? fileSize : 0,
-          ));
-
-          final prepared = await _prepareVaultAddition(
-            sourcePath: entry.file.sourcePath,
-            originalName: entry.file.originalName,
-            type: entry.file.type,
-            mimeType: entry.file.mimeType,
-            encrypt: fileEncrypt,
-            isDecoy: isDecoy,
-            encryptionAlgorithm: entry.file.encryptionAlgorithm,
-            kdfIterations: entry.file.kdfIterations,
-            onEncryptionProgress: fileShouldEncrypt
-                ? (processed, total) {
-                    final pct = total > 0
-                        ? (processed / total * 100).toStringAsFixed(0)
-                        : '0';
-                    onFileProgress?.call(FileProgressInfo(
-                      current: entry.index + 1,
-                      total: files.length,
-                      fileName: entry.file.originalName,
-                      fileSize: fileSize,
-                      status: 'Encrypting $pct%...',
-                      isEncrypting: true,
-                      encryptedBytes: processed,
-                      totalBytes: total,
-                    ));
-                  }
-                : null,
-          );
-
-          return _BatchPreparationResult(
-            index: entry.index,
-            file: entry.file,
-            fileSize: fileSize,
-            prepared: prepared,
-          );
-        }),
+  }) =>
+      _files.addFiles(
+        files: files,
+        deleteOriginals: deleteOriginals,
+        encrypt: encrypt,
+        isDecoy: isDecoy,
+        onProgress: onProgress,
+        onFileProgress: onFileProgress,
       );
 
-      for (final preparedResult in preparedChunk) {
-        if (preparedResult.prepared != null) {
-          await _storePreparedVaultAddition(
-            preparedResult.prepared!,
-            deleteOriginal: deleteOriginals,
-          );
-          results.add(preparedResult.prepared!.vaultedFile);
-        }
+  Future<VaultedFile?> updateFile(VaultedFile updatedFile) =>
+      _files.updateFile(updatedFile);
 
-        completed++;
-        onProgress?.call(completed, files.length);
+  Future<bool> removeFile(String fileId, {bool isDecoy = false}) =>
+      _files.removeFile(fileId, isDecoy: isDecoy);
 
-        onFileProgress?.call(FileProgressInfo(
-          current: preparedResult.index + 1,
-          total: files.length,
-          fileName: preparedResult.file.originalName,
-          fileSize: preparedResult.fileSize,
-          status: preparedResult.prepared != null ? 'Complete' : 'Failed',
-          isEncrypting: false,
-        ));
-      }
-    }
-
-    return results;
-  }
-
-  Future<_PreparedVaultAddition?> _prepareVaultAddition({
-    required String sourcePath,
-    required String originalName,
-    required VaultedFileType type,
-    required String mimeType,
-    required bool encrypt,
-    required bool isDecoy,
-    Function(int processed, int total)? onEncryptionProgress,
-    List<String>? tags,
-    List<String>? albumIds,
-    EncryptionAlgorithm? encryptionAlgorithm,
-    int? kdfIterations,
-  }) async {
-    String? sourcePathToUse;
-    String? vaultPath;
-    Uint8List? compressedImageBytes;
-
-    try {
-      final sourceFile = File(sourcePath);
-      if (!await sourceFile.exists()) {
-        debugPrint('Source file does not exist: $sourcePath');
-        return null;
-      }
-
-      sourcePathToUse = sourcePath;
-      _cachedSettings ??= await _loadSettings();
-
-      if (_cachedSettings?.compressionEnabled == true) {
-        if (type == VaultedFileType.image) {
-          final bytes = await CompressionService.instance
-              .compressImageToBytes(sourcePath);
-          if (bytes != null) {
-            compressedImageBytes = bytes;
-            debugPrint(
-                '[Vault] Using compressed image bytes (${bytes.length} bytes)');
-          }
-        } else if (type == VaultedFileType.video) {
-          final compressedPath =
-              await CompressionService.instance.compressVideo(sourcePath);
-          if (compressedPath != null) {
-            sourcePathToUse = compressedPath;
-            debugPrint('[Vault] Using compressed video: $compressedPath');
-          }
-        }
-      }
-
-      final directory = isDecoy
-          ? await _ensureDecoyDirectory()
-          : await _ensureVaultDirectory();
-
-      final vaultFilename = _generateVaultFilename(originalName);
-      final subdirectory = _getSubdirectory(type);
-      vaultPath = '${directory.path}/$subdirectory/$vaultFilename';
-
-      final shouldEncrypt =
-          encrypt || _cachedSettings?.encryptionEnabled == true;
-      String? encryptionIv;
-      int fileSize;
-      EncryptionAlgorithm? usedAlgorithm;
-      String? usedSalt;
-      int? usedKdfIterations;
-
-      Uint8List? derivedKey;
-      if (shouldEncrypt) {
-        final algorithm = encryptionAlgorithm ??
-            _cachedSettings?.encryptionAlgorithm ??
-            EncryptionAlgorithm.aes256Ctr;
-        final iterations = kdfIterations ??
-            _cachedSettings?.kdfIterations ??
-            100000;
-        final salt = _encryptionService.generateFileSalt();
-        final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy);
-        derivedKey = await _encryptionService.deriveFileKeyAsync(masterKey, salt, iterations);
-        usedAlgorithm = algorithm;
-        usedSalt = base64Encode(salt);
-        usedKdfIterations = iterations;
-      }
-
-      if (compressedImageBytes != null) {
-        fileSize = compressedImageBytes.length;
-
-        if (shouldEncrypt) {
-          onEncryptionProgress?.call(0, fileSize);
-          final useGcm = usedAlgorithm == EncryptionAlgorithm.aes256Gcm;
-
-          // ponytail: write to temp file so we can use the isolate pool.
-          // In-memory bytes path runs GCM on the main isolate, which crashes
-          // under batch concurrency. Pool needs a path; cheap write pays for itself.
-          final tempDir = await getTemporaryDirectory();
-          final tempPath =
-              '${tempDir.path}/lkr_enc_${DateTime.now().microsecondsSinceEpoch}';
-          await File(tempPath).writeAsBytes(compressedImageBytes);
-
-          try {
-            final encResult = await _encryptionService.encryptFileInIsolate(
-              tempPath,
-              vaultPath,
-              isDecoy: isDecoy,
-              useGcm: useGcm,
-              derivedKey: derivedKey,
-              onProgress: (processed, total) {
-                onEncryptionProgress?.call(processed, total);
-              },
-            );
-            onEncryptionProgress?.call(fileSize, fileSize);
-
-            if (!encResult.success) {
-              debugPrint('Encryption failed: ${encResult.error}');
-              await _deleteFileIfExists(vaultPath);
-              return null;
-            }
-
-            encryptionIv = encResult.iv;
-            fileSize = encResult.originalSize ?? fileSize;
-          } finally {
-            await _deleteFileIfExists(tempPath);
-          }
-        } else {
-          await File(vaultPath).writeAsBytes(compressedImageBytes);
-        }
-      } else {
-        final sourceFileForProcessing = File(sourcePathToUse);
-        if (!await sourceFileForProcessing.exists()) {
-          debugPrint('Processed file does not exist: $sourcePathToUse');
-          return null;
-        }
-
-        fileSize = await sourceFileForProcessing.length();
-
-        if (shouldEncrypt) {
-          onEncryptionProgress?.call(0, fileSize);
-          final useGcm = usedAlgorithm == EncryptionAlgorithm.aes256Gcm;
-          // ponytail: always isolate. The <2MB threshold used to keep small
-          // files on the main isolate; with batch concurrency that still froze
-          // UI on import. Pool dispatch is cheap, no reason to special-case.
-          final encResult = await _encryptionService.encryptFileInIsolate(
-            sourcePathToUse,
-            vaultPath,
-            isDecoy: isDecoy,
-            useGcm: useGcm,
-            derivedKey: derivedKey,
-            onProgress: (processed, total) {
-              onEncryptionProgress?.call(processed, total);
-            },
-          );
-          onEncryptionProgress?.call(fileSize, fileSize);
-
-          if (!encResult.success) {
-            debugPrint('Encryption failed: ${encResult.error}');
-            await _deleteFileIfExists(vaultPath);
-            return null;
-          }
-
-          encryptionIv = encResult.iv;
-          fileSize = encResult.originalSize ?? fileSize;
-        } else {
-          await _streamCopyFile(sourceFileForProcessing, File(vaultPath));
-        }
-      }
-
-      final normalizedTags = (tags ?? [])
-          .map((tag) => tag.toLowerCase().trim())
-          .where((tag) => tag.isNotEmpty)
-          .toSet()
-          .toList();
-      final normalizedAlbumIds = (albumIds ?? []).toSet().toList();
-      final now = DateTime.now();
-      final fileId = sha256
-          .convert(utf8.encode('$vaultPath${now.millisecondsSinceEpoch}'))
-          .toString()
-          .substring(0, 24);
-
-      // Generate an encrypted thumbnail at import (images + videos). Failure is
-      // non-fatal — the grid falls back to lazy regen via getThumbnailBytes.
-      String? thumbPath;
-      String? thumbIv;
-      if (shouldEncrypt &&
-          derivedKey != null &&
-          (type == VaultedFileType.image ||
-              type == VaultedFileType.video)) {
-        String? reconstructedTemp;
-        try {
-          File? plainFile;
-          if (await File(sourcePathToUse).exists()) {
-            plainFile = File(sourcePathToUse);
-          } else if (compressedImageBytes != null) {
-            final tmp = await getTemporaryDirectory();
-            reconstructedTemp =
-                '${tmp.path}/lkr_thumb_src_${DateTime.now().microsecondsSinceEpoch}';
-            plainFile = File(reconstructedTemp);
-            await plainFile.writeAsBytes(compressedImageBytes);
-          }
-          if (plainFile != null) {
-            final thumbBytes = await _generateThumbBytes(plainFile, type);
-            if (thumbBytes != null) {
-              final stored = await _encryptAndStoreThumbnail(
-                thumbBytes,
-                fileId: fileId,
-                derivedKey: derivedKey,
-                isDecoy: isDecoy,
-              );
-              thumbPath = stored?.path;
-              thumbIv = stored?.iv;
-            }
-          }
-        } catch (e) {
-          debugPrint('[Vault] import-time thumbnail generation failed: $e');
-        } finally {
-          if (reconstructedTemp != null) {
-            await _deleteFileIfExists(reconstructedTemp);
-          }
-        }
-      }
-
-      return _PreparedVaultAddition(
-        vaultedFile: VaultedFile(
-          id: fileId,
-          originalName: originalName,
-          vaultPath: vaultPath,
-          originalPath: sourcePath,
-          type: type,
-          mimeType: mimeType,
-          fileSize: fileSize,
-          dateAdded: now,
-          isFavorite: normalizedAlbumIds.contains('favorites'),
-          isEncrypted: shouldEncrypt,
-          encryptionIv: encryptionIv,
-          encryptionAlgorithm: usedAlgorithm,
-          keyDerivationSalt: usedSalt,
-          kdfIterations: usedKdfIterations,
-          isDecoy: isDecoy,
-          tags: normalizedTags,
-          albumIds: normalizedAlbumIds,
-          thumbnailPath: thumbPath,
-          thumbnailIv: thumbIv,
-        ),
-      );
-    } catch (e) {
-      if (vaultPath != null) {
-        await _deleteFileIfExists(vaultPath);
-      }
-      debugPrint('Error adding file to vault: $e');
-      return null;
-    } finally {
-      if (sourcePathToUse != null && sourcePathToUse != sourcePath) {
-        try {
-          await File(sourcePathToUse).delete();
-          debugPrint(
-              '[Vault] Cleaned up compressed temp file: $sourcePathToUse');
-        } catch (e) {
-          debugPrint('[Vault] Could not delete temp compressed file: $e');
-        }
-      }
-    }
-  }
-
-  Future<void> _storePreparedVaultAddition(
-    _PreparedVaultAddition prepared, {
-    required bool deleteOriginal,
-  }) async {
-    final vaultedFile = prepared.vaultedFile;
-
-    if (vaultedFile.isDecoy) {
-      _cachedDecoyFiles ??= await _loadFileIndex(isDecoy: true);
-      _cachedDecoyFiles!.add(vaultedFile);
-      await _saveFileIndex(isDecoy: true);
-    } else {
-      _cachedFiles ??= await _loadFileIndex();
-      _cachedFiles!.add(vaultedFile);
-      await _saveFileIndex();
-
-      if (vaultedFile.albumIds.isNotEmpty) {
-        _cachedAlbums ??= await _loadAlbums();
-
-        for (final albumId in vaultedFile.albumIds) {
-          final albumIndex =
-              _cachedAlbums!.indexWhere((album) => album.id == albumId);
-          if (albumIndex != -1) {
-            _cachedAlbums![albumIndex] =
-                _cachedAlbums![albumIndex].addFile(vaultedFile.id);
-          }
-        }
-
-        await _saveAlbums();
-      }
-
-      if (vaultedFile.tags.isNotEmpty) {
-        await _updateTagUsage(vaultedFile.tags);
-      }
-    }
-
-    if (!deleteOriginal || vaultedFile.originalPath == null) {
-      return;
-    }
-
-    final originalFile = File(vaultedFile.originalPath!);
-    bool deleted = false;
-
-    try {
-      if (await originalFile.exists()) {
-        await originalFile.delete();
-        deleted = true;
-      } else {
-        deleted = true; // already gone, nothing to do
-      }
-    } catch (e) {
-      debugPrint('Could not delete original file: $e');
-    }
-
-    // Verify the original was actually removed from storage
-    if (!deleted) {
-      try {
-        if (await originalFile.exists()) {
-          debugPrint(
-              'Original file still exists, attempting secure delete: ${vaultedFile.originalPath}');
-          if (_cachedSettings?.secureDelete == true) {
-            await _encryptionService.secureDelete(vaultedFile.originalPath!);
-          } else {
-            await originalFile.delete();
-          }
-        }
-      } catch (_) {}
-    }
-
-    // Final check — the file must be gone for the hide to be effective
-    try {
-      if (await originalFile.exists()) {
-        debugPrint(
-            'WARNING: Could not delete original file from device storage: ${vaultedFile.originalPath}');
-      }
-    } catch (_) {}
-  }
-
-  /// Update a file's metadata
-  Future<VaultedFile?> updateFile(VaultedFile updatedFile) async {
-    try {
-      final files = await _loadFileIndex(isDecoy: updatedFile.isDecoy);
-      final index = files.indexWhere((f) => f.id == updatedFile.id);
-
-      if (index == -1) return null;
-
-      if (updatedFile.isDecoy) {
-        _cachedDecoyFiles![index] = updatedFile;
-        await _saveFileIndex(isDecoy: true);
-      } else {
-        _cachedFiles![index] = updatedFile;
-        await _saveFileIndex();
-      }
-
-      return updatedFile;
-    } catch (e) {
-      debugPrint('Error updating file: $e');
-      return null;
-    }
-  }
-
-  /// Remove a file from the vault
-  Future<bool> removeFile(String fileId, {bool isDecoy = false}) async {
-    try {
-      final files = await _loadFileIndex(isDecoy: isDecoy);
-      final fileIndex = files.indexWhere((f) => f.id == fileId);
-
-      if (fileIndex == -1) return false;
-
-      final file = files[fileIndex];
-
-      // Delete the actual file
-      final vaultFile = File(file.vaultPath);
-      if (await vaultFile.exists()) {
-        if (_cachedSettings?.secureDelete == true) {
-          await _encryptionService.secureDelete(file.vaultPath);
-        } else {
-          await vaultFile.delete();
-        }
-      }
-
-      // Delete thumbnail if exists
-      if (file.thumbnailPath != null) {
-        final thumbFile = File(file.thumbnailPath!);
-        if (await thumbFile.exists()) {
-          await thumbFile.delete();
-        }
-      }
-
-      // Remove from albums
-      if (!isDecoy && file.albumIds.isNotEmpty) {
-        for (final albumId in file.albumIds) {
-          await removeFileFromAlbum(fileId, albumId);
-        }
-      }
-
-      // Remove from folder
-      if (!isDecoy && file.folderId != null) {
-        _cachedFolders ??= await _loadFolders();
-        final folderIndex =
-            _cachedFolders!.indexWhere((f) => f.id == file.folderId);
-        if (folderIndex != -1) {
-          _cachedFolders![folderIndex] =
-              _cachedFolders![folderIndex].removeFile(fileId);
-          await _saveFolders();
-        }
-      }
-
-      // Remove from index
-      if (isDecoy) {
-        _cachedDecoyFiles!.removeAt(fileIndex);
-        await _saveFileIndex(isDecoy: true);
-      } else {
-        _cachedFiles!.removeAt(fileIndex);
-        await _saveFileIndex();
-      }
-
-      return true;
-    } catch (e) {
-      debugPrint('Error removing file from vault: $e');
-      return false;
-    }
-  }
-
-  /// Remove multiple files from the vault (batch optimized: single index save)
   Future<int> removeFiles(
     List<String> fileIds, {
     bool isDecoy = false,
     void Function(int current, int total, {int currentSize, int totalSize})?
         onProgress,
-  }) async {
-    final fileIndex = await _loadFileIndex(isDecoy: isDecoy);
-    final idSet = fileIds.toSet();
-    final filesToDelete = fileIndex.where((f) => idSet.contains(f.id)).toList();
-    final totalSize = filesToDelete.fold<int>(0, (s, f) => s + f.fileSize);
+  }) =>
+      _files.removeFiles(
+        fileIds,
+        isDecoy: isDecoy,
+        onProgress: onProgress,
+      );
 
-    final albumUpdates = <String, Set<String>>{};
-    final folderUpdates = <String, Set<String>>{};
-    int removed = 0;
-    int currentSize = 0;
+  Future<List<VaultedFile>> getAllFiles({bool isDecoy = false}) =>
+      _files.getAllFiles(isDecoy: isDecoy);
 
-    for (final file in filesToDelete) {
-      try {
-        final vaultFile = File(file.vaultPath);
-        if (await vaultFile.exists()) {
-          if (_cachedSettings?.secureDelete == true) {
-            await _encryptionService.secureDelete(file.vaultPath);
-          } else {
-            await vaultFile.delete();
-          }
-        }
+  Future<List<VaultedFile>> getFilesByType(VaultedFileType type,
+          {bool isDecoy = false}) =>
+      _files.getFilesByType(type, isDecoy: isDecoy);
 
-        if (file.thumbnailPath != null) {
-          final thumbFile = File(file.thumbnailPath!);
-          if (await thumbFile.exists()) {
-            await thumbFile.delete();
-          }
-        }
+  Future<VaultedFile?> getFileById(String fileId, {bool isDecoy = false}) =>
+      _files.getFileById(fileId, isDecoy: isDecoy);
 
-        if (!isDecoy && file.albumIds.isNotEmpty) {
-          for (final albumId in file.albumIds) {
-            albumUpdates.putIfAbsent(albumId, () => {}).add(file.id);
-          }
-        }
-
-        if (!isDecoy && file.folderId != null) {
-          folderUpdates.putIfAbsent(file.folderId!, () => {}).add(file.id);
-        }
-
-        removed++;
-        currentSize += file.fileSize;
-        onProgress?.call(removed, fileIds.length,
-            currentSize: currentSize, totalSize: totalSize);
-      } catch (e) {
-        debugPrint('Error deleting file ${file.id}: $e');
-      }
-    }
-
-    if (!isDecoy && albumUpdates.isNotEmpty) {
-      final albums = await _loadAlbums();
-      bool albumsChanged = false;
-      for (final entry in albumUpdates.entries) {
-        final albumIdx = albums.indexWhere((a) => a.id == entry.key);
-        if (albumIdx != -1) {
-          var album = albums[albumIdx];
-          for (final fid in entry.value) {
-            album = album.removeFile(fid);
-          }
-          albums[albumIdx] = album;
-          albumsChanged = true;
-        }
-      }
-      if (albumsChanged) await _saveAlbums();
-    }
-
-    if (!isDecoy && folderUpdates.isNotEmpty) {
-      _cachedFolders ??= await _loadFolders();
-      bool foldersChanged = false;
-      for (final entry in folderUpdates.entries) {
-        final folderIdx =
-            _cachedFolders!.indexWhere((f) => f.id == entry.key);
-        if (folderIdx != -1) {
-          var folder = _cachedFolders![folderIdx];
-          for (final fid in entry.value) {
-            folder = folder.removeFile(fid);
-          }
-          _cachedFolders![folderIdx] = folder;
-          foldersChanged = true;
-        }
-      }
-      if (foldersChanged) await _saveFolders();
-    }
-
-    final deleteIdSet = filesToDelete.map((f) => f.id).toSet();
-    if (isDecoy) {
-      _cachedDecoyFiles!.removeWhere((f) => deleteIdSet.contains(f.id));
-      await _saveFileIndex(isDecoy: true);
-    } else {
-      _cachedFiles!.removeWhere((f) => deleteIdSet.contains(f.id));
-      await _saveFileIndex();
-    }
-
-    return removed;
-  }
-
-  /// Get all vaulted files
-  Future<List<VaultedFile>> getAllFiles({bool isDecoy = false}) async {
-    return await _loadFileIndex(isDecoy: isDecoy);
-  }
-
-  /// Get files by type
-  Future<List<VaultedFile>> getFilesByType(
-    VaultedFileType type, {
-    bool isDecoy = false,
-  }) async {
-    final files = await _loadFileIndex(isDecoy: isDecoy);
-    return files.where((f) => f.type == type).toList();
-  }
-
-  /// Get file by ID
-  Future<VaultedFile?> getFileById(String fileId,
-      {bool isDecoy = false}) async {
-    final files = await _loadFileIndex(isDecoy: isDecoy);
-    try {
-      return files.firstWhere((f) => f.id == fileId);
-    } catch (e) {
-      return null;
-    }
-  }
-
-  Future<Uint8List?> _deriveKeyForFile(VaultedFile file, {bool isDecoy = false}) async {
-    if (file.keyDerivationSalt == null || file.kdfIterations == null) return null;
-    final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
-    final salt = base64Decode(file.keyDerivationSalt!);
-    // ponytail: async (compute isolate). Sync PBKDF2 @ 100k iterations on the
-    // main isolate was the 5-7s UI freeze when opening encrypted files.
-    return _encryptionService.deriveFileKeyAsync(masterKey, salt, file.kdfIterations!);
-  }
-
-  /// Get the actual file from vault (decrypts if needed).
-  ///
-  /// [cancelToken] makes the operation cooperative: it is checked after the
-  /// (un-killable) key derivation and bound to the decrypt isolate's kill
-  /// handle, so cancellation during either stage unblocks promptly. A
-  /// cancelled call returns null and writes no final file.
   Future<File?> getVaultedFile(
     String fileId, {
     bool isDecoy = false,
     Function(int processed, int total)? onProgress,
     CancelToken? cancelToken,
-  }) async {
-    final vaultedFile = await getFileById(fileId, isDecoy: isDecoy);
-    if (vaultedFile == null) return null;
-
-    final file = File(vaultedFile.vaultPath);
-    if (!await file.exists()) return null;
-
-    // If encrypted, decrypt to temp file
-    if (vaultedFile.isEncrypted && vaultedFile.encryptionIv != null) {
-      final tempDir = await _ensureVaultDirectory();
-      final tempPath =
-          '${tempDir.path}/temp/${vaultedFile.id}_${vaultedFile.originalName}';
-
-      final format = _encryptionService.detectFileFormat(vaultedFile.vaultPath);
-      final isLegacyCbc = (format == 0 || format == 3);
-      final derivedKey = await _deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
-
-      // Derive runs on `compute` and can't be killed; abort here if the user
-      // cancelled during that window so we never dispatch the decrypt job.
-      if (cancelToken?.isCancelled == true) return null;
-
-      FileDecryptionResult result;
-      if (isLegacyCbc) {
-        result = await _encryptionService.decryptFile(
-          vaultedFile.vaultPath,
-          tempPath,
-          vaultedFile.encryptionIv!,
-          isDecoy: isDecoy,
-          derivedKey: derivedKey,
-          onProgress: onProgress == null
-              ? null
-              : (current, total) {
-                  final estimatedProcessed = total > 0
-                      ? (current / total * vaultedFile.fileSize).round()
-                      : 0;
-                  onProgress(estimatedProcessed, vaultedFile.fileSize);
-                },
-        );
-      } else {
-        result = await _encryptionService.decryptFileInIsolate(
-          vaultedFile.vaultPath,
-          tempPath,
-          vaultedFile.encryptionIv!,
-          isDecoy: isDecoy,
-          derivedKey: derivedKey,
-          onProgress: onProgress,
-          cancelToken: cancelToken,
-        );
-      }
-
-      if (cancelToken?.isCancelled == true) return null;
-
-      if (result.success && result.decryptedPath != null) {
-        return File(result.decryptedPath!);
-      }
-      return null;
-    }
-
-    return file;
-  }
-
-  // ---- Encrypted thumbnails ----
-  // Thumbs are GCM-encrypted with the file's per-file derived key + a fresh IV
-  // (stored in thumbnailIv), independent of the file's own algorithm. GCM auth
-  // lets us detect a stale thumb (e.g. after re-encrypt changed the key) and
-  // transparently regenerate. No plaintext thumb is ever at rest.
-
-  /// Decrypt (or lazily generate) the encrypted thumbnail bytes for [file].
-  /// Returns null for unencrypted files (callers render vaultPath directly) or
-  /// when no thumb can be produced.
-  Future<Uint8List?> getThumbnailBytes(VaultedFile file) async {
-    if (!file.isEncrypted) return null;
-    final cached = _thumbnailCache[file.id];
-    if (cached != null) return cached;
-    // ponytail: dedupe concurrent fetches so a fast scroll doesn't kick off
-    // N parallel full-decrypts for the same file.
-    final inFlight = _thumbnailInFlight[file.id];
-    if (inFlight != null) return inFlight;
-    final fut = _loadOrRegenerateThumbnail(file);
-    _thumbnailInFlight[file.id] = fut;
-    try {
-      final bytes = await fut;
-      if (bytes != null) _cacheThumbnail(file.id, bytes);
-      return bytes;
-    } finally {
-      _thumbnailInFlight.remove(file.id);
-    }
-  }
-
-  void _cacheThumbnail(String id, Uint8List bytes) {
-    _thumbnailCache[id] = bytes;
-    // ponytail: naive FIFO eviction — Map preserves insertion order, so
-    // dropping the first entry bounds the cache. Real LRU if hit-rate matters.
-    if (_thumbnailCache.length > _thumbnailCacheLimit) {
-      _thumbnailCache.remove(_thumbnailCache.keys.first);
-    }
-  }
-
-  Future<Uint8List?> _loadOrRegenerateThumbnail(VaultedFile file) {
-    // ponytail: serialize to one-at-a-time (see _thumbGenLock). Prevents a grid
-    // of N encrypted files from decrypting N full images concurrently (OOM/ANR).
-    final prev = _thumbGenLock;
-    final result = prev.then((_) => _loadOrRegenerateThumbnailLocked(file));
-    _thumbGenLock = result.then((_) {}, onError: (_) {});
-    return result;
-  }
-
-  Future<Uint8List?> _loadOrRegenerateThumbnailLocked(VaultedFile file) async {
-    if (file.thumbnailPath != null && file.thumbnailIv != null) {
-      final thumbFile = File(file.thumbnailPath!);
-      if (await thumbFile.exists()) {
-        final derivedKey = await _deriveKeyForFile(file);
-        final res = await _encryptionService.decryptStreamedFileToMemoryGcm(
-          file.thumbnailPath!,
-          file.thumbnailIv!,
-          isDecoy: file.isDecoy,
-          derivedKey: derivedKey,
-        );
-        if (res.success && res.data != null) return res.data;
-        // Auth failure / stale key (e.g. post re-encrypt): fall through to regen.
-      }
-    }
-    return _regenerateThumbnail(file);
-  }
-
-  Future<Uint8List?> _regenerateThumbnail(VaultedFile file) async {
-    final plaintext = await getVaultedFile(file.id, isDecoy: file.isDecoy);
-    if (plaintext == null) return null;
-    try {
-      final thumbBytes = await _generateThumbBytes(plaintext, file.type);
-      if (thumbBytes == null) return null;
-      final derivedKey = await _deriveKeyForFile(file);
-      if (derivedKey != null) {
-        final stored = await _encryptAndStoreThumbnail(
-          thumbBytes,
-          fileId: file.id,
-          derivedKey: derivedKey,
-          isDecoy: file.isDecoy,
-        );
-        if (stored != null) {
-          await _persistThumbnailRecord(
-            file.id,
-            stored.path,
-            stored.iv,
-            isDecoy: file.isDecoy,
-          );
-        }
-      }
-      return thumbBytes;
-    } finally {
-      try {
-        if (await plaintext.exists()) await plaintext.delete();
-      } catch (_) {}
-    }
-  }
-
-  /// Produce small JPEG bytes for an image or the first frame of a video.
-  /// Both plugins are platform-channel backed -> only callable on a device.
-  Future<Uint8List?> _generateThumbBytes(
-    File plaintext,
-    VaultedFileType type,
-  ) async {
-    try {
-      if (type == VaultedFileType.video) {
-        return await VideoCompress.getByteThumbnail(plaintext.path, quality: 70);
-      }
-      return await FlutterImageCompress.compressWithFile(
-        plaintext.path,
-        minWidth: 300,
-        minHeight: 300,
-        quality: 70,
-      );
-    } catch (e) {
-      debugPrint('[Vault] thumbnail generation failed: $e');
-      return null;
-    }
-  }
-
-  /// Encrypt [thumbBytes] to `thumbnails/<fileId>.thumb.enc` with a fresh IV.
-  /// Reuses the isolate encrypt path so the on-disk format matches the GCM
-  /// decrypt-to-memory reader. Returns null on failure.
-  Future<_StoredThumb?> _encryptAndStoreThumbnail(
-    Uint8List thumbBytes, {
-    required String fileId,
-    required Uint8List derivedKey,
-    required bool isDecoy,
-  }) async {
-    final dir = isDecoy
-        ? await _ensureDecoyDirectory()
-        : await _ensureVaultDirectory();
-    final thumbPath = '${dir.path}/thumbnails/$fileId.thumb.enc';
-    final tempDir = await getTemporaryDirectory();
-    final tempPath =
-        '${tempDir.path}/lkr_thumb_${DateTime.now().microsecondsSinceEpoch}';
-    await File(tempPath).writeAsBytes(thumbBytes);
-    try {
-      final res = await _encryptionService.encryptFileInIsolate(
-        tempPath,
-        thumbPath,
+  }) =>
+      _files.getVaultedFile(
+        fileId,
         isDecoy: isDecoy,
-        useGcm: true,
-        derivedKey: derivedKey,
+        onProgress: onProgress,
+        cancelToken: cancelToken,
       );
-      if (!res.success || res.iv == null) return null;
-      return _StoredThumb(thumbPath, res.iv!);
-    } catch (e) {
-      debugPrint('[Vault] thumbnail encrypt failed: $e');
-      return null;
-    } finally {
-      await _deleteFileIfExists(tempPath);
-    }
-  }
 
-  Future<void> _persistThumbnailRecord(
+  Future<Uint8List?> getDecryptedFileData(String fileId, {bool isDecoy = false}) =>
+      _files.getDecryptedFileData(fileId, isDecoy: isDecoy);
+
+  Future<File?> exportFile(
     String fileId,
-    String path,
-    String iv, {
-    required bool isDecoy,
-  }) async {
-    final files = await _loadFileIndex(isDecoy: isDecoy);
-    final idx = files.indexWhere((f) => f.id == fileId);
-    if (idx == -1) return;
-    files[idx] = files[idx].copyWith(thumbnailPath: path, thumbnailIv: iv);
-    await _saveFileIndex(isDecoy: isDecoy);
-  }
-
-  /// Drop the in-memory thumbnail cache. Called on vault clear / logout flows.
-  void clearThumbnailCache() {
-    _thumbnailCache.clear();
-    _thumbnailInFlight.clear();
-  }
-
-  /// Get decrypted file data in memory (for viewing)
-  Future<Uint8List?> getDecryptedFileData(
-    String fileId, {
+    String destinationPath, {
     bool isDecoy = false,
-  }) async {
-    final vaultedFile = await getFileById(fileId, isDecoy: isDecoy);
-    if (vaultedFile == null) return null;
-
-    if (vaultedFile.isEncrypted && vaultedFile.encryptionIv != null) {
-      final derivedKey = await _deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
-      final result = await _encryptionService.decryptStreamedFileToMemory(
-        vaultedFile.vaultPath,
-        vaultedFile.encryptionIv!,
+    Function(int processed, int total)? onProgress,
+  }) =>
+      _files.exportFile(
+        fileId,
+        destinationPath,
         isDecoy: isDecoy,
-        derivedKey: derivedKey,
+        onProgress: onProgress,
       );
 
-      if (result.success && result.data != null) {
-        // Mark as viewed
-        await updateFile(vaultedFile.markViewed());
-        return result.data;
-      }
-      return null;
-    }
+  Future<int> reEncryptVault(
+    EncryptionAlgorithm targetAlgorithm, {
+    bool isDecoy = false,
+    Function(int current, int total, String currentFileName, int processedBytes,
+            int totalBytes)?
+        onProgress,
+    Set<String>? fileFilter,
+  }) =>
+      _files.reEncryptVault(
+        targetAlgorithm,
+        isDecoy: isDecoy,
+        onProgress: onProgress,
+        fileFilter: fileFilter,
+      );
 
-    final file = File(vaultedFile.vaultPath);
-    if (!await file.exists()) return null;
+  Future<int> encryptVaultFiles(
+    EncryptionAlgorithm algorithm, {
+    bool isDecoy = false,
+    Function(int current, int total, String currentFileName, int processedBytes,
+            int totalBytes)?
+        onProgress,
+    Set<String>? fileFilter,
+  }) =>
+      _files.encryptVaultFiles(
+        algorithm,
+        isDecoy: isDecoy,
+        onProgress: onProgress,
+        fileFilter: fileFilter,
+      );
 
-    // Mark as viewed
-    await updateFile(vaultedFile.markViewed());
-    return await file.readAsBytes();
-  }
+  Future<int> removeEncryption({
+    bool isDecoy = false,
+    Function(int current, int total, String currentFileName, int processedBytes,
+            int totalBytes)?
+        onProgress,
+    Set<String>? fileFilter,
+  }) =>
+      _files.removeEncryption(
+        isDecoy: isDecoy,
+        onProgress: onProgress,
+        fileFilter: fileFilter,
+      );
 
-  // ========== ALBUM OPERATIONS ==========
+  Future<void> cleanupTemp() => _files.cleanupTemp();
 
-  /// Get all albums
-  Future<List<Album>> getAllAlbums() async {
-    return await _loadAlbums();
-  }
+  Future<void> registerNoteEntry({
+    required String noteId,
+    required String title,
+    required String encryptedContentPath,
+    String fileExtension = 'txt',
+    bool isEncrypted = false,
+    EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
+    int kdfIterations = 0,
+    String? folderId,
+    bool isDecoy = false,
+  }) =>
+      _files.registerNoteEntry(
+        noteId: noteId,
+        title: title,
+        encryptedContentPath: encryptedContentPath,
+        fileExtension: fileExtension,
+        isEncrypted: isEncrypted,
+        encryptionAlgorithm: encryptionAlgorithm,
+        kdfIterations: kdfIterations,
+        folderId: folderId,
+        isDecoy: isDecoy,
+      );
 
-  /// Get album by ID
-  Future<Album?> getAlbumById(String albumId) async {
-    final albums = await _loadAlbums();
-    try {
-      return albums.firstWhere((a) => a.id == albumId);
-    } catch (e) {
-      return null;
-    }
-  }
+  Future<void> removeNoteEntry(String noteId, {bool isDecoy = false}) =>
+      _files.removeNoteEntry(noteId, isDecoy: isDecoy);
 
-  /// Create a new album
+  Future<void> registerPasswordEntry({
+    required String passwordId,
+    required String title,
+    required String encryptedContentPath,
+    List<String> tags = const [],
+    bool isEncrypted = false,
+    EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
+    int kdfIterations = 0,
+    bool isDecoy = false,
+  }) =>
+      _files.registerPasswordEntry(
+        passwordId: passwordId,
+        title: title,
+        encryptedContentPath: encryptedContentPath,
+        tags: tags,
+        isEncrypted: isEncrypted,
+        encryptionAlgorithm: encryptionAlgorithm,
+        kdfIterations: kdfIterations,
+        isDecoy: isDecoy,
+      );
+
+  Future<void> removePasswordEntry(String passwordId, {bool isDecoy = false}) =>
+      _files.removePasswordEntry(passwordId, isDecoy: isDecoy);
+
+  // ---- Thumbnails ----
+
+  Future<Uint8List?> getThumbnailBytes(VaultedFile file) =>
+      _thumbnails.getThumbnailBytes(file);
+
+  void clearThumbnailCache() => _thumbnails.clearCache();
+
+  // ---- Albums ----
+
+  Future<List<Album>> getAllAlbums() => _albums.getAllAlbums();
+
+  Future<Album?> getAlbumById(String albumId) =>
+      _albums.getAlbumById(albumId);
+
   Future<Album?> createAlbum({
     required String name,
     String? description,
     String? coverImageId,
-  }) async {
-    try {
-      final now = DateTime.now();
-      final id = sha256
-          .convert(utf8.encode('$name${now.millisecondsSinceEpoch}'))
-          .toString()
-          .substring(0, 16);
-
-      final album = Album(
-        id: id,
+  }) =>
+      _albums.createAlbum(
         name: name,
         description: description,
         coverImageId: coverImageId,
-        createdAt: now,
-        updatedAt: now,
-        sortOrder: (_cachedAlbums?.length ?? 0) + 1,
       );
 
-      _cachedAlbums ??= [];
-      _cachedAlbums!.add(album);
-      await _saveAlbums();
+  Future<Album?> updateAlbum(Album updatedAlbum) =>
+      _albums.updateAlbum(updatedAlbum);
 
-      return album;
-    } catch (e) {
-      debugPrint('Error creating album: $e');
-      return null;
-    }
-  }
+  Future<bool> deleteAlbum(String albumId) => _albums.deleteAlbum(albumId);
 
-  /// Update an album
-  Future<Album?> updateAlbum(Album updatedAlbum) async {
-    try {
-      final albums = await _loadAlbums();
-      final index = albums.indexWhere((a) => a.id == updatedAlbum.id);
+  Future<bool> addFileToAlbum(String fileId, String albumId) =>
+      _albums.addFileToAlbum(fileId, albumId);
 
-      if (index == -1) return null;
+  Future<bool> addFilesToAlbum(List<String> fileIds, String albumId) =>
+      _albums.addFilesToAlbum(fileIds, albumId);
 
-      _cachedAlbums![index] = updatedAlbum.copyWith(updatedAt: DateTime.now());
-      await _saveAlbums();
+  Future<bool> removeFilesFromAlbum(List<String> fileIds, String albumId) =>
+      _albums.removeFilesFromAlbum(fileIds, albumId);
 
-      return _cachedAlbums![index];
-    } catch (e) {
-      debugPrint('Error updating album: $e');
-      return null;
-    }
-  }
+  Future<bool> removeFileFromAlbum(String fileId, String albumId) =>
+      _albums.removeFileFromAlbum(fileId, albumId);
 
-  /// Delete an album
-  Future<bool> deleteAlbum(String albumId) async {
-    try {
-      final albums = await _loadAlbums();
-      final album = albums.firstWhere(
-        (a) => a.id == albumId,
-        orElse: () => throw Exception('Album not found'),
-      );
+  Future<List<VaultedFile>> getFilesInAlbum(String albumId) =>
+      _albums.getFilesInAlbum(albumId);
 
-      // Don't delete default albums
-      if (album.isDefault) {
-        debugPrint('Cannot delete default album');
-        return false;
-      }
+  // ---- Folders ----
 
-      // Remove album reference from files
-      for (final fileId in album.fileIds) {
-        final file = await getFileById(fileId);
-        if (file != null) {
-          await updateFile(file.removeFromAlbum(albumId));
-        }
-      }
+  Future<List<VaultFolder>> getAllFolders() => _folders.getAllFolders();
 
-      _cachedAlbums!.removeWhere((a) => a.id == albumId);
-      await _saveAlbums();
+  Future<VaultFolder?> getFolderById(String folderId) =>
+      _folders.getFolderById(folderId);
 
-      return true;
-    } catch (e) {
-      debugPrint('Error deleting album: $e');
-      return false;
-    }
-  }
+  Future<List<VaultFolder>> getRootFolders() => _folders.getRootFolders();
 
-  /// Add file to album
-  Future<bool> addFileToAlbum(String fileId, String albumId) async {
-    try {
-      final file = await getFileById(fileId);
-      if (file == null) return false;
+  Future<List<VaultFolder>> getSubfolders(String parentId) =>
+      _folders.getSubfolders(parentId);
 
-      final albums = await _loadAlbums();
-      final albumIndex = albums.indexWhere((a) => a.id == albumId);
-      if (albumIndex == -1) return false;
-
-      // Update album
-      _cachedAlbums![albumIndex] = _cachedAlbums![albumIndex].addFile(fileId);
-      await _saveAlbums();
-
-      // Update file - also set isFavorite if adding to favorites album
-      VaultedFile updatedFile = file.addToAlbum(albumId);
-      if (albumId == 'favorites') {
-        updatedFile = updatedFile.copyWith(isFavorite: true);
-      }
-      await updateFile(updatedFile);
-
-      return true;
-    } catch (e) {
-      debugPrint('Error adding file to album: $e');
-      return false;
-    }
-  }
-
-  Future<bool> addFilesToAlbum(List<String> fileIds, String albumId) async {
-    try {
-      final albums = await _loadAlbums();
-      final albumIndex = albums.indexWhere((a) => a.id == albumId);
-      if (albumIndex == -1) return false;
-
-      final files = await _loadFileIndex();
-      bool changed = false;
-
-      for (final fileId in fileIds) {
-        final fileIdx = files.indexWhere((f) => f.id == fileId);
-        if (fileIdx == -1) continue;
-
-        _cachedAlbums![albumIndex] =
-            _cachedAlbums![albumIndex].addFile(fileId);
-
-        VaultedFile updatedFile = files[fileIdx].addToAlbum(albumId);
-        if (albumId == 'favorites') {
-          updatedFile = updatedFile.copyWith(isFavorite: true);
-        }
-        _cachedFiles![fileIdx] = updatedFile;
-        changed = true;
-      }
-
-      if (changed) {
-        await _saveAlbums();
-        await _saveFileIndex();
-      }
-      return true;
-    } catch (e) {
-      debugPrint('Error adding files to album: $e');
-      return false;
-    }
-  }
-
-  Future<bool> removeFilesFromAlbum(
-      List<String> fileIds, String albumId) async {
-    try {
-      final albums = await _loadAlbums();
-      final albumIndex = albums.indexWhere((a) => a.id == albumId);
-      if (albumIndex == -1) return false;
-
-      final files = await _loadFileIndex();
-      bool changed = false;
-
-      for (final fileId in fileIds) {
-        _cachedAlbums![albumIndex] =
-            _cachedAlbums![albumIndex].removeFile(fileId);
-
-        final fileIdx = files.indexWhere((f) => f.id == fileId);
-        if (fileIdx != -1) {
-          VaultedFile updatedFile = files[fileIdx].removeFromAlbum(albumId);
-          if (albumId == 'favorites') {
-            updatedFile = updatedFile.copyWith(isFavorite: false);
-          }
-          _cachedFiles![fileIdx] = updatedFile;
-        }
-        changed = true;
-      }
-
-      if (changed) {
-        await _saveAlbums();
-        await _saveFileIndex();
-      }
-      return true;
-    } catch (e) {
-      debugPrint('Error removing files from album: $e');
-      return false;
-    }
-  }
-
-  /// Remove file from album
-  Future<bool> removeFileFromAlbum(String fileId, String albumId) async {
-    try {
-      final albums = await _loadAlbums();
-      final albumIndex = albums.indexWhere((a) => a.id == albumId);
-      if (albumIndex == -1) return false;
-
-      // Update album
-      _cachedAlbums![albumIndex] =
-          _cachedAlbums![albumIndex].removeFile(fileId);
-      await _saveAlbums();
-
-      // Update file - also unset isFavorite if removing from favorites album
-      final file = await getFileById(fileId);
-      if (file != null) {
-        VaultedFile updatedFile = file.removeFromAlbum(albumId);
-        if (albumId == 'favorites') {
-          updatedFile = updatedFile.copyWith(isFavorite: false);
-        }
-        await updateFile(updatedFile);
-      }
-
-      return true;
-    } catch (e) {
-      debugPrint('Error removing file from album: $e');
-      return false;
-    }
-  }
-
-  /// Get files in album
-  Future<List<VaultedFile>> getFilesInAlbum(String albumId) async {
-    final album = await getAlbumById(albumId);
-    if (album == null) return [];
-
-    final files = await getAllFiles();
-    return files.where((f) => album.fileIds.contains(f.id)).toList();
-  }
-
-  // ========== FOLDER OPERATIONS ==========
-
-  /// Get all folders
-  Future<List<VaultFolder>> getAllFolders() async {
-    return await _loadFolders();
-  }
-
-  /// Get folder by ID
-  Future<VaultFolder?> getFolderById(String folderId) async {
-    final folders = await _loadFolders();
-    try {
-      return folders.firstWhere((f) => f.id == folderId);
-    } catch (e) {
-      return null;
-    }
-  }
-
-  /// Get root folders (no parent)
-  Future<List<VaultFolder>> getRootFolders() async {
-    final folders = await _loadFolders();
-    return folders.where((f) => f.isRoot).toList();
-  }
-
-  /// Get subfolders of a folder
-  Future<List<VaultFolder>> getSubfolders(String parentId) async {
-    final folders = await _loadFolders();
-    return folders.where((f) => f.parentId == parentId).toList();
-  }
-
-  /// Create a new folder
   Future<VaultFolder?> createFolder({
     required String name,
     String? parentId,
     String? description,
-  }) async {
-    try {
-      final now = DateTime.now();
-      final id = sha256
-          .convert(utf8.encode('$name${now.millisecondsSinceEpoch}'))
-          .toString()
-          .substring(0, 16);
-
-      final folder = VaultFolder(
-        id: id,
+  }) =>
+      _folders.createFolder(
         name: name,
         parentId: parentId,
         description: description,
-        createdAt: now,
-        updatedAt: now,
       );
 
-      _cachedFolders ??= [];
-      _cachedFolders!.add(folder);
+  Future<VaultFolder?> updateFolder(VaultFolder updatedFolder) =>
+      _folders.updateFolder(updatedFolder);
 
-      if (parentId != null) {
-        final parentIndex =
-            _cachedFolders!.indexWhere((f) => f.id == parentId);
-        if (parentIndex != -1) {
-          _cachedFolders![parentIndex] =
-              _cachedFolders![parentIndex].addSubfolder(id);
-        }
-      }
+  Future<bool> deleteFolder(String folderId, {bool deleteContents = false}) =>
+      _folders.deleteFolder(folderId, deleteContents: deleteContents);
 
-      await _saveFolders();
+  Future<bool> addFileToFolder(String fileId, String folderId) =>
+      _folders.addFileToFolder(fileId, folderId);
 
-      return folder;
-    } catch (e) {
-      debugPrint('Error creating folder: $e');
-      return null;
-    }
-  }
+  Future<bool> removeFileFromFolder(String fileId, String folderId) =>
+      _folders.removeFileFromFolder(fileId, folderId);
 
-  /// Update a folder
-  Future<VaultFolder?> updateFolder(VaultFolder updatedFolder) async {
-    try {
-      final folders = await _loadFolders();
-      final index = folders.indexWhere((f) => f.id == updatedFolder.id);
+  Future<List<VaultedFile>> getFilesInFolder(String folderId) =>
+      _folders.getFilesInFolder(folderId);
 
-      if (index == -1) return null;
-
-      _cachedFolders![index] =
-          updatedFolder.copyWith(updatedAt: DateTime.now());
-      await _saveFolders();
-
-      return _cachedFolders![index];
-    } catch (e) {
-      debugPrint('Error updating folder: $e');
-      return null;
-    }
-  }
-
-  /// Delete a folder and optionally its subfolders
-  Future<bool> deleteFolder(String folderId, {bool deleteContents = false}) async {
-    try {
-      final folders = await _loadFolders();
-      final folder = folders.firstWhere(
-        (f) => f.id == folderId,
-        orElse: () => throw Exception('Folder not found'),
-      );
-
-      if (deleteContents) {
-        for (final subfolderId in folder.subfolderIds) {
-          await deleteFolder(subfolderId, deleteContents: true);
-        }
-
-        for (final fileId in folder.fileIds) {
-          await removeFile(fileId);
-        }
-      } else {
-        for (final fileId in folder.fileIds) {
-          final file = await getFileById(fileId);
-          if (file != null) {
-            await updateFile(file.removeFromFolder());
-          }
-        }
-
-        for (final subfolderId in folder.subfolderIds) {
-          final subfolder = await getFolderById(subfolderId);
-          if (subfolder != null) {
-            await updateFolder(subfolder.copyWith(parentId: folder.parentId));
-            if (folder.parentId != null) {
-              final parentIndex =
-                  _cachedFolders!.indexWhere((f) => f.id == folder.parentId);
-              if (parentIndex != -1) {
-                _cachedFolders![parentIndex] =
-                    _cachedFolders![parentIndex].addSubfolder(subfolderId);
-              }
-            }
-          }
-        }
-      }
-
-      if (folder.parentId != null) {
-        final parentIndex =
-            _cachedFolders!.indexWhere((f) => f.id == folder.parentId);
-        if (parentIndex != -1) {
-          _cachedFolders![parentIndex] =
-              _cachedFolders![parentIndex].removeSubfolder(folderId);
-        }
-      }
-
-      _cachedFolders!.removeWhere((f) => f.id == folderId);
-      await _saveFolders();
-
-      return true;
-    } catch (e) {
-      debugPrint('Error deleting folder: $e');
-      return false;
-    }
-  }
-
-  /// Add file to folder
-  Future<bool> addFileToFolder(String fileId, String folderId) async {
-    try {
-      final file = await getFileById(fileId);
-      if (file == null) return false;
-
-      final folders = await _loadFolders();
-      final folderIndex = folders.indexWhere((f) => f.id == folderId);
-      if (folderIndex == -1) return false;
-
-      if (file.folderId != null && file.folderId != folderId) {
-        final oldFolderIndex =
-            _cachedFolders!.indexWhere((f) => f.id == file.folderId);
-        if (oldFolderIndex != -1) {
-          _cachedFolders![oldFolderIndex] =
-              _cachedFolders![oldFolderIndex].removeFile(fileId);
-        }
-      }
-
-      _cachedFolders![folderIndex] =
-          _cachedFolders![folderIndex].addFile(fileId);
-      await _saveFolders();
-
-      final updatedFile = file.addToFolder(folderId);
-      await updateFile(updatedFile);
-
-      return true;
-    } catch (e) {
-      debugPrint('Error adding file to folder: $e');
-      return false;
-    }
-  }
-
-  /// Remove file from folder
-  Future<bool> removeFileFromFolder(String fileId, String folderId) async {
-    try {
-      final folders = await _loadFolders();
-      final folderIndex = folders.indexWhere((f) => f.id == folderId);
-      if (folderIndex == -1) return false;
-
-      _cachedFolders![folderIndex] =
-          _cachedFolders![folderIndex].removeFile(fileId);
-      await _saveFolders();
-
-      final file = await getFileById(fileId);
-      if (file != null && file.folderId == folderId) {
-        await updateFile(file.removeFromFolder());
-      }
-
-      return true;
-    } catch (e) {
-      debugPrint('Error removing file from folder: $e');
-      return false;
-    }
-  }
-
-  /// Get files in folder
-  Future<List<VaultedFile>> getFilesInFolder(String folderId) async {
-    final folder = await getFolderById(folderId);
-    if (folder == null) return [];
-
-    final files = await getAllFiles();
-    return files.where((f) => folder.fileIds.contains(f.id)).toList();
-  }
-
-  /// Import a device folder: create a VaultFolder from a filesystem path
-  /// and import all files within it
   Future<FolderImportResult> importDeviceFolder(
     String deviceFolderPath, {
     String? parentFolderId,
@@ -1942,275 +382,48 @@ class VaultService {
     bool isDecoy = false,
     Function(int current, int total)? onProgress,
     Function(String fileName, int fileNumber, int total)? onFileProgress,
-  }) async {
-    final deviceDir = Directory(deviceFolderPath);
-    if (!await deviceDir.exists()) {
-      return FolderImportResult(foldersCreated: 0, filesImported: 0, errors: ['Directory does not exist: $deviceFolderPath']);
-    }
-
-    final folderName = deviceDir.path.split('/').last;
-    final folder = await createFolder(
-      name: folderName,
-      parentId: parentFolderId,
-    );
-    if (folder == null) {
-      return FolderImportResult(foldersCreated: 0, filesImported: 0, errors: ['Failed to create folder']);
-    }
-
-    int foldersCreated = 1;
-    int filesImported = 0;
-    final errors = <String>[];
-
-    final allFiles = <FileToVault>[];
-    final subfolderPaths = <String>[];
-
-    await _collectFilesFromDirectory(
-      deviceDir,
-      allFiles: allFiles,
-      subfolderPaths: subfolderPaths,
-      recursive: recursive,
-    );
-
-    final totalFiles = allFiles.length;
-    if (totalFiles > 0) {
-      final importedFiles = await addFiles(
-        files: allFiles,
+  }) =>
+      _folders.importDeviceFolder(
+        deviceFolderPath,
+        parentFolderId: parentFolderId,
+        recursive: recursive,
         deleteOriginals: deleteOriginals,
         encrypt: encrypt,
         isDecoy: isDecoy,
         onProgress: onProgress,
-        onFileProgress: onFileProgress != null
-            ? (info) => onFileProgress(info.fileName, info.current, info.total)
-            : null,
+        onFileProgress: onFileProgress,
       );
 
-      for (final importedFile in importedFiles) {
-        await addFileToFolder(importedFile.id, folder.id);
-        filesImported++;
-      }
-    }
+  // ---- Tags ----
 
-    if (recursive) {
-      for (final subPath in subfolderPaths) {
-        final subResult = await importDeviceFolder(
-          subPath,
-          parentFolderId: folder.id,
-          recursive: true,
-          deleteOriginals: deleteOriginals,
-          encrypt: encrypt,
-          isDecoy: isDecoy,
-        );
-        foldersCreated += subResult.foldersCreated;
-        filesImported += subResult.filesImported;
-        errors.addAll(subResult.errors);
-      }
-    }
+  Future<List<TagInfo>> getAllTags() => _tags.getAllTags();
 
-    return FolderImportResult(
-      foldersCreated: foldersCreated,
-      filesImported: filesImported,
-      errors: errors,
-      rootFolder: folder,
-    );
-  }
+  Future<List<VaultedFile>> getFilesByTag(String tag) =>
+      _tags.getFilesByTag(tag);
 
-  Future<void> _collectFilesFromDirectory(
-    Directory dir, {
-    required List<FileToVault> allFiles,
-    required List<String> subfolderPaths,
-    required bool recursive,
-  }) async {
-    try {
-      await for (final entity in dir.list()) {
-        if (entity is File) {
-          final file = entity;
-          final fileName = file.path.split('/').last;
-          if (fileName.startsWith('.')) continue;
+  Future<VaultedFile?> addTagToFile(String fileId, String tag) =>
+      _tags.addTagToFile(fileId, tag);
 
-          final extension = fileName.contains('.')
-              ? fileName.split('.').last.toLowerCase()
-              : '';
-          final mimeType = _getMimeTypeFromExtension(extension);
-          final fileType = getFileTypeFromExtension(extension);
+  Future<VaultedFile?> removeTagFromFile(String fileId, String tag) =>
+      _tags.removeTagFromFile(fileId, tag);
 
-          allFiles.add(FileToVault(
-            sourcePath: file.path,
-            originalName: fileName,
-            type: fileType,
-            mimeType: mimeType,
-          ));
-        } else if (entity is Directory && recursive) {
-          final dirName = entity.path.split('/').last;
-          if (dirName.startsWith('.')) continue;
-          subfolderPaths.add(entity.path);
-        }
-      }
-    } catch (e) {
-      debugPrint('Error collecting files from directory: $e');
-    }
-  }
+  Future<TagInfo> createTag(String name, [int? colorValue]) =>
+      _tags.createTag(name, colorValue);
 
-  String _getMimeTypeFromExtension(String extension) {
-    const mimeMap = {
-      'jpg': 'image/jpeg', 'jpeg': 'image/jpeg', 'png': 'image/png',
-      'gif': 'image/gif', 'webp': 'image/webp', 'bmp': 'image/bmp',
-      'heic': 'image/heic', 'heif': 'image/heif',
-      'mp4': 'video/mp4', 'mov': 'video/quicktime', 'avi': 'video/x-msvideo',
-      'mkv': 'video/x-matroska', 'webm': 'video/webm',
-      'mp3': 'audio/mpeg', 'wav': 'audio/wav', 'flac': 'audio/flac',
-      'aac': 'audio/aac', 'ogg': 'audio/ogg', 'm4a': 'audio/mp4',
-      'pdf': 'application/pdf', 'doc': 'application/msword',
-      'docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'txt': 'text/plain', 'rtf': 'application/rtf',
-      'zip': 'application/zip', 'rar': 'application/x-rar-compressed',
-      '7z': 'application/x-7z-compressed',
-      'json': 'application/json', 'xml': 'application/xml',
-      'csv': 'text/csv', 'html': 'text/html', 'htm': 'text/html',
-    };
-    return mimeMap[extension.toLowerCase()] ?? 'application/octet-stream';
-  }
+  Future<bool> updateTagColor(String tagName, int colorValue) =>
+      _tags.updateTagColor(tagName, colorValue);
 
-  // ========== TAG OPERATIONS ==========
+  Future<bool> deleteTag(String tagName) => _tags.deleteTag(tagName);
 
-  /// Get all unique tags
-  Future<List<TagInfo>> getAllTags() async {
-    return await _loadTags();
-  }
+  // ---- Favorites ----
 
-  /// Get files by tag
-  Future<List<VaultedFile>> getFilesByTag(String tag) async {
-    final files = await getAllFiles();
-    return files.where((f) => f.hasTag(tag)).toList();
-  }
+  Future<VaultedFile?> toggleFavorite(String fileId) =>
+      _tags.toggleFavorite(fileId);
 
-  /// Add tag to file
-  Future<VaultedFile?> addTagToFile(String fileId, String tag) async {
-    final file = await getFileById(fileId);
-    if (file == null) return null;
+  Future<List<VaultedFile>> getFavoriteFiles() => _tags.getFavoriteFiles();
 
-    final updatedFile = file.addTag(tag);
-    await updateFile(updatedFile);
-    await _updateTagUsage([tag]);
+  // ---- Sorting ----
 
-    return updatedFile;
-  }
-
-  /// Remove tag from file
-  Future<VaultedFile?> removeTagFromFile(String fileId, String tag) async {
-    final file = await getFileById(fileId);
-    if (file == null) return null;
-
-    final updatedFile = file.removeTag(tag);
-    await updateFile(updatedFile);
-
-    return updatedFile;
-  }
-
-  /// Update tag usage counts
-  Future<void> _updateTagUsage(List<String> tags) async {
-    _cachedTags ??= [];
-
-    for (final tag in tags) {
-      final normalizedTag = tag.toLowerCase().trim();
-      if (normalizedTag.isEmpty) continue;
-
-      final existingIndex =
-          _cachedTags!.indexWhere((t) => t.name == normalizedTag);
-
-      if (existingIndex == -1) {
-        _cachedTags!.add(TagInfo(name: normalizedTag, usageCount: 1));
-      } else {
-        _cachedTags![existingIndex] = TagInfo(
-          name: normalizedTag,
-          colorValue: _cachedTags![existingIndex].colorValue,
-          usageCount: _cachedTags![existingIndex].usageCount + 1,
-        );
-      }
-    }
-
-    await _saveTags();
-  }
-
-  /// Create a new tag with optional color
-  Future<TagInfo> createTag(String name, [int? colorValue]) async {
-    _cachedTags ??= await _loadTags();
-
-    final normalizedName = name.toLowerCase().trim();
-    final existingIndex =
-        _cachedTags!.indexWhere((t) => t.name == normalizedName);
-
-    if (existingIndex != -1) {
-      // Tag already exists, just update color if provided
-      if (colorValue != null) {
-        _cachedTags![existingIndex] = TagInfo(
-          name: normalizedName,
-          colorValue: colorValue,
-          usageCount: _cachedTags![existingIndex].usageCount,
-        );
-        await _saveTags();
-      }
-      return _cachedTags![existingIndex];
-    }
-
-    // Create new tag
-    final newTag = TagInfo(
-      name: normalizedName,
-      colorValue: colorValue ?? 0xFF1976D2,
-      usageCount: 0,
-    );
-    _cachedTags!.add(newTag);
-    await _saveTags();
-
-    return newTag;
-  }
-
-  /// Update a tag's color
-  Future<bool> updateTagColor(String tagName, int colorValue) async {
-    _cachedTags ??= await _loadTags();
-
-    final normalizedName = tagName.toLowerCase().trim();
-    final index = _cachedTags!.indexWhere((t) => t.name == normalizedName);
-
-    if (index == -1) return false;
-
-    _cachedTags![index] = TagInfo(
-      name: normalizedName,
-      colorValue: colorValue,
-      usageCount: _cachedTags![index].usageCount,
-    );
-    await _saveTags();
-
-    return true;
-  }
-
-  /// Delete a tag and remove it from all files
-  Future<bool> deleteTag(String tagName) async {
-    try {
-      final normalizedName = tagName.toLowerCase().trim();
-
-      // Remove tag from all files
-      final files = await getAllFiles();
-      for (final file in files) {
-        if (file.hasTag(normalizedName)) {
-          await removeTagFromFile(file.id, normalizedName);
-        }
-      }
-
-      // Remove from cached tags
-      _cachedTags ??= await _loadTags();
-      _cachedTags!.removeWhere((t) => t.name == normalizedName);
-      await _saveTags();
-
-      return true;
-    } catch (e) {
-      debugPrint('Error deleting tag: $e');
-      return false;
-    }
-  }
-
-  // ========== SORTING ==========
-
-  /// Sort files
   List<VaultedFile> sortFiles(List<VaultedFile> files, SortOption sortOption) {
     final sorted = List<VaultedFile>.from(files);
 
@@ -2256,52 +469,11 @@ class VaultService {
     return sorted;
   }
 
-  // ========== FAVORITES ==========
+  // ---- Search ----
 
-  /// Toggle favorite status
-  Future<VaultedFile?> toggleFavorite(String fileId) async {
-    final file = await getFileById(fileId);
-    if (file == null) return null;
+  Future<List<VaultedFile>> searchFiles(String query) =>
+      _search.searchFiles(query);
 
-    // Update favorites album - this will also update the isFavorite flag
-    final favoritesAlbum = await getAlbumById('favorites');
-    if (favoritesAlbum != null) {
-      if (file.isFavorite) {
-        // Currently favorite, so remove from favorites
-        await removeFileFromAlbum(fileId, 'favorites');
-      } else {
-        // Not favorite, so add to favorites
-        await addFileToAlbum(fileId, 'favorites');
-      }
-    } else {
-      // No favorites album exists, just toggle the flag directly
-      final updatedFile = file.toggleFavorite();
-      await updateFile(updatedFile);
-      return updatedFile;
-    }
-
-    // Return the updated file
-    return await getFileById(fileId);
-  }
-
-  /// Get favorite files
-  Future<List<VaultedFile>> getFavoriteFiles() async {
-    final files = await getAllFiles();
-    return files.where((f) => f.isFavorite).toList();
-  }
-
-  // ========== SEARCH ==========
-
-  /// Search files by name
-  Future<List<VaultedFile>> searchFiles(String query) async {
-    final files = await _loadFileIndex();
-    final lowerQuery = query.toLowerCase();
-    return files
-        .where((f) => f.originalName.toLowerCase().contains(lowerQuery))
-        .toList();
-  }
-
-  /// Search files by name and tags
   Future<List<VaultedFile>> searchFilesAdvanced({
     String? query,
     List<String>? tags,
@@ -2310,900 +482,55 @@ class VaultService {
     DateTime? dateTo,
     bool? isFavorite,
     String? albumId,
-  }) async {
-    var files = await getAllFiles();
-
-    // Filter by query
-    if (query != null && query.isNotEmpty) {
-      final lowerQuery = query.toLowerCase();
-      files = files
-          .where((f) => f.originalName.toLowerCase().contains(lowerQuery))
-          .toList();
-    }
-
-    // Filter by tags
-    if (tags != null && tags.isNotEmpty) {
-      files = files.where((f) => tags.every((tag) => f.hasTag(tag))).toList();
-    }
-
-    // Filter by type
-    if (type != null) {
-      files = files.where((f) => f.type == type).toList();
-    }
-
-    // Filter by date range
-    if (dateFrom != null) {
-      files = files.where((f) => f.dateAdded.isAfter(dateFrom)).toList();
-    }
-    if (dateTo != null) {
-      files = files.where((f) => f.dateAdded.isBefore(dateTo)).toList();
-    }
-
-    // Filter by favorite
-    if (isFavorite != null) {
-      files = files.where((f) => f.isFavorite == isFavorite).toList();
-    }
-
-    // Filter by album
-    if (albumId != null) {
-      files = files.where((f) => f.isInAlbum(albumId)).toList();
-    }
-
-    return files;
-  }
-
-  // ========== SETTINGS ==========
-
-  /// Get vault settings
-  Future<VaultSettings> getSettings() async {
-    return await _loadSettings();
-  }
-
-  /// Update vault settings
-  Future<void> updateSettings(VaultSettings settings) async {
-    _cachedSettings = settings;
-    await _saveSettings();
-  }
-
-  // ========== STATISTICS ==========
-
-  /// Get file counts by type
-  Future<Map<VaultedFileType, int>> getFileCounts() async {
-    final files = await _loadFileIndex();
-    final counts = <VaultedFileType, int>{};
-
-    for (final type in VaultedFileType.values) {
-      counts[type] = files.where((f) => f.type == type).length;
-    }
-
-    return counts;
-  }
-
-  /// Get total storage used
-  Future<int> getTotalStorageUsed() async {
-    final files = await _loadFileIndex();
-    return files.fold<int>(0, (sum, file) => sum + file.fileSize);
-  }
-
-  Future<File?> exportFile(
-    String fileId,
-    String destinationPath, {
-    bool isDecoy = false,
-    Function(int processed, int total)? onProgress,
-  }) async {
-    try {
-      final vaultedFile = await getFileById(fileId, isDecoy: isDecoy);
-      if (vaultedFile == null) return null;
-
-      final sourceFile = File(vaultedFile.vaultPath);
-      if (!await sourceFile.exists()) return null;
-
-      if (vaultedFile.isEncrypted && vaultedFile.encryptionIv != null) {
-        final format = _encryptionService.detectFileFormat(vaultedFile.vaultPath);
-        final isLegacyCbc = (format == 0 || format == 3);
-        final derivedKey = await _deriveKeyForFile(vaultedFile, isDecoy: isDecoy);
-
-        FileDecryptionResult result;
-        if (isLegacyCbc) {
-          result = await _encryptionService.decryptFile(
-            vaultedFile.vaultPath,
-            destinationPath,
-            vaultedFile.encryptionIv!,
-            derivedKey: derivedKey,
-            onProgress: onProgress == null
-                ? null
-                : (current, total) {
-                    final estimatedProcessed = total > 0
-                        ? (current / total * vaultedFile.fileSize).round()
-                        : 0;
-                    onProgress(estimatedProcessed, vaultedFile.fileSize);
-                  },
-          );
-        } else {
-          result = await _encryptionService.decryptFileInIsolate(
-            vaultedFile.vaultPath,
-            destinationPath,
-            vaultedFile.encryptionIv!,
-            isDecoy: isDecoy,
-            derivedKey: derivedKey,
-            onProgress: onProgress == null
-                ? null
-                : (bytesProcessed, totalBytes) {
-                    onProgress(bytesProcessed, totalBytes);
-                  },
-          );
-        }
-
-        if (result.success && result.decryptedPath != null) {
-          return File(result.decryptedPath!);
-        }
-        return null;
-      }
-
-      await _streamCopyFile(
-        sourceFile,
-        File(destinationPath),
-        onProgress: onProgress,
+  }) =>
+      _search.searchFilesAdvanced(
+        query: query,
+        tags: tags,
+        type: type,
+        dateFrom: dateFrom,
+        dateTo: dateTo,
+        isFavorite: isFavorite,
+        albumId: albumId,
       );
-      return File(destinationPath);
-    } catch (e) {
-      debugPrint('Error exporting file: $e');
-      return null;
-    }
-  }
 
-  static const String _reEncryptJournalKey = 'reencrypt_journal';
+  // ---- Settings ----
 
-  Future<int> reEncryptVault(
-    EncryptionAlgorithm targetAlgorithm, {
-    bool isDecoy = false,
-    Function(int current, int total, String currentFileName, int processedBytes,
-            int totalBytes)?
-        onProgress,
-    Set<String>? fileFilter,
-  }) async {
-    try {
-      final files = isDecoy
-          ? (await getAllFiles(isDecoy: true))
-          : (await getAllFiles(isDecoy: false));
-      var encryptedFiles = files.where((f) => f.isEncrypted).toList();
+  Future<VaultSettings> getSettings() => _settings.getSettings();
 
-      if (fileFilter != null && fileFilter.isNotEmpty) {
-        encryptedFiles = encryptedFiles.where((f) => fileFilter.contains(f.id)).toList();
-      }
+  Future<void> updateSettings(VaultSettings settings) =>
+      _settings.updateSettings(settings);
 
-      if (encryptedFiles.isEmpty) return 0;
+  // ---- Stats ----
 
-      final journalIvs = <String, String>{};
-      String? priorInProgress;
+  Future<Map<VaultedFileType, int>> getFileCounts() => _stats.getFileCounts();
 
-      final journalStr = await _storage.read(key: _reEncryptJournalKey);
-      if (journalStr != null) {
-        try {
-          final journal = jsonDecode(journalStr) as Map<String, dynamic>;
-          final savedIvs = (journal['ivs'] as Map<String, dynamic>?)?.cast<String, String>() ?? {};
-          journalIvs.addAll(savedIvs);
-          priorInProgress = journal['inProgress'] as String?;
+  Future<int> getTotalStorageUsed() => _stats.getTotalStorageUsed();
 
-          for (final entry in journalIvs.entries) {
-            final idx = files.indexWhere((f) => f.vaultPath == entry.key);
-            if (idx >= 0) {
-              files[idx] = files[idx].copyWith(encryptionIv: entry.value);
-            }
-          }
+  // ---- Misc ----
 
-          if (priorInProgress != null) {
-            try { await File('$priorInProgress.tmp').delete(); } catch (_) {}
-          }
-
-          encryptedFiles = files.where((f) => f.isEncrypted).toList();
-          // ponytail: journal recovery rebuilds from the full list (to restore
-          // IVs from vaultPath matches), so re-apply the selection here —
-          // without this a leftover journal makes reEncryptVault ignore
-          // fileFilter and process every encrypted file.
-          if (fileFilter != null && fileFilter.isNotEmpty) {
-            encryptedFiles =
-                encryptedFiles.where((f) => fileFilter.contains(f.id)).toList();
-          }
-
-          if (isDecoy) { _cachedDecoyFiles = files; } else { _cachedFiles = files; }
-          await _saveFileIndex(isDecoy: isDecoy);
-        } catch (_) {}
-      }
-
-      final totalBytes = encryptedFiles.fold<int>(0, (s, f) => s + f.fileSize);
-      var processedBytes = 0;
-      int reEncryptedCount = 0;
-
-      for (int i = 0; i < encryptedFiles.length; i++) {
-        final file = encryptedFiles[i];
-        onProgress?.call(i, encryptedFiles.length, file.originalName,
-            processedBytes, totalBytes);
-
-        if (!await File(file.vaultPath).exists()) {
-          processedBytes += file.fileSize;
-          onProgress?.call(i + 1, encryptedFiles.length, file.originalName,
-              processedBytes, totalBytes);
-          continue;
-        }
-        // ponytail: an encrypted file with no stored IV is undecryptable on any
-        // path (the IV is never embedded in the file — pool encrypt returns it
-        // for the index to store). Skip it instead of throwing "IV must be at
-        // least 1 byte" and aborting the whole batch; matches removeEncryption's
-        // guard. These are legacy/orphaned entries, not normal imports.
-        if (file.encryptionIv == null || file.encryptionIv!.isEmpty) {
-          debugPrint(
-              'reEncryptVault: skipping ${file.originalName} (missing IV)');
-          processedBytes += file.fileSize;
-          onProgress?.call(i + 1, encryptedFiles.length, file.originalName,
-              processedBytes, totalBytes);
-          continue;
-        }
-
-        final currentFormat = _encryptionService.detectFileFormat(file.vaultPath);
-        final targetIsGcm = targetAlgorithm == EncryptionAlgorithm.aes256Gcm;
-        final currentIsGcm = (currentFormat == 1 || currentFormat == 4);
-
-        if (currentIsGcm == targetIsGcm && currentFormat != 0 && currentFormat != 3) {
-          processedBytes += file.fileSize;
-          onProgress?.call(i + 1, encryptedFiles.length, file.originalName,
-              processedBytes, totalBytes);
-          continue;
-        }
-
-        await _storage.write(
-          key: _reEncryptJournalKey,
-          value: jsonEncode({
-            'ivs': journalIvs,
-            'inProgress': file.vaultPath,
-          }),
-        );
-
-        final oldDerivedKey = await _deriveKeyForFile(file, isDecoy: isDecoy);
-        final newSalt = _encryptionService.generateFileSalt();
-        final newIterations = _cachedSettings?.kdfIterations ?? 100000;
-        final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
-        // ponytail: async (Compute isolate). Sync deriveFileKey @ 100k iterations
-        // per file on the main isolate was the re-encrypt hang; encrypt (line ~702)
-        // and the old-key derivation above both already use the async path.
-        final newDerivedKey = await _encryptionService.deriveFileKeyAsync(masterKey, newSalt, newIterations);
-
-        final baseBytes = processedBytes;
-        final halfBytes = file.fileSize ~/ 2;
-        final newIv = await _encryptionService.reEncryptFile(
-          file.vaultPath,
-          file.encryptionIv ?? '',
-          targetAlgorithm: targetAlgorithm,
-          isDecoy: isDecoy,
-          oldDerivedKey: oldDerivedKey,
-          newDerivedKey: newDerivedKey,
-          onProgress: onProgress == null
-              ? null
-              // ponytail: fold decrypt(0..half) then encrypt(half..full) into one
-              // monotonic budget so the bar advances across both pool stages.
-              : (processed, _, isEnc) => onProgress(
-                    i,
-                    encryptedFiles.length,
-                    file.originalName,
-                    baseBytes +
-                        (isEnc
-                            ? halfBytes + (processed ~/ 2)
-                            : processed ~/ 2),
-                    totalBytes),
-        );
-
-        journalIvs[file.vaultPath] = newIv;
-        await _storage.write(
-          key: _reEncryptJournalKey,
-          value: jsonEncode({
-            'ivs': journalIvs,
-          }),
-        );
-
-        final fileIndex = files.indexWhere((f) => f.id == file.id);
-        if (fileIndex >= 0) {
-          // ponytail: per-file key changed → the stored thumb ciphertext is
-          // undecryptable. Delete it; getThumbnailBytes lazily regenerates with
-          // the new key. In-memory cache (still the correct image) is left as-is.
-          if (file.thumbnailPath != null) {
-            try {
-              await File(file.thumbnailPath!).delete();
-            } catch (_) {}
-          }
-          files[fileIndex] = file.copyWith(
-            encryptionIv: newIv,
-            encryptionAlgorithm: targetAlgorithm,
-            keyDerivationSalt: base64Encode(newSalt),
-            kdfIterations: newIterations,
-          );
-          reEncryptedCount++;
-        }
-        processedBytes += file.fileSize;
-        onProgress?.call(i + 1, encryptedFiles.length, file.originalName,
-            processedBytes, totalBytes);
-      }
-
-      if (isDecoy) {
-        _cachedDecoyFiles = files;
-      } else {
-        _cachedFiles = files;
-      }
-
-      await _saveFileIndex(isDecoy: isDecoy);
-      await _storage.delete(key: _reEncryptJournalKey);
-      return reEncryptedCount;
-    } catch (e) {
-      debugPrint('Re-encryption error: $e');
-      return -1;
-    }
-  }
-
-  /// Add encryption to currently-unencrypted vault files, in place.
-  /// Same reliability profile as reEncryptVault: isolate pool + async key
-  /// derivation + atomic temp/rename. [algorithm] picks CTR vs GCM.
-  /// ponytail: index saved ONCE at the end (not per file). A per-file save
-  /// jsonEncodes + re-writes the whole index N times through secure storage,
-  /// which froze the UI on batches — reEncryptVault saves once for the same
-  /// reason. Each file is still atomic (temp + rename), so a crash can only
-  /// ever leave a completed file's bytes consistent; the index is reconciled
-  /// by re-running the op against the still-eligible files.
-  Future<int> encryptVaultFiles(
-    EncryptionAlgorithm algorithm, {
-    bool isDecoy = false,
-    Function(int current, int total, String currentFileName, int processedBytes,
-            int totalBytes)?
-        onProgress,
-    Set<String>? fileFilter,
-  }) async {
-    try {
-      final files = await getAllFiles(isDecoy: isDecoy);
-      var targets = files.where((f) => !f.isEncrypted).toList();
-      if (fileFilter != null && fileFilter.isNotEmpty) {
-        targets = targets.where((f) => fileFilter.contains(f.id)).toList();
-      }
-      if (targets.isEmpty) return 0;
-
-      final iterations = _cachedSettings?.kdfIterations ?? 100000;
-      final totalBytes = targets.fold<int>(0, (s, f) => s + f.fileSize);
-      var processedBytes = 0;
-      var count = 0;
-
-      for (int i = 0; i < targets.length; i++) {
-        final file = targets[i];
-        onProgress?.call(i, targets.length, file.originalName, processedBytes,
-            totalBytes);
-        if (!await File(file.vaultPath).exists()) {
-          processedBytes += file.fileSize;
-          continue;
-        }
-
-        final salt = _encryptionService.generateFileSalt();
-        final masterKey = await _encryptionService.getMasterKey(isDecoy: isDecoy || file.isDecoy);
-        final derivedKey = await _encryptionService.deriveFileKeyAsync(masterKey, salt, iterations);
-
-        final baseBytes = processedBytes;
-        final newIv = await _encryptionService.encryptFileInPlace(
-          file.vaultPath,
-          useGcm: algorithm == EncryptionAlgorithm.aes256Gcm,
-          isDecoy: isDecoy,
-          derivedKey: derivedKey,
-          onProgress: onProgress == null
-              ? null
-              : (processed, _) => onProgress(
-                    i, targets.length, file.originalName,
-                    baseBytes + processed, totalBytes),
-        );
-
-        final idx = files.indexWhere((f) => f.id == file.id);
-        if (idx >= 0) {
-          files[idx] = file.copyWith(
-            isEncrypted: true,
-            encryptionIv: newIv,
-            encryptionAlgorithm: algorithm,
-            keyDerivationSalt: base64Encode(salt),
-            kdfIterations: iterations,
-          );
-          count++;
-        }
-        processedBytes += file.fileSize;
-        onProgress?.call(i + 1, targets.length, file.originalName,
-            processedBytes, totalBytes);
-      }
-
-      await _saveFileIndex(isDecoy: isDecoy);
-      return count;
-    } catch (e) {
-      // Persist whatever completed before the failure so the index matches disk.
-      try { await _saveFileIndex(isDecoy: isDecoy); } catch (_) {}
-      debugPrint('Encrypt-in-place error: $e');
-      return -1;
-    }
-  }
-
-  /// Remove encryption from encrypted vault files, decrypting them in place
-  /// so they are stored as plaintext. Same reliability profile as reEncryptVault.
-  Future<int> removeEncryption({
-    bool isDecoy = false,
-    Function(int current, int total, String currentFileName, int processedBytes,
-            int totalBytes)?
-        onProgress,
-    Set<String>? fileFilter,
-  }) async {
-    try {
-      final files = await getAllFiles(isDecoy: isDecoy);
-      var targets = files.where((f) => f.isEncrypted).toList();
-      if (fileFilter != null && fileFilter.isNotEmpty) {
-        targets = targets.where((f) => fileFilter.contains(f.id)).toList();
-      }
-      if (targets.isEmpty) return 0;
-
-      final totalBytes = targets.fold<int>(0, (s, f) => s + f.fileSize);
-      var processedBytes = 0;
-      var count = 0;
-
-      for (int i = 0; i < targets.length; i++) {
-        final file = targets[i];
-        onProgress?.call(i, targets.length, file.originalName, processedBytes,
-            totalBytes);
-        if (!await File(file.vaultPath).exists()) {
-          processedBytes += file.fileSize;
-          continue;
-        }
-        if (file.encryptionIv == null) {
-          processedBytes += file.fileSize;
-          continue;
-        }
-
-        final derivedKey = await _deriveKeyForFile(file, isDecoy: isDecoy);
-
-        final baseBytes = processedBytes;
-        await _encryptionService.decryptFileInPlace(
-          file.vaultPath,
-          file.encryptionIv!,
-          isDecoy: isDecoy,
-          derivedKey: derivedKey,
-          onProgress: onProgress == null
-              ? null
-              : (processed, _) => onProgress(
-                    i, targets.length, file.originalName,
-                    baseBytes + processed, totalBytes),
-        );
-
-        final idx = files.indexWhere((f) => f.id == file.id);
-        if (idx >= 0) {
-          // copyWith can't null out fields, so rebuild clearing the crypto ones.
-          // ponytail: file is now plaintext, grids render vaultPath directly and
-          // getThumbnailBytes returns null for unencrypted files — so drop the
-          // thumb field and delete the now-orphaned ciphertext thumb.
-          if (file.thumbnailPath != null) {
-            try {
-              await File(file.thumbnailPath!).delete();
-            } catch (_) {}
-          }
-          files[idx] = VaultedFile(
-            id: file.id,
-            originalName: file.originalName,
-            vaultPath: file.vaultPath,
-            originalPath: file.originalPath,
-            type: file.type,
-            mimeType: file.mimeType,
-            fileSize: file.fileSize,
-            dateAdded: file.dateAdded,
-            dateModified: DateTime.now(),
-            metadata: file.metadata,
-            tags: file.tags,
-            isFavorite: file.isFavorite,
-            isEncrypted: false,
-            isDecoy: file.isDecoy,
-            lastViewed: file.lastViewed,
-            viewCount: file.viewCount,
-            notes: file.notes,
-            albumIds: file.albumIds,
-            folderId: file.folderId,
-          );
-          count++;
-        }
-        processedBytes += file.fileSize;
-        onProgress?.call(i + 1, targets.length, file.originalName,
-            processedBytes, totalBytes);
-      }
-
-      await _saveFileIndex(isDecoy: isDecoy);
-      return count;
-    } catch (e) {
-      try { await _saveFileIndex(isDecoy: isDecoy); } catch (_) {}
-      debugPrint('Remove-encryption error: $e');
-      return -1;
-    }
-  }
-
-  /// Clear all vault data (use with caution!)
   Future<void> clearVault({bool isDecoy = false}) async {
     try {
-      final appDir = await getApplicationDocumentsDirectory();
-      final directory = Directory(
-        '${appDir.path}/${isDecoy ? _decoyFolderName : _vaultFolderName}',
-      );
-
-      if (await directory.exists()) {
-        await directory.delete(recursive: true);
-      }
-
-      if (isDecoy) {
-        _cachedDecoyFiles = [];
-        await _storage.delete(key: _decoyIndexKey);
-        _decoyDirectory = null;
-      } else {
-        _cachedFiles = [];
-        _cachedAlbums = null;
-        _cachedFolders = null;
-        _cachedTags = null;
-        await _storage.delete(key: _vaultIndexKey);
-        await _storage.delete(key: _albumsKey);
-        await _storage.delete(key: _foldersKey);
-        await _storage.delete(key: _tagsKey);
-        _vaultDirectory = null;
-      }
+      await _store.wipe(isDecoy: isDecoy);
       clearThumbnailCache();
     } catch (e) {
       debugPrint('Error clearing vault: $e');
     }
   }
 
-  /// Refresh the cache
   Future<void> refresh() async {
-    // ponytail: atomic swap — read storage into locals before replacing caches,
-    // so a concurrent mutation never observes a null cache (was the NPE vector
-    // flagged in Tier 4). Full mutation serialization (repositories + a
-    // re-entrant lock) is deferred; a naive lock deadlocks because mutating
-    // methods call each other (addFileToAlbum → updateFile, etc.).
-    final files = await _loadFileIndex(forceReload: true);
-    final decoyFiles = await _loadFileIndex(isDecoy: true, forceReload: true);
-    final albums = await _loadAlbums(forceReload: true);
-    final folders = await _loadFolders(forceReload: true);
-    final tags = await _loadTags(forceReload: true);
-    _cachedFiles = files;
-    _cachedDecoyFiles = decoyFiles;
-    _cachedAlbums = albums;
-    _cachedFolders = folders;
-    _cachedTags = tags;
-  }
-
-  /// Clean up temp files
-  Future<void> cleanupTemp() async {
-    try {
-      final vaultDir = await _ensureVaultDirectory();
-      final tempDir = Directory('${vaultDir.path}/temp');
-
-      if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
-        await tempDir.create();
-      }
-    } catch (e) {
-      debugPrint('Error cleaning temp: $e');
-    }
-  }
-
-  Future<void> registerNoteEntry({
-    required String noteId,
-    required String title,
-    required String encryptedContentPath,
-    String fileExtension = 'txt',
-    bool isEncrypted = false,
-    EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
-    int kdfIterations = 0,
-    String? folderId,
-    bool isDecoy = false,
-  }) async {
-    final files = isDecoy
-        ? (_cachedDecoyFiles ??= await _loadFileIndex(isDecoy: true))
-        : (_cachedFiles ??= await _loadFileIndex());
-
-    final existingIndex =
-        files.indexWhere((f) => f.metadata?['noteId'] == noteId);
-
-    final mimeType = switch (fileExtension) {
-      'md' => 'text/markdown',
-      'html' => 'text/html',
-      _ => 'text/plain',
-    };
-
-    final entry = VaultedFile(
-      id: existingIndex != -1 ? files[existingIndex].id : noteId,
-      originalName: '$title.$fileExtension',
-      vaultPath: encryptedContentPath,
-      type: VaultedFileType.document,
-      mimeType: mimeType,
-      fileSize: 0,
-      dateAdded: existingIndex != -1
-          ? files[existingIndex].dateAdded
-          : DateTime.now(),
-      dateModified: DateTime.now(),
-      tags: ['note'],
-      isEncrypted: isEncrypted,
-      encryptionAlgorithm: encryptionAlgorithm,
-      kdfIterations: kdfIterations,
-      folderId: folderId,
-      metadata: {'noteId': noteId},
-    );
-
-    if (existingIndex != -1) {
-      files[existingIndex] = entry;
-    } else {
-      files.insert(0, entry);
-    }
-
-    if (isDecoy) {
-      await _saveFileIndex(isDecoy: true);
-    } else {
-      await _saveFileIndex();
-    }
-  }
-
-  Future<void> removeNoteEntry(String noteId, {bool isDecoy = false}) async {
-    final files = isDecoy
-        ? (_cachedDecoyFiles ??= await _loadFileIndex(isDecoy: true))
-        : (_cachedFiles ??= await _loadFileIndex());
-
-    files.removeWhere((f) => f.metadata?['noteId'] == noteId);
-
-    if (isDecoy) {
-      await _saveFileIndex(isDecoy: true);
-    } else {
-      await _saveFileIndex();
-    }
-  }
-
-  Future<void> registerPasswordEntry({
-    required String passwordId,
-    required String title,
-    required String encryptedContentPath,
-    List<String> tags = const [],
-    bool isEncrypted = false,
-    EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
-    int kdfIterations = 0,
-    bool isDecoy = false,
-  }) async {
-    final files = isDecoy
-        ? (_cachedDecoyFiles ??= await _loadFileIndex(isDecoy: true))
-        : (_cachedFiles ??= await _loadFileIndex());
-
-    final existingIndex =
-        files.indexWhere((f) => f.metadata?['passwordId'] == passwordId);
-
-    final entry = VaultedFile(
-      id: existingIndex != -1 ? files[existingIndex].id : passwordId,
-      originalName: '$title.pwd',
-      vaultPath: encryptedContentPath,
-      type: VaultedFileType.document,
-      mimeType: 'application/octet-stream',
-      fileSize: 0,
-      dateAdded: existingIndex != -1
-          ? files[existingIndex].dateAdded
-          : DateTime.now(),
-      dateModified: DateTime.now(),
-      tags: ['password', ...tags],
-      isEncrypted: isEncrypted,
-      encryptionAlgorithm: encryptionAlgorithm,
-      kdfIterations: kdfIterations,
-      metadata: {'passwordId': passwordId},
-    );
-
-    if (existingIndex != -1) {
-      files[existingIndex] = entry;
-    } else {
-      files.insert(0, entry);
-    }
-
-    if (isDecoy) {
-      await _saveFileIndex(isDecoy: true);
-    } else {
-      await _saveFileIndex();
-    }
-  }
-
-  Future<void> removePasswordEntry(String passwordId,
-      {bool isDecoy = false}) async {
-    final files = isDecoy
-        ? (_cachedDecoyFiles ??= await _loadFileIndex(isDecoy: true))
-        : (_cachedFiles ??= await _loadFileIndex());
-
-    files.removeWhere((f) => f.metadata?['passwordId'] == passwordId);
-
-    if (isDecoy) {
-      await _saveFileIndex(isDecoy: true);
-    } else {
-      await _saveFileIndex();
-    }
-  }
-}
-
-/// Helper class for batch file import
-class FileToVault {
-  final String sourcePath;
-  final String originalName;
-  final VaultedFileType type;
-  final String mimeType;
-  final bool? encrypt;
-  final EncryptionAlgorithm? encryptionAlgorithm;
-  final int? kdfIterations;
-
-  const FileToVault({
-    required this.sourcePath,
-    required this.originalName,
-    required this.type,
-    required this.mimeType,
-    this.encrypt,
-    this.encryptionAlgorithm,
-    this.kdfIterations,
-  });
-}
-
-/// Result of importing a device folder
-class FolderImportResult {
-  final int foldersCreated;
-  final int filesImported;
-  final List<String> errors;
-  final VaultFolder? rootFolder;
-
-  const FolderImportResult({
-    required this.foldersCreated,
-    required this.filesImported,
-    this.errors = const [],
-    this.rootFolder,
-  });
-}
-
-/// Vault settings
-class VaultSettings {
-  final bool encryptionEnabled;
-  final EncryptionAlgorithm encryptionAlgorithm;
-  final int kdfIterations;
-  final bool secureDelete;
-  final bool screenshotProtectionEnabled;
-  final int autoKillDelaySeconds;
-  final SortOption defaultSort;
-  final bool showHiddenFiles;
-  final bool autoBackup;
-  final int? maxStorageMB;
-  final bool decoyModeEnabled;
-  final String? decoyPin;
-  final bool compressionEnabled;
-  final bool failedUnlockProtectionEnabled;
-  final int maxFailedAttemptsBeforeLockout;
-  final int lockoutDurationSeconds;
-  final bool wipeVaultOnMaxFailedAttempts;
-  final int maxFailedAttemptsBeforeWipe;
-  final bool showPermissionWarning;
-
-  const VaultSettings({
-    this.encryptionEnabled = false,
-    this.encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
-    this.kdfIterations = 600000,
-    this.secureDelete = true,
-    this.screenshotProtectionEnabled = false,
-    this.autoKillDelaySeconds = 0,
-    this.defaultSort = SortOption.dateAddedNewest,
-    this.showHiddenFiles = false,
-    this.autoBackup = false,
-    this.maxStorageMB,
-    this.decoyModeEnabled = false,
-    this.decoyPin,
-    this.compressionEnabled = false,
-    this.failedUnlockProtectionEnabled = false,
-    this.maxFailedAttemptsBeforeLockout = 5,
-    this.lockoutDurationSeconds = 30,
-    this.wipeVaultOnMaxFailedAttempts = false,
-    this.maxFailedAttemptsBeforeWipe = 12,
-    this.showPermissionWarning = true,
-  });
-
-  VaultSettings copyWith({
-    bool? encryptionEnabled,
-    EncryptionAlgorithm? encryptionAlgorithm,
-    int? kdfIterations,
-    bool? secureDelete,
-    bool? screenshotProtectionEnabled,
-    int? autoKillDelaySeconds,
-    SortOption? defaultSort,
-    bool? showHiddenFiles,
-    bool? autoBackup,
-    int? maxStorageMB,
-    bool? decoyModeEnabled,
-    String? decoyPin,
-    bool? compressionEnabled,
-    bool? failedUnlockProtectionEnabled,
-    int? maxFailedAttemptsBeforeLockout,
-    int? lockoutDurationSeconds,
-    bool? wipeVaultOnMaxFailedAttempts,
-    int? maxFailedAttemptsBeforeWipe,
-    bool? showPermissionWarning,
-  }) {
-    return VaultSettings(
-      encryptionEnabled: encryptionEnabled ?? this.encryptionEnabled,
-      encryptionAlgorithm: encryptionAlgorithm ?? this.encryptionAlgorithm,
-      kdfIterations: kdfIterations ?? this.kdfIterations,
-      secureDelete: secureDelete ?? this.secureDelete,
-      screenshotProtectionEnabled:
-          screenshotProtectionEnabled ?? this.screenshotProtectionEnabled,
-      autoKillDelaySeconds: autoKillDelaySeconds ?? this.autoKillDelaySeconds,
-      defaultSort: defaultSort ?? this.defaultSort,
-      showHiddenFiles: showHiddenFiles ?? this.showHiddenFiles,
-      autoBackup: autoBackup ?? this.autoBackup,
-      maxStorageMB: maxStorageMB ?? this.maxStorageMB,
-      decoyModeEnabled: decoyModeEnabled ?? this.decoyModeEnabled,
-      decoyPin: decoyPin ?? this.decoyPin,
-      compressionEnabled: compressionEnabled ?? this.compressionEnabled,
-      failedUnlockProtectionEnabled:
-          failedUnlockProtectionEnabled ?? this.failedUnlockProtectionEnabled,
-      maxFailedAttemptsBeforeLockout:
-          maxFailedAttemptsBeforeLockout ?? this.maxFailedAttemptsBeforeLockout,
-      lockoutDurationSeconds:
-          lockoutDurationSeconds ?? this.lockoutDurationSeconds,
-      wipeVaultOnMaxFailedAttempts:
-          wipeVaultOnMaxFailedAttempts ?? this.wipeVaultOnMaxFailedAttempts,
-      maxFailedAttemptsBeforeWipe:
-          maxFailedAttemptsBeforeWipe ?? this.maxFailedAttemptsBeforeWipe,
-      showPermissionWarning:
-          showPermissionWarning ?? this.showPermissionWarning,
-    );
-  }
-
-  Map<String, dynamic> toJson() => {
-        'encryptionEnabled': encryptionEnabled,
-        'encryptionAlgorithm': encryptionAlgorithm.name,
-        'kdfIterations': kdfIterations,
-        'secureDelete': secureDelete,
-        'screenshotProtectionEnabled': screenshotProtectionEnabled,
-        'autoKillDelaySeconds': autoKillDelaySeconds,
-        'defaultSort': defaultSort.name,
-        'showHiddenFiles': showHiddenFiles,
-        'autoBackup': autoBackup,
-        'maxStorageMB': maxStorageMB,
-        'decoyModeEnabled': decoyModeEnabled,
-        'decoyPin': decoyPin,
-        'compressionEnabled': compressionEnabled,
-        'failedUnlockProtectionEnabled': failedUnlockProtectionEnabled,
-        'maxFailedAttemptsBeforeLockout': maxFailedAttemptsBeforeLockout,
-        'lockoutDurationSeconds': lockoutDurationSeconds,
-        'wipeVaultOnMaxFailedAttempts': wipeVaultOnMaxFailedAttempts,
-        'maxFailedAttemptsBeforeWipe': maxFailedAttemptsBeforeWipe,
-        'showPermissionWarning': showPermissionWarning,
-      };
-
-  factory VaultSettings.fromJson(Map<String, dynamic> json) {
-    return VaultSettings(
-      encryptionEnabled: json['encryptionEnabled'] as bool? ?? false,
-      encryptionAlgorithm: EncryptionAlgorithm.values.firstWhere(
-        (a) => a.name == (json['encryptionAlgorithm'] as String? ?? 'aes256Gcm'),
-        orElse: () => EncryptionAlgorithm.aes256Gcm,
-      ),
-      kdfIterations: json['kdfIterations'] as int? ?? 600000,
-      secureDelete: json['secureDelete'] as bool? ?? true,
-      screenshotProtectionEnabled:
-          json['screenshotProtectionEnabled'] as bool? ?? false,
-      autoKillDelaySeconds: json['autoKillDelaySeconds'] as int? ?? 0,
-      defaultSort: SortOption.values.firstWhere(
-        (s) => s.name == (json['defaultSort'] as String? ?? 'dateAddedNewest'),
-        orElse: () => SortOption.dateAddedNewest,
-      ),
-      showHiddenFiles: json['showHiddenFiles'] as bool? ?? false,
-      autoBackup: json['autoBackup'] as bool? ?? false,
-      maxStorageMB: json['maxStorageMB'] as int?,
-      decoyModeEnabled: json['decoyModeEnabled'] as bool? ?? false,
-      decoyPin: json['decoyPin'] as String?,
-      compressionEnabled: json['compressionEnabled'] as bool? ?? false,
-      failedUnlockProtectionEnabled:
-          json['failedUnlockProtectionEnabled'] as bool? ?? false,
-      maxFailedAttemptsBeforeLockout:
-          json['maxFailedAttemptsBeforeLockout'] as int? ?? 5,
-      lockoutDurationSeconds: json['lockoutDurationSeconds'] as int? ?? 30,
-      wipeVaultOnMaxFailedAttempts:
-          json['wipeVaultOnMaxFailedAttempts'] as bool? ?? false,
-      maxFailedAttemptsBeforeWipe:
-          json['maxFailedAttemptsBeforeWipe'] as int? ?? 12,
-      showPermissionWarning:
-          json['showPermissionWarning'] as bool? ?? true,
-    );
+    // ponytail: atomic swap — reload all caches before replacing them, so a
+    // concurrent mutation never observes a null cache (was the NPE vector
+    // flagged in Tier 4). Full mutation serialization deferred.
+    final files = await _store.loadFileIndex(forceReload: true);
+    final decoyFiles =
+        await _store.loadFileIndex(isDecoy: true, forceReload: true);
+    final albums = await _store.loadAlbums(forceReload: true);
+    final folders = await _store.loadFolders(forceReload: true);
+    final tags = await _store.loadTags(forceReload: true);
+    _store.cachedFiles = files;
+    _store.cachedDecoyFiles = decoyFiles;
+    _store.cachedAlbums = albums;
+    _store.cachedFolders = folders;
+    _store.cachedTags = tags;
   }
 }

--- a/lib/services/vault_store.dart
+++ b/lib/services/vault_store.dart
@@ -1,0 +1,469 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../models/album.dart';
+import '../models/vault_folder.dart';
+import '../models/vault_settings.dart';
+import '../models/vaulted_file.dart';
+
+/// Centralized vault state + persistence. Owns `_storage`, directories, the
+/// `_cached*` maps and all `_load*`/`_save*` methods. Domain services depend
+/// on this + `EncryptionService` via constructor.
+///
+/// ponytail: single shared-state holder. The original VaultService had every
+/// cache read inline across all seams — no service could be extracted
+/// cleanly without centralizing state first. This is that centralization.
+class VaultStore {
+  static const _storage = FlutterSecureStorage(
+    aOptions: AndroidOptions(),
+    iOptions:
+        IOSOptions(accessibility: KeychainAccessibility.unlocked_this_device),
+  );
+
+  static const String vaultIndexKey = 'vault_file_index';
+  static const String decoyIndexKey = 'vault_decoy_index';
+  static const String albumsKey = 'vault_albums';
+  static const String tagsKey = 'vault_tags';
+  static const String settingsKey = 'vault_settings';
+  static const String vaultFolderName = '.locker_vault';
+  static const String decoyFolderName = '.locker_decoy';
+  static const String foldersKey = 'vault_folders';
+  static const String reEncryptJournalKey = 'reencrypt_journal';
+
+  Directory? vaultDirectory;
+  Directory? decoyDirectory;
+
+  List<VaultedFile>? cachedFiles;
+  List<VaultedFile>? cachedDecoyFiles;
+  List<Album>? cachedAlbums;
+  List<VaultFolder>? cachedFolders;
+  List<TagInfo>? cachedTags;
+  VaultSettings? cachedSettings;
+
+  /// Read-only secure-storage handle (used by services for the re-encrypt
+  /// journal, which lives outside the cached maps).
+  Future<String?> read(String key) => _storage.read(key: key);
+
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+
+  Future<void> delete(String key) => _storage.delete(key: key);
+
+  /// Ensure the vault directory (and its subdirs) exist.
+  Future<Directory> ensureVaultDirectory() async {
+    if (vaultDirectory != null && await vaultDirectory!.exists()) {
+      await _ensureNoMediaFile(vaultDirectory!.path);
+      return vaultDirectory!;
+    }
+
+    final appDir = await getApplicationDocumentsDirectory();
+    vaultDirectory = Directory('${appDir.path}/$vaultFolderName');
+
+    if (!await vaultDirectory!.exists()) {
+      await vaultDirectory!.create(recursive: true);
+    }
+
+    await Directory('${vaultDirectory!.path}/images').create(recursive: true);
+    await Directory('${vaultDirectory!.path}/videos').create(recursive: true);
+    await Directory('${vaultDirectory!.path}/songs').create(recursive: true);
+    await Directory('${vaultDirectory!.path}/documents')
+        .create(recursive: true);
+    await Directory('${vaultDirectory!.path}/thumbnails')
+        .create(recursive: true);
+    await Directory('${vaultDirectory!.path}/temp').create(recursive: true);
+
+    await _ensureNoMediaFile(vaultDirectory!.path);
+
+    return vaultDirectory!;
+  }
+
+  /// Ensure the decoy vault directory (and its subdirs) exist.
+  Future<Directory> ensureDecoyDirectory() async {
+    if (decoyDirectory != null && await decoyDirectory!.exists()) {
+      await _ensureNoMediaFile(decoyDirectory!.path);
+      return decoyDirectory!;
+    }
+
+    final appDir = await getApplicationDocumentsDirectory();
+    decoyDirectory = Directory('${appDir.path}/$decoyFolderName');
+
+    if (!await decoyDirectory!.exists()) {
+      await decoyDirectory!.create(recursive: true);
+    }
+
+    await Directory('${decoyDirectory!.path}/images').create(recursive: true);
+    await Directory('${decoyDirectory!.path}/videos').create(recursive: true);
+    await Directory('${decoyDirectory!.path}/songs').create(recursive: true);
+    await Directory('${decoyDirectory!.path}/documents')
+        .create(recursive: true);
+
+    await _ensureNoMediaFile(decoyDirectory!.path);
+
+    return decoyDirectory!;
+  }
+
+  Future<void> _ensureNoMediaFile(String directoryPath) async {
+    final noMediaFile = File('$directoryPath/.nomedia');
+    if (!await noMediaFile.exists()) {
+      await noMediaFile.create();
+    }
+  }
+
+  /// Get subdirectory path for file type.
+  String getSubdirectory(VaultedFileType type) {
+    switch (type) {
+      case VaultedFileType.image:
+        return 'images';
+      case VaultedFileType.video:
+        return 'videos';
+      case VaultedFileType.song:
+        return 'songs';
+      case VaultedFileType.document:
+      case VaultedFileType.other:
+        return 'documents';
+    }
+  }
+
+  // ---- Load / save primitive indexes ----
+
+  Future<List<VaultedFile>> loadFileIndex({
+    bool isDecoy = false,
+    bool forceReload = false,
+  }) async {
+    if (!forceReload && !isDecoy && cachedFiles != null) {
+      return cachedFiles!;
+    }
+    if (!forceReload && isDecoy && cachedDecoyFiles != null) {
+      return cachedDecoyFiles!;
+    }
+
+    try {
+      final key = isDecoy ? decoyIndexKey : vaultIndexKey;
+      final indexJson = await _storage.read(key: key);
+      if (indexJson == null || indexJson.isEmpty) {
+        if (isDecoy) {
+          cachedDecoyFiles = [];
+          return cachedDecoyFiles!;
+        }
+        cachedFiles = [];
+        return cachedFiles!;
+      }
+
+      final List<dynamic> jsonList = jsonDecode(indexJson);
+      final files = <VaultedFile>[];
+      for (int i = 0; i < jsonList.length; i++) {
+        try {
+          files.add(
+            VaultedFile.fromJson(jsonList[i] as Map<String, dynamic>),
+          );
+        } catch (e) {
+          debugPrint('Error parsing vault entry $i: $e');
+        }
+      }
+
+      if (files.length < jsonList.length) {
+        debugPrint(
+          'Vault index: recovered ${files.length}/${jsonList.length} entries',
+        );
+        await _storage.write(
+          key: key,
+          value: jsonEncode(files.map((f) => f.toJson()).toList()),
+        );
+      }
+
+      if (isDecoy) {
+        cachedDecoyFiles = files;
+        return cachedDecoyFiles!;
+      }
+      cachedFiles = files;
+      return cachedFiles!;
+    } catch (e) {
+      debugPrint('Error loading vault index: $e');
+      if (isDecoy) {
+        cachedDecoyFiles = [];
+        return cachedDecoyFiles!;
+      }
+      cachedFiles = [];
+      return cachedFiles!;
+    }
+  }
+
+  Future<void> saveFileIndex({bool isDecoy = false}) async {
+    try {
+      final files = isDecoy ? cachedDecoyFiles : cachedFiles;
+      final key = isDecoy ? decoyIndexKey : vaultIndexKey;
+      final jsonList = files?.map((file) => file.toJson()).toList() ?? [];
+
+      if (jsonList.isEmpty) {
+        final existing = await _storage.read(key: key);
+        if (existing != null && existing.isNotEmpty) {
+          final existingCount =
+              (jsonDecode(existing) as List<dynamic>).length;
+          if (existingCount > 0) {
+            debugPrint(
+              'WARNING: Attempted to save empty index over $existingCount existing entries. Aborting save.',
+            );
+            return;
+          }
+        }
+      }
+
+      await _storage.write(key: key, value: jsonEncode(jsonList));
+    } catch (e) {
+      debugPrint('Error saving vault index: $e');
+    }
+  }
+
+  Future<List<Album>> loadAlbums({bool forceReload = false}) async {
+    if (!forceReload && cachedAlbums != null) return cachedAlbums!;
+
+    try {
+      final albumsJson = await _storage.read(key: albumsKey);
+      if (albumsJson == null || albumsJson.isEmpty) {
+        cachedAlbums = createDefaultAlbums();
+        await saveAlbums();
+        return cachedAlbums!;
+      }
+
+      final List<dynamic> jsonList = jsonDecode(albumsJson);
+      cachedAlbums = jsonList
+          .map((json) => Album.fromJson(json as Map<String, dynamic>))
+          .toList();
+
+      return cachedAlbums!;
+    } catch (e) {
+      debugPrint('Error loading albums: $e');
+      cachedAlbums = createDefaultAlbums();
+      return cachedAlbums!;
+    }
+  }
+
+  List<Album> createDefaultAlbums() {
+    final now = DateTime.now();
+    return [
+      Album(
+        id: 'favorites',
+        name: 'Favorites',
+        createdAt: now,
+        updatedAt: now,
+        isDefault: true,
+        type: AlbumType.favorites,
+        sortOrder: 0,
+      ),
+      Album(
+        id: 'recent',
+        name: 'Recent',
+        createdAt: now,
+        updatedAt: now,
+        isDefault: true,
+        type: AlbumType.recent,
+        sortOrder: 1,
+      ),
+    ];
+  }
+
+  Future<void> saveAlbums() async {
+    try {
+      final jsonList = cachedAlbums?.map((a) => a.toJson()).toList() ?? [];
+      await _storage.write(key: albumsKey, value: jsonEncode(jsonList));
+    } catch (e) {
+      debugPrint('Error saving albums: $e');
+    }
+  }
+
+  Future<List<VaultFolder>> loadFolders({bool forceReload = false}) async {
+    if (!forceReload && cachedFolders != null) return cachedFolders!;
+
+    try {
+      final foldersJson = await _storage.read(key: foldersKey);
+      if (foldersJson == null || foldersJson.isEmpty) {
+        cachedFolders = [];
+        return cachedFolders!;
+      }
+
+      final List<dynamic> jsonList = jsonDecode(foldersJson);
+      cachedFolders = jsonList
+          .map((json) => VaultFolder.fromJson(json as Map<String, dynamic>))
+          .toList();
+
+      return cachedFolders!;
+    } catch (e) {
+      debugPrint('Error loading folders: $e');
+      cachedFolders = [];
+      return cachedFolders!;
+    }
+  }
+
+  Future<void> saveFolders() async {
+    try {
+      final jsonList = cachedFolders?.map((f) => f.toJson()).toList() ?? [];
+      await _storage.write(key: foldersKey, value: jsonEncode(jsonList));
+    } catch (e) {
+      debugPrint('Error saving folders: $e');
+    }
+  }
+
+  Future<List<TagInfo>> loadTags({bool forceReload = false}) async {
+    if (!forceReload && cachedTags != null) return cachedTags!;
+
+    try {
+      final tagsJson = await _storage.read(key: tagsKey);
+      if (tagsJson == null || tagsJson.isEmpty) {
+        cachedTags = [];
+        return cachedTags!;
+      }
+
+      final List<dynamic> jsonList = jsonDecode(tagsJson);
+      cachedTags = jsonList
+          .map((json) => TagInfo.fromJson(json as Map<String, dynamic>))
+          .toList();
+
+      return cachedTags!;
+    } catch (e) {
+      debugPrint('Error loading tags: $e');
+      cachedTags = [];
+      return cachedTags!;
+    }
+  }
+
+  Future<void> saveTags() async {
+    try {
+      final jsonList = cachedTags?.map((t) => t.toJson()).toList() ?? [];
+      await _storage.write(key: tagsKey, value: jsonEncode(jsonList));
+    } catch (e) {
+      debugPrint('Error saving tags: $e');
+    }
+  }
+
+  Future<VaultSettings> loadSettings() async {
+    if (cachedSettings != null) return cachedSettings!;
+
+    try {
+      final settingsJson = await _storage.read(key: settingsKey);
+      if (settingsJson == null || settingsJson.isEmpty) {
+        cachedSettings = const VaultSettings();
+        return cachedSettings!;
+      }
+
+      cachedSettings = VaultSettings.fromJson(
+        jsonDecode(settingsJson) as Map<String, dynamic>,
+      );
+      return cachedSettings!;
+    } catch (e) {
+      debugPrint('Error loading settings: $e');
+      cachedSettings = const VaultSettings();
+      return cachedSettings!;
+    }
+  }
+
+  Future<void> saveSettings() async {
+    try {
+      await _storage.write(
+        key: settingsKey,
+        value: jsonEncode(cachedSettings?.toJson() ?? {}),
+      );
+    } catch (e) {
+      debugPrint('Error saving settings: $e');
+    }
+  }
+
+  // ---- File-system helpers (stateless) ----
+
+  /// Stream copy a file in chunks (memory-efficient for large files).
+  Future<void> streamCopyFile(
+    File source,
+    File destination, {
+    Function(int processed, int total)? onProgress,
+  }) async {
+    final totalBytes = await source.length();
+    var processedBytes = 0;
+    final sink = destination.openWrite();
+
+    onProgress?.call(0, totalBytes);
+
+    await for (final chunk in source.openRead()) {
+      sink.add(chunk);
+      processedBytes += chunk.length;
+      onProgress?.call(processedBytes, totalBytes);
+    }
+
+    await sink.flush();
+    await sink.close();
+  }
+
+  Future<void> deleteFileIfExists(String path) async {
+    try {
+      final file = File(path);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (_) {}
+  }
+
+  Future<int> getFileSizeIfExists(String path) async {
+    try {
+      return await File(path).length();
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  /// Generate a unique encrypted filename.
+  String generateVaultFilename(String originalName) {
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final randomBytes = utf8.encode('$originalName$timestamp${DateTime.now()}');
+    final hash = sha256.convert(randomBytes).toString().substring(0, 16);
+
+    final extension =
+        originalName.contains('.') ? originalName.split('.').last : '';
+
+    return extension.isNotEmpty ? '$hash.$extension' : hash;
+  }
+
+  /// Reload every cache atomically (used by `refresh()` in VaultService).
+  Future<void> reloadAll() async {
+    final files = await loadFileIndex(forceReload: true);
+    final decoyFiles = await loadFileIndex(isDecoy: true, forceReload: true);
+    final albums = await loadAlbums(forceReload: true);
+    final folders = await loadFolders(forceReload: true);
+    final tags = await loadTags(forceReload: true);
+    cachedFiles = files;
+    cachedDecoyFiles = decoyFiles;
+    cachedAlbums = albums;
+    cachedFolders = folders;
+    cachedTags = tags;
+  }
+
+  /// Wipe caches + storage for a vault (used by `clearVault()` in VaultService).
+  Future<void> wipe({bool isDecoy = false}) async {
+    final appDir = await getApplicationDocumentsDirectory();
+    final directory = Directory(
+      '${appDir.path}/${isDecoy ? decoyFolderName : vaultFolderName}',
+    );
+
+    if (await directory.exists()) {
+      await directory.delete(recursive: true);
+    }
+
+    if (isDecoy) {
+      cachedDecoyFiles = [];
+      await _storage.delete(key: decoyIndexKey);
+      decoyDirectory = null;
+    } else {
+      cachedFiles = [];
+      cachedAlbums = null;
+      cachedFolders = null;
+      cachedTags = null;
+      await _storage.delete(key: vaultIndexKey);
+      await _storage.delete(key: albumsKey);
+      await _storage.delete(key: foldersKey);
+      await _storage.delete(key: tagsKey);
+      vaultDirectory = null;
+    }
+  }
+}

--- a/test/vault_service_test.dart
+++ b/test/vault_service_test.dart
@@ -1,0 +1,361 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/models/album.dart';
+import 'package:locker/models/vault_settings.dart';
+import 'package:locker/models/vaulted_file.dart';
+import 'package:locker/services/vault_service.dart';
+
+const _secureStorageChannel = 'plugins.it_nomads.com/flutter_secure_storage';
+const _pathProviderChannel = 'plugins.flutter.io/path_provider';
+
+Future<VaultService> _freshVault({
+  required Map<String, String> storage,
+  required Directory tmpDir,
+}) async {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    const MethodChannel(_secureStorageChannel),
+    (call) async {
+      final args = (call.arguments ?? {}) as Map;
+      final key = args['key'] as String?;
+      switch (call.method) {
+        case 'read':
+          return storage[key];
+        case 'write':
+          storage[key!] = args['value'] as String;
+          return null;
+        case 'delete':
+          storage.remove(key);
+          return null;
+        case 'deleteAll':
+          storage.clear();
+          return null;
+        case 'containsKey':
+          return storage.containsKey(key);
+        case 'readAll':
+          return storage;
+        default:
+          return null;
+      }
+    },
+  );
+
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    const MethodChannel(_pathProviderChannel),
+    (call) async {
+      if (call.method == 'getApplicationDocumentsDirectory') {
+        return tmpDir.path;
+      }
+      return null;
+    },
+  );
+
+  final vault = VaultService();
+  await vault.loadIndexesForTesting();
+  return vault;
+}
+
+VaultedFile _makeFile(String id, {bool isFavorite = false}) {
+  return VaultedFile(
+    id: id,
+    originalName: '$id.jpg',
+    vaultPath: '/tmp/$id.enc',
+    type: VaultedFileType.image,
+    mimeType: 'image/jpeg',
+    fileSize: 1024,
+    dateAdded: DateTime(2024, 1, 1),
+    dateModified: DateTime(2024, 1, 1),
+    isFavorite: isFavorite,
+  );
+}
+
+Future<void> _seedFiles(VaultService vault, List<VaultedFile> files) async {
+  for (final f in files) {
+    await vault.registerNoteEntry(
+      noteId: f.id,
+      title: f.id,
+      encryptedContentPath: f.vaultPath,
+      isEncrypted: false,
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Map<String, String> storage;
+  late Directory tmpDir;
+
+  setUp(() async {
+    storage = {};
+    tmpDir = await Directory.systemTemp.createTemp('latch_vault_test');
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel(_secureStorageChannel),
+      null,
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel(_pathProviderChannel),
+      null,
+    );
+    try {
+      await tmpDir.delete(recursive: true);
+    } catch (_) {}
+  });
+
+  group('settings', () {
+    test('default settings have failedUnlockProtectionEnabled=true', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      final s = await vault.getSettings();
+      expect(s.failedUnlockProtectionEnabled, true);
+    });
+
+    test('updateSettings persists and survives reload', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await vault.updateSettings(
+        const VaultSettings().copyWith(
+          encryptionEnabled: true,
+          kdfIterations: 100000,
+          compressionEnabled: true,
+        ),
+      );
+
+      final vault2 = await _freshVault(storage: storage, tmpDir: tmpDir);
+      final s = await vault2.getSettings();
+      expect(s.encryptionEnabled, true);
+      expect(s.kdfIterations, 100000);
+      expect(s.compressionEnabled, true);
+    });
+
+    test('fromJson preserves explicit false for failedUnlockProtectionEnabled',
+        () async {
+      storage['vault_settings'] =
+          jsonEncode(const VaultSettings(failedUnlockProtectionEnabled: false)
+              .toJson());
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      final s = await vault.getSettings();
+      expect(s.failedUnlockProtectionEnabled, false);
+    });
+  });
+
+  group('albums + file cross-mutation', () {
+    test('addFilesToAlbum updates both album.fileIds and file.albumIds',
+        () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1'), _makeFile('f2')]);
+      final album = await vault.createAlbum(name: 'Holiday');
+      expect(album, isNotNull);
+
+      final ok = await vault.addFilesToAlbum(['f1', 'f2'], album!.id);
+      expect(ok, true);
+
+      final files = await vault.getAllFiles();
+      expect(files.firstWhere((f) => f.id == 'f1').albumIds, contains(album.id));
+      expect(files.firstWhere((f) => f.id == 'f2').albumIds, contains(album.id));
+
+      final reloaded = await vault.getAlbumById(album.id);
+      expect(reloaded!.fileIds, containsAll(['f1', 'f2']));
+    });
+
+    test('deleteAlbum clears albumId from associated files', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1'), _makeFile('f2')]);
+      final album = await vault.createAlbum(name: 'Trip');
+
+      await vault.addFilesToAlbum(['f1', 'f2'], album!.id);
+      await vault.deleteAlbum(album.id);
+
+      final files = await vault.getAllFiles();
+      for (final f in files) {
+        expect(f.albumIds, isNot(contains(album.id)));
+      }
+      expect(await vault.getAlbumById(album.id), isNull);
+    });
+
+    test('removeFilesFromAlbum clears file.albumIds', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1'), _makeFile('f2')]);
+      final album = await vault.createAlbum(name: 'Work');
+
+      await vault.addFilesToAlbum(['f1', 'f2'], album!.id);
+      await vault.removeFilesFromAlbum(['f1'], album.id);
+
+      final files = await vault.getAllFiles();
+      expect(
+          files.firstWhere((f) => f.id == 'f1').albumIds, isNot(contains(album.id)));
+      expect(files.firstWhere((f) => f.id == 'f2').albumIds, contains(album.id));
+    });
+
+    test('favorites album sets isFavorite on file', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1')]);
+
+      await vault.addFilesToAlbum(['f1'], 'favorites');
+
+      final files = await vault.getAllFiles();
+      expect(files.firstWhere((f) => f.id == 'f1').isFavorite, true);
+    });
+  });
+
+  group('folders', () {
+    test('createFolder + addFileToFolder sets file.folderId', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1')]);
+      final folder = await vault.createFolder(name: 'Docs');
+      expect(folder, isNotNull);
+
+      final ok = await vault.addFileToFolder('f1', folder!.id);
+      expect(ok, true);
+
+      final files = await vault.getAllFiles();
+      expect(files.firstWhere((f) => f.id == 'f1').folderId, folder.id);
+    });
+
+    test('deleteFolder clears folderId from files', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1')]);
+      final folder = await vault.createFolder(name: 'Temp');
+      await vault.addFileToFolder('f1', folder!.id);
+
+      await vault.deleteFolder(folder.id);
+
+      final files = await vault.getAllFiles();
+      expect(files.firstWhere((f) => f.id == 'f1').folderId, isNull);
+    });
+  });
+
+  group('tags', () {
+    test('addTagToFile updates file.tags and tag index', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1')]);
+
+      await vault.addTagToFile('f1', 'beach');
+
+      final files = await vault.getAllFiles();
+      expect(files.firstWhere((f) => f.id == 'f1').tags, contains('beach'));
+
+      final tags = await vault.getAllTags();
+      expect(tags.any((t) => t.name == 'beach'), true);
+    });
+
+    test('removeTagFromFile removes from file.tags', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1')]);
+      await vault.addTagToFile('f1', 'beach');
+      await vault.addTagToFile('f1', 'sunset');
+
+      await vault.removeTagFromFile('f1', 'beach');
+
+      final files = await vault.getAllFiles();
+      final tags = files.firstWhere((f) => f.id == 'f1').tags;
+      expect(tags, isNot(contains('beach')));
+      expect(tags, contains('sunset'));
+    });
+  });
+
+  group('favorites', () {
+    test('toggleFavorite flips isFavorite', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1')]);
+
+      await vault.toggleFavorite('f1');
+      expect(
+          (await vault.getAllFiles()).firstWhere((f) => f.id == 'f1').isFavorite,
+          true);
+
+      await vault.toggleFavorite('f1');
+      expect(
+          (await vault.getAllFiles()).firstWhere((f) => f.id == 'f1').isFavorite,
+          false);
+    });
+
+    test('getFavoriteFiles returns only favorites', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1'), _makeFile('f2')]);
+      await vault.toggleFavorite('f1');
+
+      final favs = await vault.getFavoriteFiles();
+      expect(favs.length, 1);
+      expect(favs.first.id, 'f1');
+    });
+  });
+
+  group('search', () {
+    test('searchFilesAdvanced filters by name query', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('beach'), _makeFile('mountain')]);
+
+      final results = await vault.searchFilesAdvanced(query: 'beach');
+      expect(results.length, 1);
+      expect(results.first.id, 'beach');
+    });
+
+    test('searchFilesAdvanced filters by tag', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1'), _makeFile('f2')]);
+      await vault.addTagToFile('f1', 'nature');
+
+      final results = await vault.searchFilesAdvanced(tags: ['nature']);
+      expect(results.length, 1);
+      expect(results.first.id, 'f1');
+    });
+  });
+
+  group('sort', () {
+    test('sortFiles by name ascending', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      final files = [_makeFile('zebra'), _makeFile('apple'), _makeFile('mango')];
+      final sorted = vault.sortFiles(files, SortOption.nameAsc);
+      expect(sorted.map((f) => f.id).toList(), ['apple', 'mango', 'zebra']);
+    });
+
+    test('sortFiles by date newest first', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      final old = _makeFile('old').copyWith(dateAdded: DateTime(2020));
+      final recent = _makeFile('new').copyWith(dateAdded: DateTime(2024, 6));
+      final sorted = vault.sortFiles([old, recent], SortOption.dateAddedNewest);
+      expect(sorted.first.id, 'new');
+    });
+  });
+
+  group('stats', () {
+    test('getFileCounts counts by type', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1'), _makeFile('f2')]);
+
+      final counts = await vault.getFileCounts();
+      expect(counts[VaultedFileType.document], 2);
+    });
+
+    test('getTotalStorageUsed sums file sizes', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1'), _makeFile('f2')]);
+
+      final total = await vault.getTotalStorageUsed();
+      expect(total, 0);
+    });
+  });
+
+  group('clearVault', () {
+    test('clears file index and albums from storage', () async {
+      final vault = await _freshVault(storage: storage, tmpDir: tmpDir);
+      await _seedFiles(vault, [_makeFile('f1'), _makeFile('f2')]);
+      await vault.createAlbum(name: 'Trip');
+      expect(storage['vault_file_index'], isNotNull);
+      expect(storage['vault_albums'], isNotNull);
+
+      await vault.clearVault();
+
+      expect(storage['vault_file_index'], isNull);
+      expect(storage['vault_albums'], isNull);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

Refactors `VaultService` into a facade over multiple domain-specific services (Album, File, Folder, Search, Settings, Stats, Tag, VaultStore) for improved modularity. Adds encrypted thumbnail service with caching, migrate office document conversion to isolate, and adds comprehensive tests.

# Changes

## Architecture

- Refactor `VaultService` into a facade over split domain services
- Add `VaultStore` as centralized state and persistence layer
- Add `VaultSettings` model for configuring vault behavior
- Add refactoring roadmap document

## Domain Services

- Add `AlbumService` for CRUD and file-album management
- Add file service with full vault operations
- Add folder service with CRUD and device import operations
- Add search service with basic and advanced file querying
- Add `SettingsService` with get/update methods
- Add `StatsService` for read-only file analytics
- Add `TagService` for tag CRUD and favorite toggling

## Encrypted Thumbnails

- Add encrypted thumbnail service with caching and lazy regeneration

## Import Flow

- Add per-file progress callback to import service
- Replace `setState` with progress sheet bottom modal for import flow
- Add helper classes for batch file import

## Document Conversion

- Move office document conversion to isolate
- Add font caching

## PDF Viewer

- Add clamping scroll physics to PDF viewer widgets
- Add scroll thumb overlay to PDF document viewer

## Testing

- Add comprehensive unit tests for `VaultService`

## Other

- Replace `vaultServiceProvider` usage with `VaultService.instance`
- Refactor `cleanupTemp` to use `VaultService` singleton
- Refactor encryption settings to use vault settings provider
- Add missing imports and improve async image compression