### PR TITLE
Add WebDAV remote store for sync with profile management and tests

### DIFF
--- a/docs/local_server_sync.md
+++ b/docs/local_server_sync.md
@@ -5,8 +5,11 @@ self-hosted cloud) to Latch. Today the vault is device-local with a manual
 *decrypted* ZIP backup (`BackupService`). This plan defines an
 **encrypted-at-rest** sync to a server on the LAN or internet.
 
-Status: **PLANNING** — no code yet. Locked decisions are marked **[LOCKED]**;
-open ones are marked **[OPEN]** and listed again at the bottom.
+Status: **IN PROGRESS** — S0 (transport + creds), S1 (manifest crypto), and the
+S2.1 reconcile engine are implemented and unit-tested (90 tests green).
+Pending: S0.4 connection UI, S1.4/S2.2 sync execution (`runSync`), S2.3–S2.5
+provider/guard/UI. Locked decisions are marked **[LOCKED]**; open ones are
+marked **[OPEN]** and listed again at the bottom.
 
 ---
 
@@ -53,6 +56,11 @@ open ones are marked **[OPEN]** and listed again at the bottom.
    alongside) Phase 4 so we don't add a 13th singleton we then have to remove.
    It takes `VaultStore` + `EncryptionService` via constructor, like the
    Phase 2 services.
+
+   Current state: `SyncService` exists but holds only **pure static logic**
+   (`blobNameFor`, `reconcile`, `buildManifest`, manifest encrypt/decrypt). It
+   is not registered anywhere — no singleton, no provider — so the locked
+   decision stands for the stateful `runSync` orchestration.
 
 ---
 
@@ -118,7 +126,7 @@ Hard rules:
 │ local index  │      │ putManifest /      │
 │              │      │ getBlob / putBlob /│
 │              │      │ deleteBlob /       │
-│              │      │ listRemote         │
+│              │      │ listBlobs         │
 └──────────────┘      └─────────┬──────────┘
                                 │ HTTP
                          ┌──────▼──────┐
@@ -134,12 +142,11 @@ added later behind the same `SyncService` — but only one impl ships now.
 ### Server layout (what the user's NAS holds)
 
 ```
-/latch/
-  manifest.enc            # encrypted index + metadata + tombstones
-  blobs/
-    ab/cd/abcd1234…enc    # content-addressed encrypted media (sha256 of ciphertext)
-    ef/01/ef019876…enc
-  manifest.enc.sig        # [OPEN] GCM tag already authenticates; separate sig = YAGNI for v1
+<basePath>/                     # SyncProfile.basePath, default /locker
+  manifest.enc                  # encrypted index + metadata + tombstones
+  ab/cd/abcd1234…enc            # content-addressed encrypted media (sha256 of ciphertext)
+  ef/01/ef019876…enc
+  manifest.enc.sig              # [OPEN] GCM tag already authenticates; separate sig = YAGNI for v1
 ```
 
 Content-addressing the blobs by hash of the **ciphertext** gives us:
@@ -194,15 +201,17 @@ Direction control (setting):
 
 - **New model:** `SyncProfile` (URL, username, base path, lastSyncAt,
   syncDirection, wifiOnly) — stored in `flutter_secure_storage` as JSON.
-  Not in `VaultSettings` (keeps settings free of secrets).
+  Not in `VaultSettings` (keeps settings free of secrets). **DONE** — plus
+  `SyncProfileService` CRUD with per-profile password keys
+  (`sync_profile_pw_<id>`); passwords never live in the profile JSON.
 - **`VaultSettings` additions:** `bool syncEnabled = false`,
-  `String? syncProfileId`. (Small additions to the existing
-  `toJson`/`fromJson`/`copyWith` — follows the existing field pattern.)
+  `String? syncProfileId`. **DONE** (`toJson`/`fromJson`/`copyWith`).
 - **`VaultedFile` additions:** `DateTime? modifiedAt`, `String? remoteHash`,
