### PR TITLE
Add encrypted-at-rest sync service with remote manifest and reconciliation

### DIFF
--- a/docs/local_server_sync.md
+++ b/docs/local_server_sync.md
@@ -1,0 +1,332 @@
+# Local Server / Local Cloud Sync — Plan
+
+Born from the request to add a self-hosted sync target (NAS, home server, or
+self-hosted cloud) to Latch. Today the vault is device-local with a manual
+*decrypted* ZIP backup (`BackupService`). This plan defines an
+**encrypted-at-rest** sync to a server on the LAN or internet.
+
+Status: **PLANNING** — no code yet. Locked decisions are marked **[LOCKED]**;
+open ones are marked **[OPEN]** and listed again at the bottom.
+
+---
+
+## Goals
+
+- Push the vault to a user-chosen server (NAS / home server / self-hosted cloud)
+  and pull it back on a new device or after a wipe.
+- The server **never** sees plaintext. It is dumb encrypted blob storage.
+- Manual sync first; optional scheduled/background sync later.
+- Reuse the existing encrypted file format and key model — **no new crypto**.
+
+## Non-goals (YAGNI)
+
+- Real-time collaborative sync / CRDT. (Last-write-wins per file is enough.)
+- A Latch-hosted cloud account. (This is *local* / self-hosted only.)
+- Syncing to multiple servers simultaneously. (One remote per vault, for now.)
+- Streaming media playback *from* the server. (Sync, not remote mount.)
+
+---
+
+## Locked decisions
+
+1. **[LOCKED] End-to-end encrypted on the server.** Files already live in the
+   vault as `[magic][IV][ciphertext][auth tag]`. We sync those exact encrypted
+   blobs. The manifest (index + metadata) is encrypted with the vault master
+   key before upload. The server sees opaque bytes only. This is the opposite
+   of the current `BackupService`, which builds a **decrypted** ZIP — that
+   behavior must **not** be carried over to the server path.
+
+2. **[LOCKED] WebDAV is the only protocol in v1.** It is plain HTTP, every
+   NAS / Nextcloud / Synology / ownCloud / Seafile exposes it, and it needs
+   one package. SMB and SFTP are deferred (see "Protocol choice").
+
+3. **[LOCKED] Server is dumb blob storage.** A thin sync client in the app
+   does all the logic. No server-side app to build or ship.
+
+4. **[LOCKED] Reuse `connectivity_plus`** (already a dep, used in
+   `update_service.dart`) for the "only on Wi-Fi / only when connected"
+   guard. No new network-detection code.
+
+5. **[LOCKED] Sync service lands as Riverpod-native**, not a new singleton.
+   Per the refactor roadmap, Phase 4 (Riverpod modernization, drops the 12
+   `instance` singletons) is pending. This service should land **after** (or
+   alongside) Phase 4 so we don't add a 13th singleton we then have to remove.
+   It takes `VaultStore` + `EncryptionService` via constructor, like the
+   Phase 2 services.
+
+---
+
+## Threat model & security
+
+This is the part that matters most for a vault.
+
+| Asset | Where | Exposure if server is compromised |
+|---|---|---|
+| Media ciphertext | Server | **Safe.** AES-256-GCM/CTR, per-file key derived via PBKDF2 from the master key. Server sees blobs only. |
+| Manifest (index + names + tags + albums + folders) | Server (encrypted) | **Safe if** encrypted with master key before upload. **Critical:** never upload the raw `vault_file_index` JSON. |
+| Server credentials (URL, user, app password) | `flutter_secure_storage` → Android Keystore | Safe (same path as the PIN/master-key wrap). |
+| Thumbnails | **Local only** v1 | Re-derivable on pull from the decrypted blob. Not synced. |
+
+Hard rules:
+
+- **Plaintext never crosses the network.** No "decrypted ZIP to server" path.
+  (Contrast: `BackupService` today decrypts to a ZIP — keep that for the
+  *local export* feature only; it must not be reused as the sync transport.)
+- **The manifest is encrypted** with the vault master key (the same one
+  wrapped by Argon2id on-device). The server holds `manifest.enc`.
+- **Credentials in `flutter_secure_storage`, never in `VaultSettings` JSON**
+  (which is itself stored in secure storage but should stay settings, not
+  secrets).
+- **TLS by default**, but WebDAV over plain HTTP on the LAN must be
+  explicitly allowed (self-hosted, self-signed certs, `.local` hostnames).
+  Present a clear "unencrypted connection" warning, do not silently downgrade.
+- **No implicit trust of server state.** Pull must verify GCM auth tags on
+  every blob before trusting it (corruption / tampering detection we already
+  have for re-encryption).
+- **Decoy vault is out of scope for v1 sync.** Syncing the decoy would leak
+  its existence and double the surface. Main vault only. Revisit later.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                          UI                                   │
+│   Sync Settings screen · Sync Status chip · Sync Now button  │
+└──────────────────────────┬────────────────────────────────────┘
+                           │ Riverpod
+┌──────────────────────────▼────────────────────────────────────┐
+│                    SyncProvider (Notifier)                     │
+│   exposes status (idle/uploading/downloading/error) + lastSync │
+└──────────────────────────┬────────────────────────────────────┘
+                           │
+┌──────────────────────────▼────────────────────────────────────┐
+│                      SyncService                               │
+│  reconcile(): diff local vs remote manifest → plan → execute   │
+│  • push encrypted blobs (new/changed local)                    │
+│  • pull encrypted blobs (new/changed remote)                   │
+│  • tombstone deletes                                           │
+│  • write encrypted manifest last (commit point)                │
+└──────┬───────────────────────┬─────────────────────────────────┘
+       │                       │
+       ▼                       ▼
+┌──────────────┐      ┌────────────────────┐
+│ VaultStore   │      │ RemoteStore        │
+│ (exists)     │      │ (WebDAV transport) │
+│ local files, │      │ getManifest /      │
+│ local index  │      │ putManifest /      │
+│              │      │ getBlob / putBlob /│
+│              │      │ deleteBlob /       │
+│              │      │ listRemote         │
+└──────────────┘      └─────────┬──────────┘
+                                │ HTTP
+                         ┌──────▼──────┐
+                         │ WebDAV server│
+                         │ (NAS/cloud)  │
+                         └──────────────┘
+```
+
+`SyncService` is the brain; `RemoteStore` is a thin transport abstraction
+(one interface, one WebDAV impl). The interface exists so SFTP/SMB can be
+added later behind the same `SyncService` — but only one impl ships now.
+
+### Server layout (what the user's NAS holds)
+
+```
+/latch/
+  manifest.enc            # encrypted index + metadata + tombstones
+  blobs/
+    ab/cd/abcd1234…enc    # content-addressed encrypted media (sha256 of ciphertext)
+    ef/01/ef019876…enc
+  manifest.enc.sig        # [OPEN] GCM tag already authenticates; separate sig = YAGNI for v1
+```
+
+Content-addressing the blobs by hash of the **ciphertext** gives us:
+dedupe (identical ciphertext across devices), easy diff (manifest lists
+hashes, not paths), and trivial rename/move (metadata-only change, blob
+unchanged). This is the same trick every content-addressed backup uses.
+
+---
+
+## Protocol choice
+
+| Protocol | Verdict | Why |
+|---|---|---|
+| **WebDAV** | **v1** | HTTP. Every NAS/cloud speaks it. One package. `MKCOL`/`PUT`/`GET`/`DELETE`/`PROPFIND` is the whole API. |
+| SFTP | Deferred | Needs a heavy SSH client package (`dartssh2`); adds key management. Add only if asked. |
+| SMB | Deferred | jCIFS port on Android is fragile. Not worth it. |
+| Custom HTTP server | Rejected | Violates locked decision #3 (server stays dumb). |
+
+Dependency: **`webdav_client`** (pub.dev). One package. Falls back to raw
+`package:http` + `PROPFIND` if its API is awkward, but try the package first.
+
+---
+
+## Sync model
+
+**Last-write-wins per file, manifest-as-commit-point.**
+
+- Each `VaultedFile` already has a UUID `id` and we can add a `modifiedAt`
+  / `syncRev` field (see data changes). The manifest maps `id → {hash,
+  modifiedAt, deleted}`.
+- **Reconcile** = compare local manifest vs remote manifest by id:
+  - remote has id, local doesn't, not tombstoned → **pull**
+  - local has id, remote doesn't → **push**
+  - both have it, hashes differ → newer `modifiedAt` wins; loser is
+    overwritten. (No three-way merge v1 — YAGNI. Flag a conflict note in UI
+    if both changed since last sync.)
+  - either side tombstoned (deleted) → propagate delete.
+- **Manifest is the commit point.** Upload/download all blobs first; the
+  manifest write is atomic-ish (PUT replaces the whole file). If we crash
+  mid-sync, the old manifest still describes a consistent older state and
+  the next run resumes. Re-running sync is always safe (idempotent).
+- **No partial-file sync.** Files are atomic units. A video is fully
+  re-pushed on change (it's encrypted; no delta possible anyway).
+
+Direction control (setting):
+- **Push only** (backup to server) — simplest, recommended default.
+- **Two-way** (sync) — enable after push-only is proven.
+
+---
+
+## Data & config changes
+
+- **New model:** `SyncProfile` (URL, username, base path, lastSyncAt,
+  syncDirection, wifiOnly) — stored in `flutter_secure_storage` as JSON.
+  Not in `VaultSettings` (keeps settings free of secrets).
+- **`VaultSettings` additions:** `bool syncEnabled = false`,
+  `String? syncProfileId`. (Small additions to the existing
+  `toJson`/`fromJson`/`copyWith` — follows the existing field pattern.)
+- **`VaultedFile` additions:** `DateTime? modifiedAt`, `String? remoteHash`,
+  `bool syncedDeleted = false` (tombstone flag). Migration on load: missing
+  `modifiedAt` → default to file mtime.
+- **New:** `RemoteManifest` model (the decrypted manifest schema: version,
+  device id, files map, tombstones, generatedAt).
+
+---
+
+## Phased plan
+
+Phases are ordered by dependency. Each is independently shippable.
+
+### Phase S0 — Transport + creds (no sync logic) — ~1-2 days
+
+| # | Task | Location |
+|---|---|---|
+| S0.1 | Add `webdav_client` dep | `pubspec.yaml` |
+| S0.2 | `RemoteStore` interface + WebDAV impl: `ping`, `getManifest`, `putManifest`, `getBlob`, `putBlob`, `deleteBlob`, `listBlobs` | `lib/services/remote/` (new) |
+| S0.3 | `SyncProfile` model + secure-storage CRUD | `lib/models/sync_profile.dart`, new `SyncProfileService` |
+| S0.4 | Connection settings UI: URL/user/password, "Test connection" button, TLS warning for plain HTTP | `lib/screens/sync_settings_screen.dart` (new) |
+| S0.5 | One runnable self-check: connect to a WebDAV URL, put/get a tiny blob, assert roundtrip | test or `__main__`-style check |
+
+**Verify:** connect to a real WebDAV server (Nextcloud demo or local
+`rclone serve webdav`), roundtrip a blob. Credentials persist across restart.
+
+### Phase S1 — Encrypted manifest — ~1-2 days
+
+| # | Task | Location |
+|---|---|---|
+| S1.1 | `RemoteManifest` model + JSON (de)serialize | `lib/models/remote_manifest.dart` |
+| S1.2 | Build manifest from `VaultStore` index; encrypt with master key; decrypt on read | `SyncService.buildManifest` / `readManifest` |
+| S1.3 | Content-address blob naming (sha256 of ciphertext, sharded `ab/cd/`) | `SyncService.blobNameFor` |
+| S1.4 | Push/pull manifest only (no blobs yet) — proves the crypto + transport glue | extends S0 |
+
+**Verify:** upload encrypted manifest, wipe local, pull manifest back,
+decrypt, assert it equals the original index. Plaintext never leaves device
+(confirmed by inspecting server).
+
+### Phase S2 — Push-only backup — ~2-3 days
+
+| # | Task | Location |
+|---|---|---|
+| S2.1 | `reconcile()` diff engine (local vs remote manifest) → plan (push/pull/delete lists) | `SyncService.reconcile` |
+| S2.2 | Execute push plan: upload new/changed blobs, then commit manifest | `SyncService.runSync` |
+| S2.3 | `SyncProvider` (Riverpod Notifier): status enum, progress, `syncNow()` | `lib/providers/sync_provider.dart` |
+| S2.4 | `connectivity_plus` guard: respect wifiOnly / connected; resubscribe like `update_service.dart:74` | `SyncService` / provider |
+| S2.5 | UI: status chip + "Sync now" in settings; progress reporting | sync settings screen + a drawer entry |
+| S2.6 | One behavioral test: seed vault, sync, assert every local file has a remote blob + manifest lists it | `test/sync_service_test.dart` |
+
+**Verify:** fill vault, push to server, inspect server (all opaque `.enc`),
+wipe app data, reinstall → pull restores the vault intact (decrypt +
+auth-tag verify per file).
+
+### Phase S3 — Two-way sync — ~2-3 days
+
+| # | Task | Location |
+|---|---|---|
+| S3.1 | Pull path: download missing/changed blobs, verify GCM auth tag, import into `VaultStore` | `SyncService` pull branch |
+| S3.2 | Last-write-wins resolution + conflict UI note when both sides changed | `reconcile` |
+| S3.3 | Tombstone propagation (delete on one device → delete on other, with a confirmation) | `reconcile` + UI |
+| S3.4 | Two-device roundtrip test | manual + scripted |
+
+**Verify:** device A adds files → sync → device B pulls them; device B
+edits → sync → device A sees edit; delete on A → propagates to B.
+
+### Phase S4 — Polish / scheduling (optional) — defer
+
+Background sync via WorkManager, conflict-resolution UX, per-album sync
+filters, restore-from-server onboarding flow. Ship S3 first; only build S4
+if the feature gets used.
+
+---
+
+## New files
+
+```
+lib/models/sync_profile.dart            sync profile (creds live in secure storage)
+lib/models/remote_manifest.dart         encrypted manifest schema
+lib/services/remote/remote_store.dart   transport interface
+lib/services/remote/webdav_store.dart   WebDAV impl
+lib/services/sync_profile_service.dart  secure-storage CRUD for profiles
+lib/services/sync_service.dart          reconcile + runSync
+lib/providers/sync_provider.dart        Riverpod status Notifier
+lib/screens/sync_settings_screen.dart   connection + sync UI
+test/sync_service_test.dart             behavioral net (one happy path per phase)
+```
+
+## Files changed
+
+```
+pubspec.yaml                              + webdav_client
+lib/models/vault_settings.dart            + syncEnabled, syncProfileId
+lib/models/vaulted_file.dart              + modifiedAt, remoteHash, syncedDeleted
+lib/services/vault_store.dart             manifest build/read helpers, blob hashing
+lib/providers/vault_providers.dart        wire SyncProvider after Phase 4 lands
+main.dart / drawer                        entry point to sync settings
+```
+
+---
+
+## Dependencies
+
+- **Add:** `webdav_client` (one package).
+- **Reuse:** `connectivity_plus` (already present), `flutter_secure_storage`
+  (already present), existing `lib/crypto/` (no new crypto code).
+
+## Verification discipline
+
+Per the refactor roadmap's test rules: no per-method suites, one happy-path
+test per phase, one failure path for anything security-touching. Each phase
+leaves one runnable check (assert-based `__main__` or a `test_*.dart`) that
+fails if the phase's logic breaks. Manual two-device roundtrip is the real
+acceptance test for S3.
+
+---
+
+## Open questions (need your call)
+
+1. **[OPEN] Protocol scope:** WebDAV-only for v1 (this plan), or do you want
+   SFTP in scope too? WebDAV covers ~all NAS/cloud cases; SFTP roughly
+   doubles the transport work.
+2. **[OPEN] Push-only first vs. two-way from day one:** this plan ships
+   push-only (Phase S2) before two-way (S3). OK with that staging, or do you
+   want two-way as the first deliverable?
+3. **[OPEN] Decoy vault sync:** explicitly excluded in v1 (security). Confirm
+   you're fine leaving the decoy device-local.
+4. **[OPEN] Self-hosted only, or allow a public WebDAV provider too** (e.g.,
+   a paid WebDAV host)? Technically identical; just a policy / wording call
+   for the settings screen.
+5. **[OPEN] Timing vs. refactor Phase 4:** this plan assumes sync lands
+   Riverpod-native (after Phase 4). If you want it sooner, it'll ship as a
+   singleton and get migrated in Phase 4 — slightly more churn.

--- a/lib/models/remote_manifest.dart
+++ b/lib/models/remote_manifest.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+
+/// One entry in the remote manifest. Describes the synced state of a single
+/// vault file. [contentHash] is the sha256-hex of the ciphertext blob (used to
+/// derive its content-addressed name); null for tombstones that never uploaded.
+class ManifestEntry {
+  final String id;
+  final String? contentHash;
+  final DateTime modifiedAt;
+  final bool deleted;
+
+  const ManifestEntry({
+    required this.id,
+    this.contentHash,
+    required this.modifiedAt,
+    this.deleted = false,
+  });
+
+  ManifestEntry copyWith({
+    String? id,
+    String? contentHash,
+    DateTime? modifiedAt,
+    bool? deleted,
+  }) {
+    return ManifestEntry(
+      id: id ?? this.id,
+      contentHash: contentHash ?? this.contentHash,
+      modifiedAt: modifiedAt ?? this.modifiedAt,
+      deleted: deleted ?? this.deleted,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'contentHash': contentHash,
+        'modifiedAt': modifiedAt.toIso8601String(),
+        'deleted': deleted,
+      };
+
+  factory ManifestEntry.fromJson(Map<String, dynamic> json) {
+    return ManifestEntry(
+      id: json['id'] as String,
+      contentHash: json['contentHash'] as String?,
+      modifiedAt: DateTime.parse(json['modifiedAt'] as String),
+      deleted: json['deleted'] as bool? ?? false,
+    );
+  }
+}
+
+/// The encrypted-at-rest manifest. Serialized to JSON, then GCM-encrypted with
+/// the vault master key before it ever touches the server. The server only ever
+/// sees opaque bytes (see SyncService.encryptManifest).
+class RemoteManifest {
+  final int version;
+  final String deviceId;
+  final DateTime generatedAt;
+  final List<ManifestEntry> entries;
+
+  const RemoteManifest({
+    this.version = 1,
+    required this.deviceId,
+    required this.generatedAt,
+    this.entries = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'version': version,
+        'deviceId': deviceId,
+        'generatedAt': generatedAt.toIso8601String(),
+        'entries': entries.map((e) => e.toJson()).toList(),
+      };
+
+  factory RemoteManifest.fromJson(Map<String, dynamic> json) {
+    return RemoteManifest(
+      version: json['version'] as int? ?? 1,
+      deviceId: json['deviceId'] as String,
+      generatedAt: DateTime.parse(json['generatedAt'] as String),
+      entries: (json['entries'] as List<dynamic>?)
+              ?.map((e) => ManifestEntry.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+    );
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+
+  factory RemoteManifest.fromJsonString(String jsonString) =>
+      RemoteManifest.fromJson(jsonDecode(jsonString) as Map<String, dynamic>);
+}

--- a/lib/models/sync_profile.dart
+++ b/lib/models/sync_profile.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+/// Sync direction for a profile.
+enum SyncDirection {
+  pushOnly,
+  twoWay;
+
+  static SyncDirection fromName(String? name) =>
+      SyncDirection.values.firstWhere(
+        (d) => d.name == name,
+        orElse: () => SyncDirection.pushOnly,
+      );
+}
+
+/// Connection profile for a remote sync target. The server password is NOT
+/// stored here — it lives in flutter_secure_storage under [passwordStorageKey],
+/// keyed by profile id, so this model stays safe to persist alongside settings.
+class SyncProfile {
+  final String id;
+  final String serverUrl;
+  final String? username;
+  final String basePath;
+  final SyncDirection direction;
+  final bool wifiOnly;
+  final bool enabled;
+  final DateTime? lastSyncedAt;
+
+  /// Secure-storage key for this profile's password.
+  String get passwordStorageKey => 'sync_profile_pw_$id';
+
+  const SyncProfile({
+    required this.id,
+    required this.serverUrl,
+    this.username,
+    this.basePath = '/locker',
+    this.direction = SyncDirection.pushOnly,
+    this.wifiOnly = true,
+    this.enabled = true,
+    this.lastSyncedAt,
+  });
+
+  SyncProfile copyWith({
+    String? id,
+    String? serverUrl,
+    String? username,
+    String? basePath,
+    SyncDirection? direction,
+    bool? wifiOnly,
+    bool? enabled,
+    DateTime? lastSyncedAt,
+  }) {
+    return SyncProfile(
+      id: id ?? this.id,
+      serverUrl: serverUrl ?? this.serverUrl,
+      username: username ?? this.username,
+      basePath: basePath ?? this.basePath,
+      direction: direction ?? this.direction,
+      wifiOnly: wifiOnly ?? this.wifiOnly,
+      enabled: enabled ?? this.enabled,
+      lastSyncedAt: lastSyncedAt ?? this.lastSyncedAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'serverUrl': serverUrl,
+        'username': username,
+        'basePath': basePath,
+        'direction': direction.name,
+        'wifiOnly': wifiOnly,
+        'enabled': enabled,
+        'lastSyncedAt': lastSyncedAt?.toIso8601String(),
+      };
+
+  factory SyncProfile.fromJson(Map<String, dynamic> json) {
+    return SyncProfile(
+      id: json['id'] as String,
+      serverUrl: json['serverUrl'] as String,
+      username: json['username'] as String?,
+      basePath: json['basePath'] as String? ?? '/locker',
+      direction: SyncDirection.fromName(json['direction'] as String?),
+      wifiOnly: json['wifiOnly'] as bool? ?? true,
+      enabled: json['enabled'] as bool? ?? true,
+      lastSyncedAt: json['lastSyncedAt'] != null
+          ? DateTime.parse(json['lastSyncedAt'] as String)
+          : null,
+    );
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+
+  factory SyncProfile.fromJsonString(String jsonString) =>
+      SyncProfile.fromJson(jsonDecode(jsonString) as Map<String, dynamic>);
+}

--- a/lib/models/vault_settings.dart
+++ b/lib/models/vault_settings.dart
@@ -23,6 +23,10 @@ class VaultSettings {
   final int maxFailedAttemptsBeforeWipe;
   final bool showPermissionWarning;
 
+  // Encrypted-at-rest sync (see docs/local_server_sync.md)
+  final bool syncEnabled;
+  final String? syncProfileId;
+
   const VaultSettings({
     this.encryptionEnabled = false,
     this.encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
@@ -43,6 +47,8 @@ class VaultSettings {
     this.wipeVaultOnMaxFailedAttempts = false,
     this.maxFailedAttemptsBeforeWipe = 12,
     this.showPermissionWarning = true,
+    this.syncEnabled = false,
+    this.syncProfileId,
   });
 
   VaultSettings copyWith({
@@ -65,6 +71,8 @@ class VaultSettings {
     bool? wipeVaultOnMaxFailedAttempts,
     int? maxFailedAttemptsBeforeWipe,
     bool? showPermissionWarning,
+    bool? syncEnabled,
+    String? syncProfileId,
   }) {
     return VaultSettings(
       encryptionEnabled: encryptionEnabled ?? this.encryptionEnabled,
@@ -93,6 +101,8 @@ class VaultSettings {
           maxFailedAttemptsBeforeWipe ?? this.maxFailedAttemptsBeforeWipe,
       showPermissionWarning:
           showPermissionWarning ?? this.showPermissionWarning,
+      syncEnabled: syncEnabled ?? this.syncEnabled,
+      syncProfileId: syncProfileId ?? this.syncProfileId,
     );
   }
 
@@ -116,6 +126,8 @@ class VaultSettings {
         'wipeVaultOnMaxFailedAttempts': wipeVaultOnMaxFailedAttempts,
         'maxFailedAttemptsBeforeWipe': maxFailedAttemptsBeforeWipe,
         'showPermissionWarning': showPermissionWarning,
+        'syncEnabled': syncEnabled,
+        'syncProfileId': syncProfileId,
       };
 
   factory VaultSettings.fromJson(Map<String, dynamic> json) {
@@ -151,6 +163,8 @@ class VaultSettings {
           json['maxFailedAttemptsBeforeWipe'] as int? ?? 12,
       showPermissionWarning:
           json['showPermissionWarning'] as bool? ?? true,
+      syncEnabled: json['syncEnabled'] as bool? ?? false,
+      syncProfileId: json['syncProfileId'] as String?,
     );
   }
 }

--- a/lib/models/vaulted_file.dart
+++ b/lib/models/vaulted_file.dart
@@ -86,6 +86,14 @@ class VaultedFile {
   final String? folderId; // Folder this file belongs to
   final bool needsMigration; // Legacy GCM v1 files need re-encryption to v2
 
+  // Sync bookkeeping (encrypted-at-rest sync, see docs/local_server_sync.md).
+  // ponytail: modifiedAt is a dedicated LWW timestamp, kept separate from
+  // dateModified so sync never clobbers existing mutation semantics.
+  // remoteHash is the sha256-hex of the uploaded ciphertext blob.
+  final DateTime? modifiedAt;
+  final String? remoteHash;
+  final bool syncedDeleted;
+
   const VaultedFile({
     required this.id,
     required this.originalName,
@@ -113,6 +121,9 @@ class VaultedFile {
     this.albumIds = const [],
     this.folderId,
     this.needsMigration = false,
+    this.modifiedAt,
+    this.remoteHash,
+    this.syncedDeleted = false,
   });
 
   /// Create a copy with updated fields
@@ -143,6 +154,9 @@ class VaultedFile {
     List<String>? albumIds,
     String? folderId,
     bool? needsMigration,
+    DateTime? modifiedAt,
+    String? remoteHash,
+    bool? syncedDeleted,
   }) {
     return VaultedFile(
       id: id ?? this.id,
@@ -171,6 +185,9 @@ class VaultedFile {
       albumIds: albumIds ?? List.from(this.albumIds),
       folderId: folderId ?? this.folderId,
       needsMigration: needsMigration ?? this.needsMigration,
+      modifiedAt: modifiedAt ?? this.modifiedAt,
+      remoteHash: remoteHash ?? this.remoteHash,
+      syncedDeleted: syncedDeleted ?? this.syncedDeleted,
     );
   }
 
@@ -291,6 +308,9 @@ class VaultedFile {
       'albumIds': albumIds,
       'folderId': folderId,
       'needsMigration': needsMigration,
+      'modifiedAt': modifiedAt?.toIso8601String(),
+      'remoteHash': remoteHash,
+      'syncedDeleted': syncedDeleted,
     };
   }
 
@@ -337,6 +357,11 @@ class VaultedFile {
           [],
       folderId: json['folderId'] as String?,
       needsMigration: json['needsMigration'] as bool? ?? false,
+      modifiedAt: json['modifiedAt'] != null
+          ? DateTime.parse(json['modifiedAt'] as String)
+          : null,
+      remoteHash: json['remoteHash'] as String?,
+      syncedDeleted: json['syncedDeleted'] as bool? ?? false,
     );
   }
 

--- a/lib/services/remote/remote_store.dart
+++ b/lib/services/remote/remote_store.dart
@@ -1,0 +1,31 @@
+import 'dart:typed_data';
+
+/// Dumb blob transport. The server sees opaque bytes only — no vault model
+/// types cross this boundary. SyncService owns manifest encrypt/decrypt and
+/// content-addressed naming; this interface just moves bytes by name.
+///
+/// ponytail: abstract only — the WebDAV implementation (webdav_client) lands in
+/// Phase S0.2 impl along with its dependency. Until then this pins the contract
+/// the pure SyncService logic and tests build against.
+abstract class RemoteStore {
+  /// Auth + reachability probe (Phase S0.5 self-check).
+  Future<void> testConnection();
+
+  /// Fetch the encrypted manifest blob, or null if none exists yet.
+  Future<Uint8List?> getManifest();
+
+  /// Overwrite the encrypted manifest blob.
+  Future<void> putManifest(Uint8List bytes);
+
+  /// Upload a content-addressed blob by name (see SyncService.blobNameFor).
+  Future<void> putBlob(String name, Uint8List bytes);
+
+  /// Fetch a blob by name, or null if absent.
+  Future<Uint8List?> getBlob(String name);
+
+  /// Delete a blob by name.
+  Future<void> deleteBlob(String name);
+
+  /// List all blob names (for garbage collection / reconciliation).
+  Future<List<String>> listBlobs();
+}

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:pointycastle/export.dart';
+
+import '../crypto/aes_gcm_cipher.dart';
+import '../crypto/key_derivation.dart';
+import '../models/remote_manifest.dart';
+import '../models/vaulted_file.dart';
+
+/// The result of diffing local vault state against a remote manifest.
+class SyncPlan {
+  /// Local files newer than (or absent from) the remote — upload these.
+  final List<VaultedFile> toPush;
+
+  /// Remote entries newer than local, or absent locally — download these.
+  /// Empty in push-only v1; populated by the two-way path in Phase S3.
+  final List<ManifestEntry> toPull;
+
+  /// Content-addressed blob names to delete (tombstoned files).
+  final List<String> toDelete;
+
+  const SyncPlan({
+    this.toPush = const [],
+    this.toPull = const [],
+    this.toDelete = const [],
+  });
+
+  bool get isEmpty => toPush.isEmpty && toPull.isEmpty && toDelete.isEmpty;
+}
+
+/// Pure sync logic. Stateless helpers — no I/O, no Riverpod, no network.
+///
+/// ponytail: the stateful orchestration (runSync, connectivity guard,
+/// VaultStore + EncryptionService injection) lands Riverpod-native after the
+/// Phase 4 refactor; these pure pieces are callable from there and tested now.
+class SyncService {
+  SyncService._();
+
+  /// Encrypted manifest blob name on the remote store.
+  static const String manifestName = 'manifest.enc';
+
+  /// sha256 of [data] as a lowercase hex string.
+  static String sha256Hex(Uint8List data) => sha256.convert(data).toString();
+
+  /// Content-addressed, sharded blob name: `ab/cd/<hash>.enc`.
+  /// Sharding keeps any one directory from bloating; the hash is the sha256 of
+  /// the ciphertext, so identical ciphertext dedups to one blob.
+  static String blobNameFor(String contentHashHex) {
+    final padded =
+        contentHashHex.length >= 4 ? contentHashHex : contentHashHex.padLeft(4, '0');
+    final a = padded.substring(0, 2);
+    final b = padded.substring(2, 4);
+    return '$a/$b/$contentHashHex.enc';
+  }
+
+  /// Snapshot the current synced state of [files] into a manifest. Only files
+  /// that carry a [VaultedFile.remoteHash] reference an uploaded blob; entries
+  /// for tombstones keep their last hash so the blob can be reaped.
+  static RemoteManifest buildManifest(
+    List<VaultedFile> files, {
+    required String deviceId,
+    DateTime? now,
+  }) {
+    final generated = (now ?? DateTime.now()).toUtc();
+    final entries = files
+        .map(
+          (f) => ManifestEntry(
+            id: f.id,
+            contentHash: f.remoteHash,
+            modifiedAt: f.modifiedAt ?? f.dateModified ?? f.dateAdded,
+            deleted: f.syncedDeleted,
+          ),
+        )
+        .toList(growable: false);
+    return RemoteManifest(
+      version: 1,
+      deviceId: deviceId,
+      generatedAt: generated,
+      entries: entries,
+    );
+  }
+
+  /// Diff local files against the remote manifest → a [SyncPlan].
+  /// Convergence is last-write-wins by modifiedAt; local/remote null
+  /// modifiedAt falls back to dateModified then dateAdded.
+  static SyncPlan reconcile({
+    required List<VaultedFile> local,
+    required RemoteManifest remote,
+  }) {
+    final remoteById = {for (final e in remote.entries) e.id: e};
+    final localIds = {for (final f in local) f.id};
+    final toPush = <VaultedFile>[];
+    final toPull = <ManifestEntry>[];
+    final toDelete = <String>[];
+
+    for (final f in local) {
+      final r = remoteById[f.id];
+      if (f.syncedDeleted) {
+        if (r != null && !r.deleted && r.contentHash != null) {
+          toDelete.add(blobNameFor(r.contentHash!));
+        }
+        continue;
+      }
+      if (r == null || r.deleted) {
+        toPush.add(f);
+      } else {
+        final localM = f.modifiedAt ?? f.dateModified ?? f.dateAdded;
+        if (localM.isAfter(r.modifiedAt)) {
+          toPush.add(f);
+        } else if (r.modifiedAt.isAfter(localM)) {
+          toPull.add(r);
+        }
+      }
+    }
+
+    // Remote files unknown locally (two-way pull). Skipped in push-only v1.
+    for (final e in remote.entries) {
+      if (!e.deleted && !localIds.contains(e.id)) {
+        toPull.add(e);
+      }
+    }
+
+    return SyncPlan(toPush: toPush, toPull: toPull, toDelete: toDelete);
+  }
+
+  /// Encrypt a manifest with the vault master key. Wire format:
+  /// `[16-byte IV][ciphertext+GCM tag]`. Reuses AesGcmCipher — no new crypto.
+  static Uint8List encryptManifest(RemoteManifest manifest, Uint8List masterKey) {
+    final iv = KeyDerivation.generateIV();
+    final ct = AesGcmCipher.process(
+      masterKey,
+      iv,
+      Uint8List.fromList(utf8.encode(manifest.toJsonString())),
+      true,
+    );
+    return Uint8List.fromList([...iv, ...ct]);
+  }
+
+  /// Decrypt a manifest blob. Throws [InvalidCipherTextException] if the GCM
+  /// auth tag does not verify — callers MUST treat that as tampering/forgery.
+  static RemoteManifest decryptManifest(Uint8List bytes, Uint8List masterKey) {
+    if (bytes.length < 17) {
+      throw const FormatException('Manifest blob too short');
+    }
+    final iv = Uint8List.fromList(bytes.sublist(0, 16));
+    final ct = Uint8List.fromList(bytes.sublist(16));
+    final pt = AesGcmCipher.process(masterKey, iv, ct, false);
+    return RemoteManifest.fromJsonString(utf8.decode(pt));
+  }
+}

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -1,0 +1,265 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/models/remote_manifest.dart';
+import 'package:locker/models/sync_profile.dart';
+import 'package:locker/models/vaulted_file.dart';
+import 'package:locker/services/sync_service.dart';
+import 'package:pointycastle/export.dart';
+
+VaultedFile _file({
+  required String id,
+  DateTime? dateAdded,
+  DateTime? dateModified,
+  DateTime? modifiedAt,
+  String? remoteHash,
+  bool syncedDeleted = false,
+}) {
+  return VaultedFile(
+    id: id,
+    originalName: '$id.jpg',
+    vaultPath: '/v/$id',
+    type: VaultedFileType.image,
+    mimeType: 'image/jpeg',
+    fileSize: 100,
+    dateAdded: dateAdded ?? DateTime(2024, 1, 1),
+    dateModified: dateModified,
+    modifiedAt: modifiedAt,
+    remoteHash: remoteHash,
+    syncedDeleted: syncedDeleted,
+  );
+}
+
+void main() {
+  group('blobNameFor', () {
+    test('shards by first 4 hex chars into ab/cd/ paths', () {
+      const hash = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+      expect(SyncService.blobNameFor(hash), 'ab/cd/$hash.enc');
+    });
+
+    test('sha256Hex is deterministic and 64 hex chars', () {
+      final a = SyncService.sha256Hex(Uint8List.fromList([1, 2, 3]));
+      final b = SyncService.sha256Hex(Uint8List.fromList([1, 2, 3]));
+      expect(a, b);
+      expect(a.length, 64);
+    });
+  });
+
+  group('reconcile', () {
+    test('empty local and remote yields empty plan', () {
+      final plan = SyncService.reconcile(
+        local: const [],
+        remote: RemoteManifest(
+          deviceId: 'd',
+          generatedAt: DateTime.utc(2024, 1, 1),
+        ),
+      );
+      expect(plan.isEmpty, isTrue);
+    });
+
+    test('new local file (absent from remote) is pushed', () {
+      final local = [_file(id: 'a')];
+      final plan = SyncService.reconcile(
+        local: local,
+        remote: RemoteManifest(
+          deviceId: 'd',
+          generatedAt: DateTime.utc(2024, 1, 1),
+        ),
+      );
+      expect(plan.toPush.map((f) => f.id), ['a']);
+      expect(plan.toPull, isEmpty);
+      expect(plan.toDelete, isEmpty);
+    });
+
+    test('locally newer file is pushed', () {
+      final local = [
+        _file(
+          id: 'a',
+          modifiedAt: DateTime(2024, 6, 1),
+          remoteHash: 'h1',
+        ),
+      ];
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: DateTime(2024, 1, 1),
+        entries: [
+          ManifestEntry(
+            id: 'a',
+            contentHash: 'h1',
+            modifiedAt: DateTime(2024, 3, 1),
+          ),
+        ],
+      );
+      final plan = SyncService.reconcile(local: local, remote: remote);
+      expect(plan.toPush.map((f) => f.id), ['a']);
+    });
+
+    test('remotely newer entry is pulled (two-way)', () {
+      final local = [
+        _file(
+          id: 'a',
+          modifiedAt: DateTime(2024, 3, 1),
+          remoteHash: 'h1',
+        ),
+      ];
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: DateTime(2024, 6, 1),
+        entries: [
+          ManifestEntry(
+            id: 'a',
+            contentHash: 'h1',
+            modifiedAt: DateTime(2024, 6, 1),
+          ),
+        ],
+      );
+      final plan = SyncService.reconcile(local: local, remote: remote);
+      expect(plan.toPush, isEmpty);
+      expect(plan.toPull.map((e) => e.id), ['a']);
+    });
+
+    test('remote entry unknown locally is pulled', () {
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: DateTime(2024, 1, 1),
+        entries: [
+          ManifestEntry(
+            id: 'ghost',
+            contentHash: 'hg',
+            modifiedAt: DateTime(2024, 1, 1),
+          ),
+        ],
+      );
+      final plan = SyncService.reconcile(local: const [], remote: remote);
+      expect(plan.toPull.map((e) => e.id), ['ghost']);
+    });
+
+    test('tombstone schedules remote blob deletion', () {
+      final local = [_file(id: 'a', syncedDeleted: true, remoteHash: 'h1')];
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: DateTime(2024, 1, 1),
+        entries: [
+          ManifestEntry(
+            id: 'a',
+            contentHash: 'deadbeef',
+            modifiedAt: DateTime(2024, 1, 1),
+          ),
+        ],
+      );
+      final plan = SyncService.reconcile(local: local, remote: remote);
+      expect(plan.toDelete, ['de/ad/deadbeef.enc']);
+      expect(plan.toPush, isEmpty);
+    });
+
+    test('in-sync file produces no work', () {
+      final t = DateTime(2024, 5, 1);
+      final local = [_file(id: 'a', modifiedAt: t, remoteHash: 'h1')];
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: t,
+        entries: [ManifestEntry(id: 'a', contentHash: 'h1', modifiedAt: t)],
+      );
+      expect(SyncService.reconcile(local: local, remote: remote).isEmpty, isTrue);
+    });
+  });
+
+  group('manifest crypto', () {
+    test('encrypt/decrypt round-trips the manifest', () {
+      final masterKey =
+          Uint8List.fromList(List<int>.generate(32, (i) => i * 7 % 256));
+      final manifest = SyncService.buildManifest(
+        [
+          _file(
+            id: 'a',
+            modifiedAt: DateTime(2024, 5, 1),
+            remoteHash: 'hash-a',
+          ),
+          _file(id: 'b', remoteHash: 'hash-b', syncedDeleted: true),
+        ],
+        deviceId: 'device-1',
+        now: DateTime.utc(2024, 5, 2),
+      );
+
+      final enc = SyncService.encryptManifest(manifest, masterKey);
+      // Wire format: 16-byte IV prefix + ciphertext+tag.
+      expect(enc.length, greaterThan(16 + 16));
+
+      final dec = SyncService.decryptManifest(enc, masterKey);
+      expect(dec.version, 1);
+      expect(dec.deviceId, 'device-1');
+      expect(dec.entries.map((e) => e.id), ['a', 'b']);
+      expect(dec.entries.first.contentHash, 'hash-a');
+      expect(dec.entries.last.deleted, isTrue);
+    });
+
+    test('tampered ciphertext fails GCM auth', () {
+      final masterKey = Uint8List(32);
+      final manifest = SyncService.buildManifest(
+        [_file(id: 'a', remoteHash: 'h')],
+        deviceId: 'd',
+        now: DateTime.utc(2024, 1, 1),
+      );
+      final enc = SyncService.encryptManifest(manifest, masterKey);
+      enc[enc.length - 1] ^= 0x01; // flip last byte (in the auth tag)
+      expect(
+        () => SyncService.decryptManifest(enc, masterKey),
+        throwsA(isA<InvalidCipherTextException>()),
+      );
+    });
+  });
+
+  group('model serialization', () {
+    test('SyncProfile round-trips through json string', () {
+      final p = SyncProfile(
+        id: 'p1',
+        serverUrl: 'https://nas.local/dav',
+        username: 'u',
+        basePath: '/locker',
+        direction: SyncDirection.twoWay,
+        wifiOnly: false,
+        enabled: true,
+        lastSyncedAt: DateTime.utc(2024, 6, 1, 12, 0),
+      );
+      final rt = SyncProfile.fromJsonString(p.toJsonString());
+      expect(rt.id, p.id);
+      expect(rt.serverUrl, p.serverUrl);
+      expect(rt.direction, SyncDirection.twoWay);
+      expect(rt.wifiOnly, false);
+      expect(rt.passwordStorageKey, 'sync_profile_pw_p1');
+    });
+
+    test('VaultedFile round-trips sync fields', () {
+      final f = _file(
+        id: 'x',
+        modifiedAt: DateTime.utc(2024, 7, 1),
+        remoteHash: 'rh',
+        syncedDeleted: true,
+      );
+      final rt = VaultedFile.fromJsonString(f.toJsonString());
+      expect(rt.modifiedAt, DateTime.utc(2024, 7, 1));
+      expect(rt.remoteHash, 'rh');
+      expect(rt.syncedDeleted, isTrue);
+    });
+
+    test('RemoteManifest round-trips entries', () {
+      final m = RemoteManifest(
+        version: 1,
+        deviceId: 'd',
+        generatedAt: DateTime.utc(2024, 1, 1),
+        entries: [
+          ManifestEntry(
+            id: 'a',
+            contentHash: 'h',
+            modifiedAt: DateTime.utc(2024, 1, 2),
+            deleted: false,
+          ),
+        ],
+      );
+      final rt = RemoteManifest.fromJsonString(m.toJsonString());
+      expect(rt.entries.single.id, 'a');
+      expect(rt.entries.single.contentHash, 'h');
+      expect(rt.entries.single.deleted, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

Adds a sync service with encrypted-at-rest blob transport, remote manifest model, reconciliation logic, and bookkeeping fields on vault entries for conflict-free synchronization.

# Changes

## Sync Infrastructure

- Add `SyncProfile` model with `SyncDirection` enum and JSON serialization
- Add remote manifest model classes
- Add sync bookkeeping fields to `VaultedFile` (`modifiedAt` LWW timestamp, `remoteHash` sha256, `syncedDeleted`)
- Add sync fields to `VaultSettings` (`syncEnabled`, `syncProfileId`)
- Add `RemoteStore` abstract interface for blob transport

## Sync Service

- Add `SyncService` with reconciliation and manifest encryption

## Testing

- Add comprehensive tests for `SyncService` reconcile, crypto, and model serialization

## Documentation

- Add local server sync plan document