-  `bool syncedDeleted = false` (tombstone flag). Migration on load: missing
-  `modifiedAt` → default to file mtime.
-- **New:** `RemoteManifest` model (the decrypted manifest schema: version,
-  device id, files map, tombstones, generatedAt).
+  `bool syncedDeleted = false` (tombstone flag). **DONE**. Migration on load
+  (missing `modifiedAt` → file mtime) **PENDING** — lands with the VaultStore
+  manifest helpers.
+- **New:** `RemoteManifest` model (`version`, `deviceId`, `generatedAt`,
+  `entries: [{id, contentHash, modifiedAt, deleted}]`). **DONE**.
 
 ---
 
@@ -214,11 +223,11 @@ Phases are ordered by dependency. Each is independently shippable.
 
 | # | Task | Location |
 |---|---|---|
-| S0.1 | Add `webdav_client` dep | `pubspec.yaml` |
-| S0.2 | `RemoteStore` interface + WebDAV impl: `ping`, `getManifest`, `putManifest`, `getBlob`, `putBlob`, `deleteBlob`, `listBlobs` | `lib/services/remote/` (new) |
-| S0.3 | `SyncProfile` model + secure-storage CRUD | `lib/models/sync_profile.dart`, new `SyncProfileService` |
-| S0.4 | Connection settings UI: URL/user/password, "Test connection" button, TLS warning for plain HTTP | `lib/screens/sync_settings_screen.dart` (new) |
-| S0.5 | One runnable self-check: connect to a WebDAV URL, put/get a tiny blob, assert roundtrip | test or `__main__`-style check |
+| [x] S0.1 | Add `webdav_client` dep (1.2.2) | `pubspec.yaml` |
+| [x] S0.2 | `RemoteStore` interface + WebDAV impl: `ping`, `getManifest`, `putManifest`, `getBlob`, `putBlob`, `deleteBlob`, `listBlobs` | `lib/services/remote/` |
+| [x] S0.3 | `SyncProfile` model + secure-storage CRUD | `lib/models/sync_profile.dart`, `lib/services/sync_profile_service.dart` |
+| [ ] S0.4 | Connection settings UI: URL/user/password, "Test connection" button, TLS warning for plain HTTP | `lib/screens/sync_settings_screen.dart` (new) |
+| [~] S0.5 | One runnable self-check: connect to a WebDAV URL, put/get a tiny blob, assert roundtrip — so far only path/URL-logic unit tests (`test/webdav_store_test.dart`); live-server roundtrip pending | test or `__main__`-style check |
 
 **Verify:** connect to a real WebDAV server (Nextcloud demo or local
 `rclone serve webdav`), roundtrip a blob. Credentials persist across restart.
@@ -227,10 +236,10 @@ Phases are ordered by dependency. Each is independently shippable.
 
 | # | Task | Location |
 |---|---|---|
-| S1.1 | `RemoteManifest` model + JSON (de)serialize | `lib/models/remote_manifest.dart` |
-| S1.2 | Build manifest from `VaultStore` index; encrypt with master key; decrypt on read | `SyncService.buildManifest` / `readManifest` |
-| S1.3 | Content-address blob naming (sha256 of ciphertext, sharded `ab/cd/`) | `SyncService.blobNameFor` |
-| S1.4 | Push/pull manifest only (no blobs yet) — proves the crypto + transport glue | extends S0 |
+| [x] S1.1 | `RemoteManifest` model + JSON (de)serialize | `lib/models/remote_manifest.dart` |
+| [~] S1.2 | Build manifest from `VaultStore` index; encrypt with master key; decrypt on read — `buildManifest` + `encryptManifest`/`decryptManifest` done (pure, tested); VaultStore index wiring pending | `SyncService.buildManifest` / `readManifest` |
+| [x] S1.3 | Content-address blob naming (sha256 of ciphertext, sharded `ab/cd/`) | `SyncService.blobNameFor` |
+| [ ] S1.4 | Push/pull manifest only (no blobs yet) — proves the crypto + transport glue | extends S0 |
 
 **Verify:** upload encrypted manifest, wipe local, pull manifest back,
 decrypt, assert it equals the original index. Plaintext never leaves device
@@ -240,12 +249,12 @@ decrypt, assert it equals the original index. Plaintext never leaves device
 
 | # | Task | Location |
 |---|---|---|
-| S2.1 | `reconcile()` diff engine (local vs remote manifest) → plan (push/pull/delete lists) | `SyncService.reconcile` |
-| S2.2 | Execute push plan: upload new/changed blobs, then commit manifest | `SyncService.runSync` |
-| S2.3 | `SyncProvider` (Riverpod Notifier): status enum, progress, `syncNow()` | `lib/providers/sync_provider.dart` |
-| S2.4 | `connectivity_plus` guard: respect wifiOnly / connected; resubscribe like `update_service.dart:74` | `SyncService` / provider |
-| S2.5 | UI: status chip + "Sync now" in settings; progress reporting | sync settings screen + a drawer entry |
-| S2.6 | One behavioral test: seed vault, sync, assert every local file has a remote blob + manifest lists it | `test/sync_service_test.dart` |
+| [x] S2.1 | `reconcile()` diff engine (local vs remote manifest) → plan (push/pull/delete lists) — covers tombstone deletion and two-way pull cases | `SyncService.reconcile` |
+| [ ] S2.2 | Execute push plan: upload new/changed blobs, then commit manifest | `SyncService.runSync` |
+| [ ] S2.3 | `SyncProvider` (Riverpod Notifier): status enum, progress, `syncNow()` | `lib/providers/sync_provider.dart` |
+| [ ] S2.4 | `connectivity_plus` guard: respect wifiOnly / connected; resubscribe like `update_service.dart:74` | `SyncService` / provider |
+| [ ] S2.5 | UI: status chip + "Sync now" in settings; progress reporting | sync settings screen + a drawer entry |
+| [~] S2.6 | One behavioral test: seed vault, sync, assert every local file has a remote blob + manifest lists it — reconcile/crypto tests in place; seed-vault behavioral test pending | `test/sync_service_test.dart` |
 
 **Verify:** fill vault, push to server, inspect server (all opaque `.enc`),
 wipe app data, reinstall → pull restores the vault intact (decrypt +
@@ -274,33 +283,34 @@ if the feature gets used.
 ## New files
 
 ```
-lib/models/sync_profile.dart            sync profile (creds live in secure storage)
-lib/models/remote_manifest.dart         encrypted manifest schema
-lib/services/remote/remote_store.dart   transport interface
-lib/services/remote/webdav_store.dart   WebDAV impl
-lib/services/sync_profile_service.dart  secure-storage CRUD for profiles
-lib/services/sync_service.dart          reconcile + runSync
-lib/providers/sync_provider.dart        Riverpod status Notifier
-lib/screens/sync_settings_screen.dart   connection + sync UI
-test/sync_service_test.dart             behavioral net (one happy path per phase)
+lib/models/sync_profile.dart            sync profile (creds live in secure storage)           [x]
+lib/models/remote_manifest.dart         encrypted manifest schema                             [x]
+lib/services/remote/remote_store.dart   transport interface                                   [x]
+lib/services/remote/webdav_store.dart   WebDAV impl                                           [x]
+lib/services/sync_profile_service.dart  secure-storage CRUD for profiles                      [x]
+lib/services/sync_service.dart          reconcile + runSync (pure logic done, runSync pending)[~]
+lib/providers/sync_provider.dart        Riverpod status Notifier                             [ ]
+lib/screens/sync_settings_screen.dart   connection + sync UI                                 [ ]
+test/sync_service_test.dart             behavioral net (reconcile + manifest crypto now)      [x]
+test/webdav_store_test.dart             transport path-logic self-check (S0.5, partial)       [x]
 ```
 
 ## Files changed
 
 ```
-pubspec.yaml                              + webdav_client
-lib/models/vault_settings.dart            + syncEnabled, syncProfileId
-lib/models/vaulted_file.dart              + modifiedAt, remoteHash, syncedDeleted
-lib/services/vault_store.dart             manifest build/read helpers, blob hashing
-lib/providers/vault_providers.dart        wire SyncProvider after Phase 4 lands
-main.dart / drawer                        entry point to sync settings
+pubspec.yaml                              + webdav_client (1.2.2)              [x]
+lib/models/vault_settings.dart            + syncEnabled, syncProfileId         [x]
+lib/models/vaulted_file.dart              + modifiedAt, remoteHash, syncedDeleted [x]
+lib/services/vault_store.dart             manifest build/read helpers, blob hashing [ ]
+lib/providers/vault_providers.dart        wire SyncProvider after Phase 4 lands [ ]
+main.dart / drawer                        entry point to sync settings          [ ]
 ```
 
 ---
 
 ## Dependencies
 
-- **Add:** `webdav_client` (one package).
+- **Add:** `webdav_client` (one package) — **done**, v1.2.2.
 - **Reuse:** `connectivity_plus` (already present), `flutter_secure_storage`
   (already present), existing `lib/crypto/` (no new crypto code).
 

--- a/lib/models/sync_profile.dart
+++ b/lib/models/sync_profile.dart
@@ -26,7 +26,10 @@ class SyncProfile {
   final DateTime? lastSyncedAt;
 
   /// Secure-storage key for this profile's password.
-  String get passwordStorageKey => 'sync_profile_pw_$id';
+  String get passwordStorageKey => passwordStorageKeyFor(id);
+
+  /// Secure-storage key for a profile's password by profile id.
+  static String passwordStorageKeyFor(String id) => 'sync_profile_pw_$id';
 
   const SyncProfile({
     required this.id,

--- a/lib/services/remote/remote_store.dart
+++ b/lib/services/remote/remote_store.dart
@@ -8,6 +8,9 @@ import 'dart:typed_data';
 /// Phase S0.2 impl along with its dependency. Until then this pins the contract
 /// the pure SyncService logic and tests build against.
 abstract class RemoteStore {
+  /// Encrypted manifest blob name on the remote store.
+  static const String manifestName = 'manifest.enc';
+
   /// Auth + reachability probe (Phase S0.5 self-check).
   Future<void> testConnection();
 

--- a/lib/services/remote/webdav_store.dart
+++ b/lib/services/remote/webdav_store.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart';
+import 'package:webdav_client/webdav_client.dart' as webdav;
+
+import 'remote_store.dart';
+
+/// WebDAV implementation of [RemoteStore] — dumb blob storage. The server only
+/// ever sees opaque bytes: content-addressed blobs + the encrypted manifest.
+class WebDAVStore implements RemoteStore {
+  WebDAVStore({
+    required this.baseUrl,
+    this.username = '',
+    this.password = '',
+    this.basePath = '/locker',
+  });
+
+  /// Server root, e.g. `https://nas.local/dav`.
+  final String baseUrl;
+
+  final String username;
+  final String password;
+
+  /// Vault root path on the server, e.g. `/locker`.
+  final String basePath;
+
+  webdav.Client? _client;
+
+  webdav.Client get _c =>
+      _client ??= webdav.newClient(baseUrl, user: username, password: password);
+
+  /// Join [base] and [name] with exactly one `/`.
+  static String joinPath(String base, String name) {
+    final b = base.replaceAll(RegExp(r'/$'), '');
+    final n = name.replaceAll(RegExp(r'^/'), '');
+    return '$b/$n';
+  }
+
+  String _path(String name) => joinPath(basePath, name);
+
+  @override
+  Future<void> testConnection() => _c.ping();
+
+  @override
+  Future<Uint8List?> getManifest() => _readOrNull(RemoteStore.manifestName);
+
+  @override
+  Future<void> putManifest(Uint8List bytes) =>
+      _c.write(_path(RemoteStore.manifestName), bytes);
+
+  @override
+  Future<Uint8List?> getBlob(String name) => _readOrNull(name);
+
+  @override
+  Future<void> putBlob(String name, Uint8List bytes) =>
+      _c.write(_path(name), bytes);
+
+  @override
+  Future<void> deleteBlob(String name) => _c.remove(_path(name));
+
+  @override
+  Future<List<String>> listBlobs() async {
+    final out = <String>[];
+    await _walk(basePath.isEmpty ? '/' : basePath, out);
+    return out;
+  }
+
+  Future<void> _walk(String dir, List<String> out) async {
+    final files = await _c.readDir(dir);
+    for (final f in files) {
+      if (f.isDir == true) {
+        await _walk(f.path ?? '', out);
+      } else {
+        out.add(f.path ?? '');
+      }
+    }
+  }
+
+  /// Absent file (404) and reachability errors both come back null.
+  /// ponytail: conflates the two; v1 treats them the same, and the caller's
+  /// testConnection gate separates "server down" from "nothing synced yet".
+  Future<Uint8List?> _readOrNull(String name) async {
+    try {
+      return Uint8List.fromList(await _c.read(_path(name)));
+    } catch (e) {
+      debugPrint('WebDAV read($name): $e');
+      return null;
+    }
+  }
+}

--- a/lib/services/sync_profile_service.dart
+++ b/lib/services/sync_profile_service.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../models/sync_profile.dart';
+
+/// CRUD for sync profiles. All profiles (no secrets) live under one
+/// secure-storage JSON key; each password lives in its own secure-storage
+/// entry keyed by profile id ([SyncProfile.passwordStorageKeyFor]).
+class SyncProfileService {
+  SyncProfileService({FlutterSecureStorage? storage})
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  static final SyncProfileService instance = SyncProfileService();
+
+  final FlutterSecureStorage _storage;
+
+  static const String profilesKey = 'sync_profiles';
+
+  Future<List<SyncProfile>> listProfiles() async {
+    final raw = await _storage.read(key: profilesKey);
+    if (raw == null) return const [];
+    return (jsonDecode(raw) as List<dynamic>)
+        .map((e) => SyncProfile.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<SyncProfile?> getProfile(String id) async {
+    for (final p in await listProfiles()) {
+      if (p.id == id) return p;
+    }
+    return null;
+  }
+
+  Future<void> saveProfile(SyncProfile profile) async {
+    final profiles = await listProfiles();
+    final i = profiles.indexWhere((p) => p.id == profile.id);
+    if (i >= 0) {
+      profiles[i] = profile;
+    } else {
+      profiles.add(profile);
+    }
+    await _storage.write(
+      key: profilesKey,
+      value: jsonEncode([for (final p in profiles) p.toJson()]),
+    );
+  }
+
+  Future<void> deleteProfile(String id) async {
+    final profiles = await listProfiles();
+    profiles.removeWhere((p) => p.id == id);
+    await _storage.write(
+      key: profilesKey,
+      value: jsonEncode([for (final p in profiles) p.toJson()]),
+    );
+    await _storage.delete(key: SyncProfile.passwordStorageKeyFor(id));
+  }
+
+  Future<void> savePassword(String id, String password) => _storage.write(
+        key: SyncProfile.passwordStorageKeyFor(id),
+        value: password,
+      );
+
+  Future<String?> getPassword(String id) =>
+      _storage.read(key: SyncProfile.passwordStorageKeyFor(id));
+
+  Future<void> deletePassword(String id) =>
+      _storage.delete(key: SyncProfile.passwordStorageKeyFor(id));
+}

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -8,6 +8,7 @@ import '../crypto/aes_gcm_cipher.dart';
 import '../crypto/key_derivation.dart';
 import '../models/remote_manifest.dart';
 import '../models/vaulted_file.dart';
+import 'remote/remote_store.dart';
 
 /// The result of diffing local vault state against a remote manifest.
 class SyncPlan {
@@ -39,7 +40,7 @@ class SyncService {
   SyncService._();
 
   /// Encrypted manifest blob name on the remote store.
-  static const String manifestName = 'manifest.enc';
+  static const String manifestName = RemoteStore.manifestName;
 
   /// sha256 of [data] as a lowercase hex string.
   static String sha256Hex(Uint8List data) => sha256.convert(data).toString();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.11.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   fake_async:
     dependency: transitive
     description:
@@ -1493,6 +1509,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdav_client:
+    dependency: "direct main"
+    description:
+      name: webdav_client
+      sha256: "682fffc50b61dc0e8f46717171db03bf9caaa17347be41c0c91e297553bf86b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   in_app_update: ^4.2.5
   connectivity_plus: ^6.0.0
   flutter_markdown: ^0.7.7+1
+  webdav_client: ^1.2.2
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/test/webdav_store_test.dart
+++ b/test/webdav_store_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/models/sync_profile.dart';
+import 'package:locker/services/remote/remote_store.dart';
+import 'package:locker/services/remote/webdav_store.dart';
+import 'package:locker/services/sync_service.dart';
+
+void main() {
+  group('joinPath', () {
+    test('joins base and name with a single slash', () {
+      expect(WebDAVStore.joinPath('/locker', 'manifest.enc'),
+          '/locker/manifest.enc');
+      expect(WebDAVStore.joinPath('/locker/', 'ab/cd/hash.enc'),
+          '/locker/ab/cd/hash.enc');
+      expect(WebDAVStore.joinPath('', 'manifest.enc'), '/manifest.enc');
+      expect(WebDAVStore.joinPath('/', '/manifest.enc'), '/manifest.enc');
+    });
+  });
+
+  group('transport paths', () {
+    test('manifest blob path resolves under the profile base path', () {
+      final store = WebDAVStore(baseUrl: 'https://nas.local/dav', basePath: '/locker');
+      // joinPath is public; _path is private, so assert the same contract the
+      // WebDAV client will receive: absolute server path for the manifest.
+      expect(WebDAVStore.joinPath(store.basePath, RemoteStore.manifestName),
+          '/locker/${SyncService.manifestName}');
+    });
+
+    test('blob names shard under the base path', () {
+      const hash =
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+      expect(
+        WebDAVStore.joinPath('/locker', SyncService.blobNameFor(hash)),
+        '/locker/ab/cd/$hash.enc',
+      );
+    });
+  });
+
+  group('SyncProfile password keys', () {
+    test('password key is derived from profile id', () {
+      final p = SyncProfile(id: 'p1', serverUrl: 'https://nas.local/dav');
+      expect(p.passwordStorageKey, 'sync_profile_pw_p1');
+      expect(SyncProfile.passwordStorageKeyFor('p1'), 'sync_profile_pw_p1');
+    });
+  });
+}


### PR DESCRIPTION
# Summary

Adds a WebDAV implementation of the `RemoteStore` interface for syncing via content-addressed blobs and encrypted manifests, along with a `SyncProfileService` for secure profile CRUD.

# Changes

## WebDAV Store

- Add `webdav_client` dependency
- Add WebDAV remote store implementation (connection testing, blob read/write/delete, recursive directory listing, graceful null-on-missing)
- Content-addressed blobs and encrypted manifest are the only objects the server sees

## Sync

- Add `manifestName` constant to `RemoteStore`
- Refactor sync service to use `RemoteStore.manifestName` constant

## Profile Management

- Add `SyncProfileService` for secure profile CRUD
- Extract password storage key logic into static method

## Testing

- Add WebDAVStore and SyncProfile tests