### PR TITLE
Add two-way vault sync with manifest v2, WebDAV, and sync settings UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ android/app/google-services.json
 
 # graphify knowledge graph (regenerated locally)
 graphify-out/
+docs/local_server_testing.md

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="false">
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/docs/embedded_pocketbase.md
+++ b/docs/embedded_pocketbase.md
@@ -1,0 +1,280 @@
+# Embedded PocketBase Local Store
+
+## Overview
+
+The vault currently stores metadata as a flat JSON index in
+`FlutterSecureStorage`, with media kept as encrypted files on disk. This
+document specifies embedding a PocketBase instance on the device itself as a
+structured, queryable local datastore for vault metadata. Media blobs remain
+on-disk encrypted files; PocketBase indexes and relates them. The WebDAV
+sync path (`docs/local_server_sync.md`) is unaffected: PocketBase is the
+local layer, WebDAV remains the remote transport.
+
+Status: **Planning**. No code exists. Phase P0 is a go/no-go feasibility
+gate (can a Go binary run inside the APK and serve HTTP on loopback from
+Dart); no later phase begins until it passes. If P0 fails, the plan falls
+back to `sqflite`.
+
+## Goals
+
+- Structured, queryable, relational local storage for metadata.
+- One embedded PocketBase instance per install; no hosted server.
+- Sensitive columns encrypted at the app layer before insert. PocketBase
+  never sees plaintext; at-rest security matches the current encrypted
+  manifest.
+- WebDAV remote sync stays untouched; the two backends coexist.
+- No new cryptography: reuse `AesGcmCipher` and the vault master key.
+
+## Non-goals
+
+- **Local-PB ↔ remote-PB replication.** PocketBase has no native
+  replication; building it is out of scope. Remote sync stays WebDAV.
+- **Multi-user operation.** Single-user, single-device instance.
+- **iOS.** The design depends on process spawning, which the iOS sandbox
+  forbids. Android only.
+- **Media blobs in PocketBase.** PB holds metadata and blob references only;
+  storing blobs would double storage and break the end-to-end model.
+- **PB admin UI and user accounts.** Unused in a single-user embedded role.
+
+## Architecture
+
+```
+UI ── Riverpod ── VaultService
+                     │
+                     ▼
+               LocalStore
+        ┌────────────┴────────────┐
+        ▼                         ▼
+  PocketBaseStore          FlutterSecureStorage
+  (preferred)              JSON index (legacy fallback,
+                           migration source)
+        │
+        │ loopback HTTP, 127.0.0.1:<ephemeral port> + auth token
+        ▼
+  libpocketbase.so (Go wrapper, bundled in jniLibs)
+  wrapper main() → PocketBase core → JS migrations → serve HTTP
+        │
+        ▼
+  SQLite (modernc, pure-Go) in app-private data dir
+  vault_files / albums / tags / folders — encrypted columns
+
+Media blobs ──► on-disk encrypted files (unchanged), referenced via blob_ref
+```
+
+`PocketBaseStore` implements the same `LocalStore` surface `VaultStore`
+exposes, so the rest of the app (including `SyncService.buildManifest`) is
+indifferent to where the index lives. The Go side is deliberately thin: a
+wrapper `main()` around `pocketbase.NewWithConfig` plus JS migrations
+defining the collections. No business logic in Go.
+
+### Device layout
+
+```
+<app-data>/pocketbase/
+  data.db                        # SQLite: encrypted columns + non-secret fields
+  data.db-wal
+  migrations/                    # versioned JS schema migrations
+<app-data>/vault/                # unchanged: encrypted media blobs
+  ab/cd/abcd1234…enc
+android/app/src/main/jniLibs/
+  arm64-v8a/libpocketbase.so     # Go binary, renamed so Android extracts it
+```
+
+`lib*.so` naming makes Android extract the binary into the native lib dir,
+discoverable at runtime via `applicationInfo.nativeLibraryDir`.
+
+### Bridge
+
+| Option | Verdict | Rationale |
+|---|---|---|
+| Sidecar subprocess + loopback HTTP | **v1** | PocketBase is an HTTP server by design; spawn the binary, parse the bound port, call its REST API from Dart via `package:http`. Simple, debuggable, PB runs as designed. |
+| FFI (`dart:ffi` → c-shared Go lib) | Alternative | Loads the Go runtime into the Flutter process; buys nothing in the data path (still HTTP) and adds Android friction. Considered only if sidecar lifecycle proves unworkable. |
+| Pure-Dart rewrite | Rejected | Not PocketBase. |
+| `sqflite` | Fallback | Covers "structured local storage" with one dependency and no binary; used only if P0 fails. |
+
+Dependency: a custom Go binary wrapping PocketBase core (one `main.go`,
+~100–300 lines), plus `package:http` on the Dart side (already available
+transitively). PocketBase version pinned in `go.mod`.
+
+## Security model
+
+| Asset | Where | Exposure if device is compromised |
+|---|---|---|
+| Media ciphertext | On-disk encrypted files (unchanged) | Safe. AES-256-GCM/CTR, per-file key from master key. PB never touches the bytes. |
+| Structured metadata (names, tags, albums, folders) | PB SQLite, app-encrypted columns | Safe: a dump yields ciphertext envelopes only, same as the current manifest. |
+| Indexable fields (`modified_at`, `deleted`, `blob_ref`) | PB SQLite, plaintext | Low risk: timestamps, booleans, content hashes. |
+| PB SQLite file | App-private storage | Readable on a rooted device; contains no plaintext secrets. |
+| Localhost PB API | Loopback only, not exposed to network | Co-resident apps could probe it; mitigated by ephemeral random port + auth token held in Dart memory. |
+| Master key | In memory after unlock; Argon2id-wrapped on disk | Unchanged; required to decrypt any column. |
+| Go binary | Shipped in APK | Static, auditable, version-pinned; listens on loopback only. |
+
+Hard rules:
+
+- **Plaintext never leaves the app process.** PB stores ciphertext
+  envelopes for secret fields. The Go binary never holds the master key and
+  cannot decrypt anything it stores.
+- **Loopback only.** PB binds `127.0.0.1` on an ephemeral random port
+  chosen at start — never `0.0.0.0`, never a fixed port. Dart learns the
+  port from the binary's stdout. A random auth token (emitted by the Go
+  side, held only in Dart memory) gates every request.
+- **Encrypt any field that could be secret.** A field is plaintext only if
+  it is non-secret by definition (timestamp, tombstone flag, content
+  hash). When in doubt, encrypt.
+- **The master key is the single root of confidentiality**, for both
+  on-disk blobs and PB columns — identical to today.
+- **Decoy vault out of scope** (mirrors `local_server_sync.md`).
+
+## Data model
+
+Collections are defined as versioned JS migrations on the Go side:
+
+- **`vault_files`** — `id` (text PK), `blob_ref` (text, on-disk shard path /
+  content hash; non-secret), `cipher_meta` (blob, app-encrypted JSON: tags,
+  albumIds, folderId, originalName, dateAdded, dateModified),
+  `modified_at` (number, plaintext for sorting), `deleted` (bool tombstone).
+- **`albums`** — `id`, `cipher_meta` (encrypted: name, cover ref, order),
+  `modified_at`, `deleted`.
+- **`tags`** — `id`, `cipher_name` (encrypted), `modified_at`, `deleted`.
+- **`folders`** — `id`, `cipher_meta` (encrypted: name, parent_id),
+  `modified_at`, `deleted`.
+
+**Encrypted-column convention:** one AES-GCM envelope per secret field —
+`[16-byte IV][ciphertext+tag]`, key = vault master key, via
+`AesGcmCipher`. Encode/decode lives in a single Dart helper shared by all
+DAOs. Sortable/filterable columns (`modified_at`, `deleted`, `blob_ref`)
+are deliberately non-secret, so PB query power survives.
+
+**Migration (one-time):** on first PB boot after unlock, read the existing
+`FlutterSecureStorage` `vault_file_index` JSON and bulk-insert into
+`vault_files`, encrypting `cipher_meta`. Guarded by a settings flag so it
+runs once. The legacy store is retained as a fallback, not deleted.
+
+## Phased plan
+
+Phases are ordered by dependency. **P0 is a go/no-go gate.**
+
+### P0 — Spike / de-risk (1–2 days)
+
+| # | Task | Location |
+|---|---|---|
+| P0.1 | Trivial Go HTTP server, cross-compile `GOOS=android GOARCH=arm64 CGO_ENABLED=0`; verify PocketBase's pure-Go `modernc.org/sqlite` backend means no CGO/NDK | `pocketbase/` (new Go module) |
+| P0.2 | Bundle as `jniLibs/arm64-v8a/libpocketbase.so`; from a throwaway Dart screen locate via `applicationInfo.nativeLibraryDir`, `Process.start`, parse port | `android/app/src/main/jniLibs/` |
+| P0.3 | Hit `/api/health` over loopback, assert 200 | throwaway screen |
+
+**Verify:** the binary runs, serves HTTP on loopback, and Dart reaches it.
+If this fails, stop and fall back to `sqflite`.
+
+### P1 — Go wrapper `locker-pb` (3–5 days)
+
+| # | Task | Location |
+|---|---|---|
+| P1.1 | `main.go` wrapping `pocketbase.NewWithConfig`: `--dir`, `--http=127.0.0.1:0` (ephemeral port printed to stdout), `--auth-token` (random, printed to stdout), `--hooks` | `pocketbase/cmd/locker-pb/main.go` |
+| P1.2 | JS migrations for `vault_files`, `albums`, `tags`, `folders` | `pocketbase/migrations/*.js` |
+| P1.3 | Cross-compile per chosen ABI (open decision 2); strip symbols | `Makefile` |
+| P1.4 | Pin PocketBase version in `go.mod` and document it | `pocketbase/go.mod` |
+
+### P2 — Dart runtime + bridge (3–4 days)
+
+| # | Task | Location |
+|---|---|---|
+| P2.1 | `PocketBaseRuntime`: binary discovery → exec → parse port+token → health-wait → graceful stop on teardown | `lib/services/pb/pocketbase_runtime.dart` |
+| P2.2 | Authenticated `http` client (token header) to localhost | `lib/services/pb/pb_client.dart` |
+| P2.3 | Lifecycle: start after unlock (needs master key), stop on lock/exit | app bootstrap |
+
+### P3 — Encrypted-column DAO layer (4–6 days)
+
+| # | Task | Location |
+|---|---|---|
+| P3.1 | `cipher_codec`: envelope/unwrap via `AesGcmCipher` + master key | `lib/services/pb/cipher_codec.dart` |
+| P3.2 | DAOs: `VaultFileDao`, `AlbumDao`, `TagDao`, `FolderDao` (CRUD against PB collections, encrypting secret fields) | `lib/services/pb/daos/*.dart` |
+| P3.3 | `PocketBaseStore implements LocalStore` (same surface `VaultStore` exposes) | `lib/services/pb/pocketbase_store.dart` |
+| P3.4 | One-time legacy → PB migration, guarded by settings flag | `lib/services/pb/migrate_legacy_index.dart` |
+| P3.5 | Behavioral test: round-trip a `VaultedFile` through the DAO; assert `cipher_meta` is ciphertext in the row and plaintext after read | `test/pb_store_test.dart` |
+
+### P4 — Wire-in + sync integration (3–4 days)
+
+| # | Task | Location |
+|---|---|---|
+| P4.1 | Introduce `LocalStore` interface; `VaultStore` and `PocketBaseStore` both implement it | `lib/services/local_store.dart` |
+| P4.2 | `VaultService` reads/writes through `LocalStore` (PB preferred, legacy fallback) | `lib/services/vault_service.dart` |
+| P4.3 | `SyncService.buildManifest` reads from the active `LocalStore` instead of `cachedFiles`; `runSync` unchanged | `lib/services/sync_service.dart` |
+| P4.4 | End-to-end: seed vault → PB rows appear → `runSync` pushes blobs + encrypted manifest (WebDAV path unchanged) | manual + scripted |
+
+### P5 — Polish (deferred)
+
+PB-vs-legacy toggle in settings, recovery UI if the binary fails to start,
+size optimization (`upx` / symbol strip), CI for the Go cross-compile,
+foreground Service for background PB survival. Ship P4 first; build P5 only
+if the feature gets used.
+
+## Files
+
+New:
+
+```
+pocketbase/                                Go module (custom PB wrapper)
+  cmd/locker-pb/main.go                    wrapper main()
+  migrations/*.js                          schema
+  go.mod                                   pinned pocketbase version
+lib/services/local_store.dart              LocalStore interface
+lib/services/pb/pocketbase_runtime.dart    binary discovery + exec + lifecycle
+lib/services/pb/pb_client.dart             authenticated localhost client
+lib/services/pb/cipher_codec.dart          column envelope/unwrap (reuse AesGcm)
+lib/services/pb/daos/*.dart                per-entity DAOs
+lib/services/pb/pocketbase_store.dart      LocalStore impl over PB
+lib/services/pb/migrate_legacy_index.dart  one-time FlutterSecureStorage → PB
+test/pb_store_test.dart                    encrypted-column round-trip
+Makefile                                   `make pb` cross-compile + place .so
+```
+
+Changed:
+
+```
+android/app/src/main/jniLibs/<abi>/libpocketbase.so   bundled Go binary
+pubspec.yaml                                          + http (Dart client)
+lib/services/vault_service.dart                       read/write via LocalStore
+lib/services/sync_service.dart                        buildManifest reads LocalStore
+lib/models/vault_settings.dart                        + pbEnabled flag
+```
+
+## Dependencies
+
+- **Add (Go):** `pocketbase` (pinned; pure-Go `modernc.org/sqlite` so
+  `CGO_ENABLED=0` cross-compile works — no NDK).
+- **Add (Dart):** `http` (localhost client; already available transitively,
+  pin explicitly).
+- **Reuse:** `lib/crypto/` (`AesGcmCipher`, master key) — no new crypto.
+  `flutter_secure_storage` retained for credentials and the legacy
+  fallback index.
+
+## Build pipeline
+
+`make pb` → cross-compile per ABI (`GOOS=android GOARCH=<arm64|arm|386>
+CGO_ENABLED=0`) → strip symbols → copy to
+`android/app/src/main/jniLibs/<abi>/libpocketbase.so` → `flutter build apk`.
+One command, version-pinned, reproducible.
+
+## Verification discipline
+
+Per the refactor roadmap's test rules: no per-method suites, one happy-path
+test per phase, one failure path for anything security-touching. P0 is the
+make-or-break check; P3.5 is the security-touching check (ciphertext at
+rest, plaintext on read). Manual end-to-end in P4.4 is the acceptance test.
+
+## Open decisions
+
+1. **Bridge style: sidecar + HTTP vs FFI.** Recommended: sidecar + HTTP
+   (data path is HTTP either way; FFI only adds Go-runtime friction).
+2. **ABIs: `arm64-v8a` only, or also `armeabi-v7a` + `x86_64`?**
+   Recommended: arm64 only for v1 (~10–12 MB stripped). Add others only if
+   emulator/old-device support matters.
+3. **Media blobs in PB, or metadata + refs only?** Recommended: metadata +
+   refs only (see Security model).
+4. **Schema source: Go JS migrations vs Dart-created at first run?**
+   Recommended: Go migrations (versioned with PB, reproducible).
+5. **Background PB survival (foreground Service) now or later?**
+   Recommended: later; foreground-only for v1.
+6. **APK size budget.** arm64-only stripped PB adds ~10–12 MB.
+7. **Remote replication scope.** If local-PB ↔ remote-PB replication is
+   the end goal, it becomes a new phase here and a meaningful scope
+   addition; the plan assumes WebDAV remains the only remote path.

--- a/docs/local_server_sync.md
+++ b/docs/local_server_sync.md
@@ -1,342 +1,271 @@
-# Local Server / Local Cloud Sync — Plan
+# Local Server Sync (WebDAV)
 
-Born from the request to add a self-hosted sync target (NAS, home server, or
-self-hosted cloud) to Latch. Today the vault is device-local with a manual
-*decrypted* ZIP backup (`BackupService`). This plan defines an
-**encrypted-at-rest** sync to a server on the LAN or internet.
+## Overview
 
-Status: **IN PROGRESS** — S0 (transport + creds), S1 (manifest crypto), and the
-S2.1 reconcile engine are implemented and unit-tested (90 tests green).
-Pending: S0.4 connection UI, S1.4/S2.2 sync execution (`runSync`), S2.3–S2.5
-provider/guard/UI. Locked decisions are marked **[LOCKED]**; open ones are
-marked **[OPEN]** and listed again at the bottom.
+The vault is device-local, with a manual *decrypted* ZIP backup
+(`BackupService`). This document specifies encrypted-at-rest sync to a
+user-chosen server (NAS, home server, or self-hosted cloud), push and pull.
+The server never sees plaintext: it is dumb encrypted blob storage.
 
----
+Status: **In progress**. S0 (transport + credentials), S1 (manifest
+crypto), and S2 (push-only backup: reconcile, `runSync`, provider,
+connectivity guard, UI) are implemented and unit-tested (92 tests pass).
+Pending: S0.5 live-server roundtrip, S3 (two-way pull/restore).
 
 ## Goals
 
-- Push the vault to a user-chosen server (NAS / home server / self-hosted cloud)
-  and pull it back on a new device or after a wipe.
-- The server **never** sees plaintext. It is dumb encrypted blob storage.
-- Manual sync first; optional scheduled/background sync later.
-- Reuse the existing encrypted file format and key model — **no new crypto**.
+- Push the vault to a user-chosen server and pull it back on a new device
+  or after a wipe.
+- The server sees opaque encrypted bytes only.
+- Manual sync first; scheduled/background sync later.
+- Reuse the existing encrypted file format and key model — no new crypto.
 
-## Non-goals (YAGNI)
+## Non-goals
 
-- Real-time collaborative sync / CRDT. (Last-write-wins per file is enough.)
-- A Latch-hosted cloud account. (This is *local* / self-hosted only.)
-- Syncing to multiple servers simultaneously. (One remote per vault, for now.)
-- Streaming media playback *from* the server. (Sync, not remote mount.)
+- Real-time collaborative sync / CRDT (last-write-wins per file suffices).
+- A hosted cloud account; sync is local / self-hosted only.
+- Multiple simultaneous servers (one remote per vault).
+- Streaming media playback from the server (sync, not remote mount).
 
----
-
-## Locked decisions
-
-1. **[LOCKED] End-to-end encrypted on the server.** Files already live in the
-   vault as `[magic][IV][ciphertext][auth tag]`. We sync those exact encrypted
-   blobs. The manifest (index + metadata) is encrypted with the vault master
-   key before upload. The server sees opaque bytes only. This is the opposite
-   of the current `BackupService`, which builds a **decrypted** ZIP — that
-   behavior must **not** be carried over to the server path.
-
-2. **[LOCKED] WebDAV is the only protocol in v1.** It is plain HTTP, every
-   NAS / Nextcloud / Synology / ownCloud / Seafile exposes it, and it needs
-   one package. SMB and SFTP are deferred (see "Protocol choice").
-
-3. **[LOCKED] Server is dumb blob storage.** A thin sync client in the app
-   does all the logic. No server-side app to build or ship.
-
-4. **[LOCKED] Reuse `connectivity_plus`** (already a dep, used in
-   `update_service.dart`) for the "only on Wi-Fi / only when connected"
-   guard. No new network-detection code.
-
-5. **[LOCKED] Sync service lands as Riverpod-native**, not a new singleton.
-   Per the refactor roadmap, Phase 4 (Riverpod modernization, drops the 12
-   `instance` singletons) is pending. This service should land **after** (or
-   alongside) Phase 4 so we don't add a 13th singleton we then have to remove.
-   It takes `VaultStore` + `EncryptionService` via constructor, like the
-   Phase 2 services.
-
-   Current state: `SyncService` exists but holds only **pure static logic**
-   (`blobNameFor`, `reconcile`, `buildManifest`, manifest encrypt/decrypt). It
-   is not registered anywhere — no singleton, no provider — so the locked
-   decision stands for the stateful `runSync` orchestration.
-
----
-
-## Threat model & security
-
-This is the part that matters most for a vault.
+## Security model
 
 | Asset | Where | Exposure if server is compromised |
 |---|---|---|
-| Media ciphertext | Server | **Safe.** AES-256-GCM/CTR, per-file key derived via PBKDF2 from the master key. Server sees blobs only. |
-| Manifest (index + names + tags + albums + folders) | Server (encrypted) | **Safe if** encrypted with master key before upload. **Critical:** never upload the raw `vault_file_index` JSON. |
-| Server credentials (URL, user, app password) | `flutter_secure_storage` → Android Keystore | Safe (same path as the PIN/master-key wrap). |
-| Thumbnails | **Local only** v1 | Re-derivable on pull from the decrypted blob. Not synced. |
+| Media ciphertext | Server | Safe. AES-256-GCM/CTR, per-file key derived via PBKDF2 from the master key. Server sees blobs only. |
+| Manifest (index, names, tags, albums, folders) | Server, encrypted | Safe if encrypted with the master key before upload. The raw `vault_file_index` JSON must never be uploaded. |
+| Server credentials (URL, user, app password) | `flutter_secure_storage` → Android Keystore | Safe; same path as the PIN/master-key wrap. |
+| Thumbnails | Local only (v1) | Re-derivable on pull from the decrypted blob; not synced. |
 
 Hard rules:
 
-- **Plaintext never crosses the network.** No "decrypted ZIP to server" path.
-  (Contrast: `BackupService` today decrypts to a ZIP — keep that for the
-  *local export* feature only; it must not be reused as the sync transport.)
+- **Plaintext never crosses the network.** The decrypted-ZIP behavior of
+  `BackupService` stays limited to local export; it is not a sync
+  transport.
 - **The manifest is encrypted** with the vault master key (the same one
   wrapped by Argon2id on-device). The server holds `manifest.enc`.
-- **Credentials in `flutter_secure_storage`, never in `VaultSettings` JSON**
-  (which is itself stored in secure storage but should stay settings, not
-  secrets).
-- **TLS by default**, but WebDAV over plain HTTP on the LAN must be
-  explicitly allowed (self-hosted, self-signed certs, `.local` hostnames).
-  Present a clear "unencrypted connection" warning, do not silently downgrade.
-- **No implicit trust of server state.** Pull must verify GCM auth tags on
-  every blob before trusting it (corruption / tampering detection we already
-  have for re-encryption).
-- **Decoy vault is out of scope for v1 sync.** Syncing the decoy would leak
-  its existence and double the surface. Main vault only. Revisit later.
-
----
+- **Credentials live in `flutter_secure_storage`**, never in
+  `VaultSettings` JSON.
+- **TLS by default**; WebDAV over plain HTTP on the LAN (self-signed
+  certs, `.local` hostnames) is allowed only with an explicit warning, and
+  never by silent downgrade.
+- **No implicit trust of server state.** Pull verifies GCM auth tags on
+  every blob before trusting it.
+- **Decoy vault is out of scope for sync** (leaks its existence, doubles
+  the surface). Main vault only.
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                          UI                                   │
-│   Sync Settings screen · Sync Status chip · Sync Now button  │
-└──────────────────────────┬────────────────────────────────────┘
-                           │ Riverpod
-┌──────────────────────────▼────────────────────────────────────┐
-│                    SyncProvider (Notifier)                     │
-│   exposes status (idle/uploading/downloading/error) + lastSync │
-└──────────────────────────┬────────────────────────────────────┘
-                           │
-┌──────────────────────────▼────────────────────────────────────┐
-│                      SyncService                               │
-│  reconcile(): diff local vs remote manifest → plan → execute   │
-│  • push encrypted blobs (new/changed local)                    │
-│  • pull encrypted blobs (new/changed remote)                   │
-│  • tombstone deletes                                           │
-│  • write encrypted manifest last (commit point)                │
-└──────┬───────────────────────┬─────────────────────────────────┘
-       │                       │
-       ▼                       ▼
-┌──────────────┐      ┌────────────────────┐
-│ VaultStore   │      │ RemoteStore        │
-│ (exists)     │      │ (WebDAV transport) │
-│ local files, │      │ getManifest /      │
-│ local index  │      │ putManifest /      │
-│              │      │ getBlob / putBlob /│
-│              │      │ deleteBlob /       │
-│              │      │ listBlobs         │
-└──────────────┘      └─────────┬──────────┘
-                                │ HTTP
-                         ┌──────▼──────┐
-                         │ WebDAV server│
-                         │ (NAS/cloud)  │
-                         └──────────────┘
+UI ── Riverpod ── SyncProvider (Notifier: status idle/uploading/downloading/error, lastSync)
+                     │
+                     ▼
+               SyncService
+               reconcile(): diff local vs remote manifest → plan → execute
+               • push encrypted blobs (new/changed local)
+               • pull encrypted blobs (new/changed remote)
+               • tombstone deletes
+               • write encrypted manifest last (commit point)
+        ┌──────────┴───────────┐
+        ▼                      ▼
+  VaultStore             RemoteStore
+  (local files,          (WebDAV transport)
+   local index)          getManifest / putManifest /
+                         getBlob / putBlob / deleteBlob / listBlobs
+                                 │ HTTP
+                                 ▼
+                          WebDAV server (NAS / cloud)
 ```
 
 `SyncService` is the brain; `RemoteStore` is a thin transport abstraction
-(one interface, one WebDAV impl). The interface exists so SFTP/SMB can be
-added later behind the same `SyncService` — but only one impl ships now.
+(one interface, one WebDAV implementation) so SFTP/SMB can slot in later
+behind the same `SyncService`.
 
-### Server layout (what the user's NAS holds)
+### Server layout
 
 ```
 <basePath>/                     # SyncProfile.basePath, default /locker
   manifest.enc                  # encrypted index + metadata + tombstones
   ab/cd/abcd1234…enc            # content-addressed encrypted media (sha256 of ciphertext)
   ef/01/ef019876…enc
-  manifest.enc.sig              # [OPEN] GCM tag already authenticates; separate sig = YAGNI for v1
 ```
 
-Content-addressing the blobs by hash of the **ciphertext** gives us:
-dedupe (identical ciphertext across devices), easy diff (manifest lists
-hashes, not paths), and trivial rename/move (metadata-only change, blob
-unchanged). This is the same trick every content-addressed backup uses.
+Blobs are content-addressed by hash of the **ciphertext**: dedupe
+(identical ciphertext across devices), easy diff (manifest lists hashes,
+not paths), and trivial rename/move (metadata-only change). GCM tags
+already authenticate the manifest; a separate signature is YAGNI for v1.
 
----
+## Protocol
 
-## Protocol choice
-
-| Protocol | Verdict | Why |
+| Protocol | Verdict | Rationale |
 |---|---|---|
-| **WebDAV** | **v1** | HTTP. Every NAS/cloud speaks it. One package. `MKCOL`/`PUT`/`GET`/`DELETE`/`PROPFIND` is the whole API. |
-| SFTP | Deferred | Needs a heavy SSH client package (`dartssh2`); adds key management. Add only if asked. |
-| SMB | Deferred | jCIFS port on Android is fragile. Not worth it. |
-| Custom HTTP server | Rejected | Violates locked decision #3 (server stays dumb). |
+| **WebDAV** | **v1** | Plain HTTP; every NAS/Nextcloud/Synology/ownCloud/Seafile exposes it; one package. `MKCOL`/`PUT`/`GET`/`DELETE`/`PROPFIND` is the whole API. |
+| SFTP | Deferred | Heavy SSH client package (`dartssh2`), key management. Add only if asked. |
+| SMB | Deferred | jCIFS on Android is fragile. |
+| Custom HTTP server | Rejected | Server stays dumb. |
 
-Dependency: **`webdav_client`** (pub.dev). One package. Falls back to raw
-`package:http` + `PROPFIND` if its API is awkward, but try the package first.
-
----
+Dependency: `webdav_client` (pub.dev), v1.2.2. Falls back to raw
+`package:http` + `PROPFIND` if its API is awkward.
 
 ## Sync model
 
-**Last-write-wins per file, manifest-as-commit-point.**
+**Last-write-wins per file; manifest as commit point.**
 
-- Each `VaultedFile` already has a UUID `id` and we can add a `modifiedAt`
-  / `syncRev` field (see data changes). The manifest maps `id → {hash,
-  modifiedAt, deleted}`.
-- **Reconcile** = compare local manifest vs remote manifest by id:
-  - remote has id, local doesn't, not tombstoned → **pull**
-  - local has id, remote doesn't → **push**
+- Each `VaultedFile` has a UUID `id` plus `modifiedAt` / `syncRev`.
+  The manifest maps `id → {hash, modifiedAt, deleted}`.
+- **Reconcile** compares local vs remote manifest by id:
+  - remote has id, local doesn't, not tombstoned → pull
+  - local has id, remote doesn't → push
   - both have it, hashes differ → newer `modifiedAt` wins; loser is
-    overwritten. (No three-way merge v1 — YAGNI. Flag a conflict note in UI
-    if both changed since last sync.)
-  - either side tombstoned (deleted) → propagate delete.
-- **Manifest is the commit point.** Upload/download all blobs first; the
-  manifest write is atomic-ish (PUT replaces the whole file). If we crash
-  mid-sync, the old manifest still describes a consistent older state and
-  the next run resumes. Re-running sync is always safe (idempotent).
-- **No partial-file sync.** Files are atomic units. A video is fully
-  re-pushed on change (it's encrypted; no delta possible anyway).
+    overwritten (no three-way merge in v1; a conflict note is flagged in
+    the UI if both sides changed since last sync)
+  - either side tombstoned → propagate delete
+- **Manifest is the commit point.** Blobs are uploaded/downloaded first;
+  the manifest write (PUT replaces the whole file) commits. A mid-sync
+  crash leaves the old manifest describing a consistent older state; the
+  next run resumes. Re-running sync is idempotent.
+- **No partial-file sync.** Files are atomic units; an encrypted video is
+  fully re-pushed on change (no delta possible).
 
-Direction control (setting):
-- **Push only** (backup to server) — simplest, recommended default.
-- **Two-way** (sync) — enable after push-only is proven.
-
----
+Direction is a setting: **push-only** (backup, recommended default) or
+**two-way** (enable after push-only is proven).
 
 ## Data & config changes
 
-- **New model:** `SyncProfile` (URL, username, base path, lastSyncAt,
-  syncDirection, wifiOnly) — stored in `flutter_secure_storage` as JSON.
-  Not in `VaultSettings` (keeps settings free of secrets). **DONE** — plus
-  `SyncProfileService` CRUD with per-profile password keys
-  (`sync_profile_pw_<id>`); passwords never live in the profile JSON.
-- **`VaultSettings` additions:** `bool syncEnabled = false`,
-  `String? syncProfileId`. **DONE** (`toJson`/`fromJson`/`copyWith`).
-- **`VaultedFile` additions:** `DateTime? modifiedAt`, `String? remoteHash`,
-  `bool syncedDeleted = false` (tombstone flag). **DONE**. Migration on load
-  (missing `modifiedAt` → file mtime) **PENDING** — lands with the VaultStore
-  manifest helpers.
-- **New:** `RemoteManifest` model (`version`, `deviceId`, `generatedAt`,
-  `entries: [{id, contentHash, modifiedAt, deleted}]`). **DONE**.
-
----
+- **`SyncProfile`** (URL, username, base path, lastSyncAt, syncDirection,
+  wifiOnly) — stored in `flutter_secure_storage` as JSON, kept out of
+  `VaultSettings`. Done, plus `SyncProfileService` CRUD with per-profile
+  password keys (`sync_profile_pw_<id>`); passwords never live in the
+  profile JSON.
+- **`VaultSettings` additions:** `syncEnabled` (bool, default false),
+  `syncProfileId` (String?). Done.
+- **`VaultedFile` additions:** `modifiedAt`, `remoteHash`, `syncedDeleted`
+  (tombstone flag). Done. No load-time migration: `runSync` backfills
+  `modifiedAt` lazily (sync completion time when missing);
+  `buildManifest` falls back to `dateModified` → `dateAdded`.
+- **`RemoteManifest`** model (`version`, `deviceId`, `generatedAt`,
+  `entries: [{id, contentHash, modifiedAt, deleted}]`). Done.
+- **`SyncService`** is Riverpod-native: instance ctor
+  `SyncService(VaultStore, EncryptionService)` via `syncServiceProvider`
+  (no singleton). Pure diff/manifest logic is static; `runSync` is static
+  and param-driven (testable with a fake `RemoteStore`); `syncNow` is the
+  thin instance glue. Two-way restore is deferred to S3, so the manifest
+  schema stays lean; full-metadata restore needs a version bump then.
 
 ## Phased plan
 
-Phases are ordered by dependency. Each is independently shippable.
+### S0 — Transport + credentials (1–2 days)
 
-### Phase S0 — Transport + creds (no sync logic) — ~1-2 days
+| # | Task | Location | Status |
+|---|---|---|---|
+| S0.1 | Add `webdav_client` dep (1.2.2) | `pubspec.yaml` | Done |
+| S0.2 | `RemoteStore` interface + WebDAV impl: `ping`, `getManifest`, `putManifest`, `getBlob`, `putBlob`, `deleteBlob`, `listBlobs` | `lib/services/remote/` | Done |
+| S0.3 | `SyncProfile` model + secure-storage CRUD | `lib/models/sync_profile.dart`, `lib/services/sync_profile_service.dart` | Done |
+| S0.4 | Connection settings UI: URL/user/password, "Test connection", TLS warning for plain HTTP | `lib/screens/sync_settings_screen.dart` | Done |
+| S0.5 | Live-server roundtrip: connect to a real WebDAV URL, put/get a tiny blob, assert roundtrip | test / self-check | Pending (path-logic unit tests in `test/webdav_store_test.dart` pass) |
 
-| # | Task | Location |
-|---|---|---|
-| [x] S0.1 | Add `webdav_client` dep (1.2.2) | `pubspec.yaml` |
-| [x] S0.2 | `RemoteStore` interface + WebDAV impl: `ping`, `getManifest`, `putManifest`, `getBlob`, `putBlob`, `deleteBlob`, `listBlobs` | `lib/services/remote/` |
-| [x] S0.3 | `SyncProfile` model + secure-storage CRUD | `lib/models/sync_profile.dart`, `lib/services/sync_profile_service.dart` |
-| [ ] S0.4 | Connection settings UI: URL/user/password, "Test connection" button, TLS warning for plain HTTP | `lib/screens/sync_settings_screen.dart` (new) |
-| [~] S0.5 | One runnable self-check: connect to a WebDAV URL, put/get a tiny blob, assert roundtrip — so far only path/URL-logic unit tests (`test/webdav_store_test.dart`); live-server roundtrip pending | test or `__main__`-style check |
+**Verify:** connect to a real WebDAV server (Nextcloud demo or
+`rclone serve webdav`), roundtrip a blob; credentials persist across
+restart.
 
-**Verify:** connect to a real WebDAV server (Nextcloud demo or local
-`rclone serve webdav`), roundtrip a blob. Credentials persist across restart.
+### S1 — Encrypted manifest (1–2 days)
 
-### Phase S1 — Encrypted manifest — ~1-2 days
-
-| # | Task | Location |
-|---|---|---|
-| [x] S1.1 | `RemoteManifest` model + JSON (de)serialize | `lib/models/remote_manifest.dart` |
-| [~] S1.2 | Build manifest from `VaultStore` index; encrypt with master key; decrypt on read — `buildManifest` + `encryptManifest`/`decryptManifest` done (pure, tested); VaultStore index wiring pending | `SyncService.buildManifest` / `readManifest` |
-| [x] S1.3 | Content-address blob naming (sha256 of ciphertext, sharded `ab/cd/`) | `SyncService.blobNameFor` |
-| [ ] S1.4 | Push/pull manifest only (no blobs yet) — proves the crypto + transport glue | extends S0 |
+| # | Task | Location | Status |
+|---|---|---|---|
+| S1.1 | `RemoteManifest` model + JSON (de)serialize | `lib/models/remote_manifest.dart` | Done |
+| S1.2 | Build manifest from `VaultStore` index; encrypt with master key; decrypt on read | `SyncService.buildManifest` / `runSync` | Done |
+| S1.3 | Content-addressed blob naming (sha256 of ciphertext, sharded `ab/cd/`) | `SyncService.blobNameFor` | Done |
+| S1.4 | Push/pull manifest only (no blobs yet) — proves crypto + transport glue | extends S0 | Done |
 
 **Verify:** upload encrypted manifest, wipe local, pull manifest back,
-decrypt, assert it equals the original index. Plaintext never leaves device
-(confirmed by inspecting server).
+decrypt, assert it equals the original index; inspect the server to
+confirm no plaintext left the device.
 
-### Phase S2 — Push-only backup — ~2-3 days
+### S2 — Push-only backup (2–3 days)
 
-| # | Task | Location |
-|---|---|---|
-| [x] S2.1 | `reconcile()` diff engine (local vs remote manifest) → plan (push/pull/delete lists) — covers tombstone deletion and two-way pull cases | `SyncService.reconcile` |
-| [ ] S2.2 | Execute push plan: upload new/changed blobs, then commit manifest | `SyncService.runSync` |
-| [ ] S2.3 | `SyncProvider` (Riverpod Notifier): status enum, progress, `syncNow()` | `lib/providers/sync_provider.dart` |
-| [ ] S2.4 | `connectivity_plus` guard: respect wifiOnly / connected; resubscribe like `update_service.dart:74` | `SyncService` / provider |
-| [ ] S2.5 | UI: status chip + "Sync now" in settings; progress reporting | sync settings screen + a drawer entry |
-| [~] S2.6 | One behavioral test: seed vault, sync, assert every local file has a remote blob + manifest lists it — reconcile/crypto tests in place; seed-vault behavioral test pending | `test/sync_service_test.dart` |
+| # | Task | Location | Status |
+|---|---|---|---|
+| S2.1 | `reconcile()` diff engine (local vs remote manifest) → plan (push/pull/delete lists), covers tombstone deletion and two-way pull cases | `SyncService.reconcile` | Done |
+| S2.2 | Execute push plan: upload new/changed blobs, then commit manifest (static `runSync`, manifest last, idempotent) | `SyncService.runSync` | Done |
+| S2.3 | `SyncProvider` (Riverpod Notifier): status enum, progress, `syncNow()` | `lib/providers/sync_provider.dart` | Done |
+| S2.4 | `connectivity_plus` guard (wifiOnly / connected) in `SyncNotifier.syncNow()`; keeps `runSync` pure | `SyncNotifier` | Done |
+| S2.5 | UI: status card + "Sync now" in settings, progress reporting, drawer entry via vault settings "Server Sync" | `sync_settings_screen.dart`, `vault_settings_screen.dart` | Done |
+| S2.6 | Behavioral test: seed vault, sync, assert every local file has a remote blob and the manifest lists it; plus tombstone reaping and idempotent re-run (`_MemStore` fake `RemoteStore`) | `test/sync_service_test.dart` | Done |
 
 **Verify:** fill vault, push to server, inspect server (all opaque `.enc`),
 wipe app data, reinstall → pull restores the vault intact (decrypt +
 auth-tag verify per file).
 
-### Phase S3 — Two-way sync — ~2-3 days
+### S3 — Two-way sync (2–3 days)
 
-| # | Task | Location |
-|---|---|---|
-| S3.1 | Pull path: download missing/changed blobs, verify GCM auth tag, import into `VaultStore` | `SyncService` pull branch |
-| S3.2 | Last-write-wins resolution + conflict UI note when both sides changed | `reconcile` |
-| S3.3 | Tombstone propagation (delete on one device → delete on other, with a confirmation) | `reconcile` + UI |
-| S3.4 | Two-device roundtrip test | manual + scripted |
+| # | Task | Location | Status |
+|---|---|---|---|
+| S3.1 | Pull path: download missing/changed blobs, verify GCM auth tag, import into `VaultStore` | `SyncService` pull branch | Pending |
+| S3.2 | Last-write-wins resolution + conflict UI note when both sides changed | `reconcile` | Pending |
+| S3.3 | Tombstone propagation (delete on one device → delete on other, with confirmation) | `reconcile` + UI | Pending |
+| S3.4 | Two-device roundtrip test | manual + scripted | Pending |
 
 **Verify:** device A adds files → sync → device B pulls them; device B
-edits → sync → device A sees edit; delete on A → propagates to B.
+edits → sync → device A sees the edit; delete on A propagates to B.
 
-### Phase S4 — Polish / scheduling (optional) — defer
+### S4 — Polish / scheduling (optional, deferred)
 
 Background sync via WorkManager, conflict-resolution UX, per-album sync
-filters, restore-from-server onboarding flow. Ship S3 first; only build S4
-if the feature gets used.
+filters, restore-from-server onboarding. Ship S3 first; build S4 only if
+the feature gets used.
 
----
+## Files
 
-## New files
-
-```
-lib/models/sync_profile.dart            sync profile (creds live in secure storage)           [x]
-lib/models/remote_manifest.dart         encrypted manifest schema                             [x]
-lib/services/remote/remote_store.dart   transport interface                                   [x]
-lib/services/remote/webdav_store.dart   WebDAV impl                                           [x]
-lib/services/sync_profile_service.dart  secure-storage CRUD for profiles                      [x]
-lib/services/sync_service.dart          reconcile + runSync (pure logic done, runSync pending)[~]
-lib/providers/sync_provider.dart        Riverpod status Notifier                             [ ]
-lib/screens/sync_settings_screen.dart   connection + sync UI                                 [ ]
-test/sync_service_test.dart             behavioral net (reconcile + manifest crypto now)      [x]
-test/webdav_store_test.dart             transport path-logic self-check (S0.5, partial)       [x]
-```
-
-## Files changed
+New:
 
 ```
-pubspec.yaml                              + webdav_client (1.2.2)              [x]
-lib/models/vault_settings.dart            + syncEnabled, syncProfileId         [x]
-lib/models/vaulted_file.dart              + modifiedAt, remoteHash, syncedDeleted [x]
-lib/services/vault_store.dart             manifest build/read helpers, blob hashing [ ]
-lib/providers/vault_providers.dart        wire SyncProvider after Phase 4 lands [ ]
-main.dart / drawer                        entry point to sync settings          [ ]
+lib/models/sync_profile.dart            sync profile (creds in secure storage)    [done]
+lib/models/remote_manifest.dart         encrypted manifest schema                 [done]
+lib/services/remote/remote_store.dart   transport interface                       [done]
+lib/services/remote/webdav_store.dart   WebDAV impl                               [done]
+lib/services/sync_profile_service.dart  secure-storage CRUD for profiles          [done]
+lib/services/sync_service.dart          reconcile + runSync (push-only done; pull = S3) [done]
+lib/providers/sync_provider.dart        Riverpod status Notifier                  [done]
+lib/screens/sync_settings_screen.dart   connection + sync UI                      [done]
+test/sync_service_test.dart             behavioral net (reconcile + manifest crypto) [done]
+test/webdav_store_test.dart             transport path-logic self-check (S0.5 partial) [done]
 ```
 
----
+Changed:
+
+```
+pubspec.yaml                              + webdav_client (1.2.2)                [done]
+lib/models/vault_settings.dart            + syncEnabled, syncProfileId           [done]
+lib/models/vaulted_file.dart              + modifiedAt, remoteHash, syncedDeleted [done]
+lib/services/vault_service.dart           + `store` getter (shares VaultStore w/ Riverpod services) [done]
+lib/providers/sync_provider.dart          wires syncServiceProvider + syncProvider [done]
+lib/screens/vault_settings_screen.dart    + "Server Sync" entry in Storage section [done]
+```
 
 ## Dependencies
 
-- **Add:** `webdav_client` (one package) — **done**, v1.2.2.
-- **Reuse:** `connectivity_plus` (already present), `flutter_secure_storage`
-  (already present), existing `lib/crypto/` (no new crypto code).
+- **Add:** `webdav_client` v1.2.2 (done).
+- **Reuse:** `connectivity_plus`, `flutter_secure_storage`, existing
+  `lib/crypto/` — no new crypto code.
 
 ## Verification discipline
 
 Per the refactor roadmap's test rules: no per-method suites, one happy-path
-test per phase, one failure path for anything security-touching. Each phase
-leaves one runnable check (assert-based `__main__` or a `test_*.dart`) that
-fails if the phase's logic breaks. Manual two-device roundtrip is the real
+test per phase, one failure path for anything security-touching. Each
+phase leaves one runnable check (assert-based self-check or a `test_*.dart`)
+that fails if the phase's logic breaks. Manual two-device roundtrip is the
 acceptance test for S3.
 
----
+## Open decisions
 
-## Open questions (need your call)
-
-1. **[OPEN] Protocol scope:** WebDAV-only for v1 (this plan), or do you want
-   SFTP in scope too? WebDAV covers ~all NAS/cloud cases; SFTP roughly
-   doubles the transport work.
-2. **[OPEN] Push-only first vs. two-way from day one:** this plan ships
-   push-only (Phase S2) before two-way (S3). OK with that staging, or do you
-   want two-way as the first deliverable?
-3. **[OPEN] Decoy vault sync:** explicitly excluded in v1 (security). Confirm
-   you're fine leaving the decoy device-local.
-4. **[OPEN] Self-hosted only, or allow a public WebDAV provider too** (e.g.,
-   a paid WebDAV host)? Technically identical; just a policy / wording call
-   for the settings screen.
-5. **[OPEN] Timing vs. refactor Phase 4:** this plan assumes sync lands
-   Riverpod-native (after Phase 4). If you want it sooner, it'll ship as a
-   singleton and get migrated in Phase 4 — slightly more churn.
+1. **Protocol scope:** WebDAV only for v1, or SFTP too? WebDAV covers
+   ~all NAS/cloud cases; SFTP roughly doubles the transport work.
+2. **Staging:** push-only (S2) before two-way (S3), or two-way as the
+   first deliverable?
+3. **Decoy vault sync:** excluded in v1; confirm the decoy stays
+   device-local.
+4. **Public WebDAV providers** (e.g. paid WebDAV hosts) allowed, or
+   self-hosted only? Technically identical; a wording call for the
+   settings screen.
+5. **Timing vs. refactor Phase 4:** sync lands Riverpod-native after
+   Phase 4. If needed sooner it ships as a singleton and is migrated in
+   Phase 4 — slightly more churn.

--- a/docs/local_server_sync.md
+++ b/docs/local_server_sync.md
@@ -8,9 +8,11 @@ user-chosen server (NAS, home server, or self-hosted cloud), push and pull.
 The server never sees plaintext: it is dumb encrypted blob storage.
 
 Status: **In progress**. S0 (transport + credentials), S1 (manifest
-crypto), and S2 (push-only backup: reconcile, `runSync`, provider,
-connectivity guard, UI) are implemented and unit-tested (92 tests pass).
-Pending: S0.5 live-server roundtrip, S3 (two-way pull/restore).
+crypto), S2 (push-only backup: reconcile, `runSync`, provider,
+connectivity guard, UI), and S3 (two-way pull/restore: manifest v2, pull
+path, conflict flagging, tombstone propagation) are implemented and
+unit-tested (100 tests pass). Pending: S0.5 live-server roundtrip and
+S3.4 two-device roundtrip (both manual — need real WebDAV infra).
 
 ## Goals
 
@@ -148,8 +150,10 @@ Direction is a setting: **push-only** (backup, recommended default) or
   `SyncService(VaultStore, EncryptionService)` via `syncServiceProvider`
   (no singleton). Pure diff/manifest logic is static; `runSync` is static
   and param-driven (testable with a fake `RemoteStore`); `syncNow` is the
-  thin instance glue. Two-way restore is deferred to S3, so the manifest
-  schema stays lean; full-metadata restore needs a version bump then.
+  thin instance glue. S3 bumped the manifest to **v2**: `ManifestEntry`
+  now carries the full per-file metadata (name, type, mime, size, dates,
+  encryption fields, tags, favorite, album/folder ids) so a fresh device
+  can restore files. v1 manifests still deserialize (missing keys default).
 
 ## Phased plan
 
@@ -199,13 +203,34 @@ auth-tag verify per file).
 
 | # | Task | Location | Status |
 |---|---|---|---|
-| S3.1 | Pull path: download missing/changed blobs, verify GCM auth tag, import into `VaultStore` | `SyncService` pull branch | Pending |
-| S3.2 | Last-write-wins resolution + conflict UI note when both sides changed | `reconcile` | Pending |
-| S3.3 | Tombstone propagation (delete on one device → delete on other, with confirmation) | `reconcile` + UI | Pending |
+| S3.1 | Pull path: download missing/changed blobs, verify GCM auth tag, import into `VaultStore` | `SyncService` pull branch | Done |
+| S3.2 | Last-write-wins resolution + conflict UI note when both sides changed | `reconcile` | Done |
+| S3.3 | Tombstone propagation (delete on one device → delete on other, with confirmation) | `reconcile` + UI | Done |
 | S3.4 | Two-device roundtrip test | manual + scripted | Pending |
 
 **Verify:** device A adds files → sync → device B pulls them; device B
 edits → sync → device A sees the edit; delete on A propagates to B.
+(Covered by simulated two-device tests in `test/sync_service_test.dart`
+using an in-memory `RemoteStore`; the live two-device run is S3.4.)
+
+**S3 ceilings (deliberate simplifications):**
+
+- **Pull integrity** is satisfied transitively: the manifest is
+  GCM-authenticated (root of trust) and each pulled blob's sha256 must
+  equal the manifest's `contentHash`. A tampered/swapped blob breaks the
+  hash. A full decrypt-to-verify-the-tag is redundant (pushed files are
+  always decryptable); add it only if a non-vault blob could enter the
+  store.
+- **Conflict detection** flags only the local-newer-and-remote-diverged
+  case. The remote-newer direction can't be detected without hashing
+  local content, so a stale local edit overwritten by a pull is silent.
+  LWW still resolves both; three-way merge is an explicit non-goal.
+- **Tombstones** propagate automatically under LWW (no blocking
+  confirmation dialog); the reaped/deleted count is surfaced in the sync
+  summary. A pre-delete confirmation prompt is S4 polish.
+- **Albums/folders** collection definitions are not synced (S4); file-
+  level `albumIds`/`folderId` are carried, and the UI already tolerates
+  dangling references.
 
 ### S4 — Polish / scheduling (optional, deferred)
 

--- a/lib/models/remote_manifest.dart
+++ b/lib/models/remote_manifest.dart
@@ -3,17 +3,54 @@ import 'dart:convert';
 /// One entry in the remote manifest. Describes the synced state of a single
 /// vault file. [contentHash] is the sha256-hex of the ciphertext blob (used to
 /// derive its content-addressed name); null for tombstones that never uploaded.
+///
+/// v2 (S3) carries the full per-file metadata needed to *restore* a file on a
+/// device that has never seen it — the lean v1 schema (`id`/`contentHash`/
+/// `modifiedAt`/`deleted`) could push but not pull. All v2 fields are nullable
+/// or defaulted so a v1 manifest (missing the new keys) still deserializes.
 class ManifestEntry {
   final String id;
   final String? contentHash;
   final DateTime modifiedAt;
   final bool deleted;
 
+  // Restore metadata (v2). Null/default on tombstones and v1 manifests.
+  final String? originalName;
+  final String? type; // VaultedFileType.name
+  final String? mimeType;
+  final int? fileSize;
+  final DateTime? dateAdded;
+  final DateTime? dateModified;
+  final bool isEncrypted;
+  final String? encryptionIv;
+  final String? encryptionAlgorithm; // EncryptionAlgorithm.name
+  final String? keyDerivationSalt;
+  final int? kdfIterations;
+  final List<String> tags;
+  final bool isFavorite;
+  final List<String> albumIds;
+  final String? folderId;
+
   const ManifestEntry({
     required this.id,
     this.contentHash,
     required this.modifiedAt,
     this.deleted = false,
+    this.originalName,
+    this.type,
+    this.mimeType,
+    this.fileSize,
+    this.dateAdded,
+    this.dateModified,
+    this.isEncrypted = false,
+    this.encryptionIv,
+    this.encryptionAlgorithm,
+    this.keyDerivationSalt,
+    this.kdfIterations,
+    this.tags = const [],
+    this.isFavorite = false,
+    this.albumIds = const [],
+    this.folderId,
   });
 
   ManifestEntry copyWith({
@@ -21,12 +58,42 @@ class ManifestEntry {
     String? contentHash,
     DateTime? modifiedAt,
     bool? deleted,
+    String? originalName,
+    String? type,
+    String? mimeType,
+    int? fileSize,
+    DateTime? dateAdded,
+    DateTime? dateModified,
+    bool? isEncrypted,
+    String? encryptionIv,
+    String? encryptionAlgorithm,
+    String? keyDerivationSalt,
+    int? kdfIterations,
+    List<String>? tags,
+    bool? isFavorite,
+    List<String>? albumIds,
+    String? folderId,
   }) {
     return ManifestEntry(
       id: id ?? this.id,
       contentHash: contentHash ?? this.contentHash,
       modifiedAt: modifiedAt ?? this.modifiedAt,
       deleted: deleted ?? this.deleted,
+      originalName: originalName ?? this.originalName,
+      type: type ?? this.type,
+      mimeType: mimeType ?? this.mimeType,
+      fileSize: fileSize ?? this.fileSize,
+      dateAdded: dateAdded ?? this.dateAdded,
+      dateModified: dateModified ?? this.dateModified,
+      isEncrypted: isEncrypted ?? this.isEncrypted,
+      encryptionIv: encryptionIv ?? this.encryptionIv,
+      encryptionAlgorithm: encryptionAlgorithm ?? this.encryptionAlgorithm,
+      keyDerivationSalt: keyDerivationSalt ?? this.keyDerivationSalt,
+      kdfIterations: kdfIterations ?? this.kdfIterations,
+      tags: tags ?? List.from(this.tags),
+      albumIds: albumIds ?? List.from(this.albumIds),
+      isFavorite: isFavorite ?? this.isFavorite,
+      folderId: folderId ?? this.folderId,
     );
   }
 
@@ -35,6 +102,21 @@ class ManifestEntry {
         'contentHash': contentHash,
         'modifiedAt': modifiedAt.toIso8601String(),
         'deleted': deleted,
+        'originalName': originalName,
+        'type': type,
+        'mimeType': mimeType,
+        'fileSize': fileSize,
+        'dateAdded': dateAdded?.toIso8601String(),
+        'dateModified': dateModified?.toIso8601String(),
+        'isEncrypted': isEncrypted,
+        'encryptionIv': encryptionIv,
+        'encryptionAlgorithm': encryptionAlgorithm,
+        'keyDerivationSalt': keyDerivationSalt,
+        'kdfIterations': kdfIterations,
+        'tags': tags,
+        'isFavorite': isFavorite,
+        'albumIds': albumIds,
+        'folderId': folderId,
       };
 
   factory ManifestEntry.fromJson(Map<String, dynamic> json) {
@@ -43,6 +125,31 @@ class ManifestEntry {
       contentHash: json['contentHash'] as String?,
       modifiedAt: DateTime.parse(json['modifiedAt'] as String),
       deleted: json['deleted'] as bool? ?? false,
+      originalName: json['originalName'] as String?,
+      type: json['type'] as String?,
+      mimeType: json['mimeType'] as String?,
+      fileSize: (json['fileSize'] as num?)?.toInt(),
+      dateAdded: json['dateAdded'] != null
+          ? DateTime.parse(json['dateAdded'] as String)
+          : null,
+      dateModified: json['dateModified'] != null
+          ? DateTime.parse(json['dateModified'] as String)
+          : null,
+      isEncrypted: json['isEncrypted'] as bool? ?? false,
+      encryptionIv: json['encryptionIv'] as String?,
+      encryptionAlgorithm: json['encryptionAlgorithm'] as String?,
+      keyDerivationSalt: json['keyDerivationSalt'] as String?,
+      kdfIterations: (json['kdfIterations'] as num?)?.toInt(),
+      tags: (json['tags'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+      isFavorite: json['isFavorite'] as bool? ?? false,
+      albumIds: (json['albumIds'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+      folderId: json['folderId'] as String?,
     );
   }
 }
@@ -57,7 +164,7 @@ class RemoteManifest {
   final List<ManifestEntry> entries;
 
   const RemoteManifest({
-    this.version = 1,
+    this.version = 2,
     required this.deviceId,
     required this.generatedAt,
     this.entries = const [],
@@ -72,7 +179,7 @@ class RemoteManifest {
 
   factory RemoteManifest.fromJson(Map<String, dynamic> json) {
     return RemoteManifest(
-      version: json['version'] as int? ?? 1,
+      version: json['version'] as int? ?? 2,
       deviceId: json['deviceId'] as String,
       generatedAt: DateTime.parse(json['generatedAt'] as String),
       entries: (json['entries'] as List<dynamic>?)

--- a/lib/providers/sync_provider.dart
+++ b/lib/providers/sync_provider.dart
@@ -1,0 +1,138 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/sync_profile.dart';
+import '../services/encryption_service.dart';
+import '../services/sync_profile_service.dart';
+import '../services/sync_service.dart';
+import 'vault_providers.dart';
+
+/// Sync UI status.
+enum SyncStatus { idle, syncing, success, error }
+
+/// Observable sync state surfaced to the settings screen.
+class SyncState {
+  final SyncStatus status;
+  final DateTime? lastSync;
+  final String? error;
+  final SyncProgress? progress;
+
+  const SyncState({
+    this.status = SyncStatus.idle,
+    this.lastSync,
+    this.error,
+    this.progress,
+  });
+
+  bool get isSyncing => status == SyncStatus.syncing;
+
+  SyncState copyWith({
+    SyncStatus? status,
+    DateTime? lastSync,
+    String? error,
+    SyncProgress? progress,
+  }) =>
+      SyncState(
+        status: status ?? this.status,
+        lastSync: lastSync ?? this.lastSync,
+        error: error,
+        progress: progress ?? this.progress,
+      );
+}
+
+/// Riverpod-constructed [SyncService] — NOT a singleton (locked decision #5).
+/// Shares [VaultStore]/[EncryptionService] state with the rest of the app.
+final syncServiceProvider = Provider<SyncService>((ref) {
+  final vault = ref.read(vaultServiceProvider);
+  return SyncService(vault.store, EncryptionService.instance);
+});
+
+/// Drives sync + exposes status. The connectivity guard (locked decision #4,
+/// reusing connectivity_plus) lives here so [SyncService.runSync] stays pure.
+class SyncNotifier extends Notifier<SyncState> {
+  @override
+  SyncState build() => const SyncState();
+
+  Future<void> syncNow() async {
+    final settings = await ref.read(vaultServiceProvider).getSettings();
+    final profileId = settings.syncProfileId;
+    if (profileId == null || !settings.syncEnabled) {
+      state = const SyncState(
+        status: SyncStatus.error,
+        error: 'Sync is not configured. Add a server profile first.',
+      );
+      return;
+    }
+
+    final profile = await SyncProfileService.instance.getProfile(profileId);
+    if (profile == null) {
+      state = const SyncState(
+        status: SyncStatus.error,
+        error: 'Sync profile not found.',
+      );
+      return;
+    }
+
+    if (profile.wifiOnly) {
+      final results = await Connectivity().checkConnectivity();
+      final onWifi = results.any((r) => r == ConnectivityResult.wifi);
+      if (!onWifi) {
+        state = const SyncState(
+          status: SyncStatus.error,
+          error: 'Waiting for Wi-Fi.',
+        );
+        return;
+      }
+    }
+
+    final password =
+        await SyncProfileService.instance.getPassword(profile.id) ?? '';
+    final deviceId = await SyncProfileService.instance.getDeviceId();
+
+    state = SyncState(
+      status: SyncStatus.syncing,
+      progress: const SyncProgress(),
+    );
+
+    try {
+      final service = ref.read(syncServiceProvider);
+      final result = await service.syncNow(
+        profile: profile,
+        password: password,
+        deviceId: deviceId,
+        onProgress: (p) => state = state.copyWith(
+          status: SyncStatus.syncing,
+          progress: p,
+        ),
+      );
+
+      // Persist refreshed remoteHash/modifiedAt so the next run dedups.
+      final vault = ref.read(vaultServiceProvider);
+      vault.store.cachedFiles = result.refreshedLocal;
+      await vault.store.saveFileIndex();
+      await SyncProfileService.instance
+          .saveProfile(profile.copyWith(lastSyncedAt: result.completedAt));
+
+      state = SyncState(
+        status: SyncStatus.success,
+        lastSync: result.completedAt,
+      );
+    } catch (e) {
+      state = SyncState(status: SyncStatus.error, error: e.toString());
+    }
+  }
+
+  void clearError() {
+    state = const SyncState();
+  }
+}
+
+final syncProvider =
+    NotifierProvider<SyncNotifier, SyncState>(SyncNotifier.new);
+
+/// All stored sync profiles (for the settings screen list). Refreshed by
+/// invalidating after a save/delete.
+final syncProfilesProvider =
+    FutureProvider<List<SyncProfile>>((ref) async {
+  return SyncProfileService.instance.listProfiles();
+});

--- a/lib/providers/sync_provider.dart
+++ b/lib/providers/sync_provider.dart
@@ -16,12 +16,20 @@ class SyncState {
   final DateTime? lastSync;
   final String? error;
   final SyncProgress? progress;
+  /// Human summary of the last completed run (e.g. "2 pushed · 1 pulled"),
+  /// including a conflict count if both sides changed. Cleared on the next run.
+  final String? message;
+
+  /// Wall-clock time the last successful run took.
+  final Duration? duration;
 
   const SyncState({
     this.status = SyncStatus.idle,
     this.lastSync,
     this.error,
     this.progress,
+    this.message,
+    this.duration,
   });
 
   bool get isSyncing => status == SyncStatus.syncing;
@@ -31,12 +39,16 @@ class SyncState {
     DateTime? lastSync,
     String? error,
     SyncProgress? progress,
+    String? message,
+    Duration? duration,
   }) =>
       SyncState(
         status: status ?? this.status,
         lastSync: lastSync ?? this.lastSync,
         error: error,
         progress: progress ?? this.progress,
+        message: message ?? this.message,
+        duration: duration ?? this.duration,
       );
 }
 
@@ -96,15 +108,13 @@ class SyncNotifier extends Notifier<SyncState> {
 
     try {
       final service = ref.read(syncServiceProvider);
+      final sw = Stopwatch()..start();
       final result = await service.syncNow(
         profile: profile,
         password: password,
         deviceId: deviceId,
-        onProgress: (p) => state = state.copyWith(
-          status: SyncStatus.syncing,
-          progress: p,
-        ),
       );
+      sw.stop();
 
       // Persist refreshed remoteHash/modifiedAt so the next run dedups.
       final vault = ref.read(vaultServiceProvider);
@@ -116,6 +126,8 @@ class SyncNotifier extends Notifier<SyncState> {
       state = SyncState(
         status: SyncStatus.success,
         lastSync: result.completedAt,
+        message: _summarize(result),
+        duration: sw.elapsed,
       );
     } catch (e) {
       state = SyncState(status: SyncStatus.error, error: e.toString());
@@ -124,6 +136,21 @@ class SyncNotifier extends Notifier<SyncState> {
 
   void clearError() {
     state = const SyncState();
+  }
+
+  /// One-line summary of a completed run for the status card. Conflicts are
+  /// surfaced here (S3.2) since LWW still resolves them silently.
+  static String _summarize(SyncResult r) {
+    final parts = <String>[];
+    if (r.blobsPushed > 0) parts.add('${r.blobsPushed} pushed');
+    if (r.blobsPulled > 0) parts.add('${r.blobsPulled} pulled');
+    if (r.blobsDeleted > 0) parts.add('${r.blobsDeleted} reaped');
+    if (r.blobsSkipped > 0) parts.add('${r.blobsSkipped} skipped');
+    if (r.plan.conflicts.isNotEmpty) {
+      parts.add('${r.plan.conflicts.length} conflict'
+          '${r.plan.conflicts.length == 1 ? '' : 's'}');
+    }
+    return parts.isEmpty ? 'Up to date' : parts.join(' · ');
   }
 }
 

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -21,6 +21,7 @@ import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 import '../utils/responsive_utils.dart';
 import '../widgets/encrypted_thumbnail.dart';
+import '../widgets/floating_capsule_bottom_bar.dart';
 import '../widgets/file_info_sheet.dart';
 import '../widgets/office_conversion_confirm_dialog.dart';
 import '../widgets/per_file_encryption_sheet.dart';
@@ -86,6 +87,7 @@ class GalleryVaultScreen extends ConsumerStatefulWidget {
 class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
   VaultCategory _selectedCategory = VaultCategory.all;
   List<VaultCategory> _enabledCategories = VaultCategory.values;
+  FeatureSide _importSide = FeatureSide.right;
   late final PageController _pageController;
   final FileImportService _importService = FileImportService.instance;
   final Map<String, GlobalKey> _selectionTileKeys = {};
@@ -159,6 +161,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
 
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      extendBody: true,
       appBar: _buildAppBar(isSelectionMode, selectedFiles),
       body: Column(
         children: [
@@ -412,112 +415,44 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
   }
 
   Widget _buildBottomBar(bool isSelectionMode) {
-    return Container(
-      decoration: BoxDecoration(
-        color: context.backgroundColor,
-        border: Border(
-          top: BorderSide(color: context.dividerColor, width: 1),
-        ),
-      ),
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.only(top: 10),
-          child: SizedBox(
-            height: 64,
-            child: Row(
-              children: [
-                if (!isSelectionMode) _buildImportBarItem(),
-                ..._enabledCategories.map(_buildCategoryItem),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+    final tabs = _enabledCategories
+        .map((c) => NavTab(
+              icon: c.icon,
+              label: c.label,
+              selected: c == _selectedCategory,
+              onTap: () {
+                final index = _enabledCategories.indexOf(c);
+                _pageController.animateToPage(
+                  index,
+                  duration: const Duration(milliseconds: 220),
+                  curve: Curves.easeOutCubic,
+                );
+              },
+            ))
+        .toList();
 
-  Widget _buildImportBarItem() {
-    return Expanded(
-      child: Tooltip(
-        message: 'Import files',
-        child: InkWell(
-          onTap: _showImportDialog,
-          customBorder: const CircleBorder(),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  gradient: LinearGradient(
-                    colors: [
-                      context.accentColor,
-                      context.accentColor.withValues(alpha: 0.8),
-                    ],
-                  ),
-                ),
-                child: const Icon(Icons.add, color: Colors.white, size: 22),
-              ),
-              const SizedBox(height: 2),
-              Text(
-                'Import',
-                style: TextStyle(
-                  fontFamily: 'ProductSans',
-                  fontSize: 11,
-                  color: context.textSecondary,
-                ),
-              ),
-            ],
-          ),
-        ),
+    return FloatingCapsuleBottomBar(
+      tabs: tabs,
+      feature: NavTab(
+        icon: Icons.add,
+        label: 'Import',
+        selected: false,
+        onTap: _showImportDialog,
       ),
-    );
-  }
-
-  Widget _buildCategoryItem(VaultCategory category) {
-    final selected = category == _selectedCategory;
-    final color = selected ? context.accentColor : AppColors.lightTextTertiary;
-    return Expanded(
-      child: Tooltip(
-        message: category.label,
-        child: InkWell(
-          onTap: () {
-            final index = _enabledCategories.indexOf(category);
-            _pageController.animateToPage(
-              index,
-              duration: const Duration(milliseconds: 220),
-              curve: Curves.easeOutCubic,
-            );
-          },
-          customBorder: const CircleBorder(),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(category.icon, size: 24, color: color),
-              const SizedBox(height: 2),
-              Text(
-                category.label,
-                style: TextStyle(
-                  fontFamily: 'ProductSans',
-                  fontSize: 11,
-                  fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
-                  color: color,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+      featureSide: _importSide,
+      showFeature: !isSelectionMode,
     );
   }
 
   static const _enabledCategoriesKey = 'gallery_bottom_bar_categories';
+  static const _importSideKey = 'gallery_bottom_bar_import_side';
 
   Future<void> _loadEnabledCategories() async {
     final prefs = await SharedPreferences.getInstance();
+    final sideRaw = prefs.getString(_importSideKey);
+    if (sideRaw == 'left' || sideRaw == 'right') {
+      _importSide = sideRaw == 'left' ? FeatureSide.left : FeatureSide.right;
+    }
     final raw = prefs.getStringList(_enabledCategoriesKey);
     if (raw == null || raw.isEmpty) return;
     final parsed = <VaultCategory>[];
@@ -549,6 +484,14 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
     await prefs.setStringList(
       _enabledCategoriesKey,
       _enabledCategories.map((c) => c.name).toList(),
+    );
+  }
+
+  Future<void> _persistImportSide() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _importSideKey,
+      _importSide == FeatureSide.left ? 'left' : 'right',
     );
   }
 
@@ -683,6 +626,32 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
                       );
                     },
                   ),
+                ),
+                SwitchListTile(
+                  value: _importSide == FeatureSide.left,
+                  onChanged: (onLeft) {
+                    setState(() =>
+                        _importSide = onLeft ? FeatureSide.left : FeatureSide.right);
+                    _persistImportSide();
+                  },
+                  activeThumbColor: context.accentColor,
+                  secondary: Icon(
+                    Icons.add_circle_outline,
+                    color: context.accentColor,
+                  ),
+                  title: const Text(
+                    'Import button on left',
+                    style: TextStyle(fontFamily: 'ProductSans'),
+                  ),
+                  subtitle: Text(
+                    'Only applies when the bar has an even total (not centered)',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 12,
+                      color: context.textTertiary,
+                    ),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 20),
                 ),
                 Padding(
                   padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),

--- a/lib/screens/sync_settings_screen.dart
+++ b/lib/screens/sync_settings_screen.dart
@@ -1,0 +1,456 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/sync_profile.dart';
+import '../providers/sync_provider.dart';
+import '../providers/vault_providers.dart';
+import '../services/remote/webdav_store.dart';
+import '../services/sync_profile_service.dart';
+import '../themes/app_colors.dart';
+
+/// Connection settings + sync status for the local-server sync feature
+/// (docs/local_server_sync.md). One profile per vault (v1).
+class SyncSettingsScreen extends ConsumerStatefulWidget {
+  const SyncSettingsScreen({super.key});
+
+  @override
+  ConsumerState<SyncSettingsScreen> createState() => _SyncSettingsScreenState();
+}
+
+class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
+  final _urlController = TextEditingController();
+  final _userController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _basePathController = TextEditingController(text: '/locker');
+
+  SyncDirection _direction = SyncDirection.pushOnly;
+  bool _wifiOnly = true;
+  bool _enabled = false;
+  bool _isTesting = false;
+  bool _loading = true;
+  String? _activeProfileId;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadActiveProfile();
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _userController.dispose();
+    _passwordController.dispose();
+    _basePathController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadActiveProfile() async {
+    final settings = await ref.read(vaultServiceProvider).getSettings();
+    String? id = settings.syncProfileId;
+    SyncProfile? profile;
+    if (id != null) profile = await SyncProfileService.instance.getProfile(id);
+    profile ??= (await SyncProfileService.instance.listProfiles()).firstOrNull;
+
+    if (profile != null) {
+      _activeProfileId = profile.id;
+      _urlController.text = profile.serverUrl;
+      _userController.text = profile.username ?? '';
+      _basePathController.text = profile.basePath;
+      _direction = profile.direction;
+      _wifiOnly = profile.wifiOnly;
+      _enabled = profile.enabled;
+    }
+    if (mounted) setState(() => _loading = false);
+  }
+
+  bool get _isPlainHttp =>
+      _urlController.text.trim().toLowerCase().startsWith('http://');
+
+  SyncProfile _profileFromForm() => SyncProfile(
+        id: _activeProfileId ?? const Uuid().v4(),
+        serverUrl: _urlController.text.trim(),
+        username: _userController.text.trim().isEmpty
+            ? null
+            : _userController.text.trim(),
+        basePath:
+            _basePathController.text.trim().isEmpty
+                ? '/locker'
+                : _basePathController.text.trim(),
+        direction: _direction,
+        wifiOnly: _wifiOnly,
+        enabled: _enabled,
+      );
+
+  Future<void> _testConnection() async {
+    final url = _urlController.text.trim();
+    if (url.isEmpty) {
+      _snack('Enter a server URL first');
+      return;
+    }
+    setState(() => _isTesting = true);
+    try {
+      final password = _passwordController.text.isNotEmpty
+          ? _passwordController.text
+          : (_activeProfileId == null
+              ? ''
+              : await SyncProfileService.instance
+                      .getPassword(_activeProfileId!) ??
+                  '');
+      final store = WebDAVStore(
+        baseUrl: url,
+        username: _userController.text.trim(),
+        password: password,
+        basePath:
+            _basePathController.text.trim().isEmpty
+                ? '/locker'
+                : _basePathController.text.trim(),
+      );
+      await store.testConnection();
+      _snack('Connected ✓');
+    } catch (e) {
+      _snack('Connection failed: $e');
+    } finally {
+      if (mounted) setState(() => _isTesting = false);
+    }
+  }
+
+  Future<void> _save() async {
+    if (_urlController.text.trim().isEmpty) {
+      _snack('Server URL is required');
+      return;
+    }
+    final profile = _profileFromForm();
+    await SyncProfileService.instance.saveProfile(profile);
+    if (_passwordController.text.isNotEmpty) {
+      await SyncProfileService.instance
+          .savePassword(profile.id, _passwordController.text);
+      _passwordController.clear();
+    }
+    _activeProfileId = profile.id;
+
+    // Activate this profile in vault settings.
+    final settings = await ref.read(vaultServiceProvider).getSettings();
+    await ref.read(vaultServiceProvider).updateSettings(
+          settings.copyWith(syncEnabled: profile.enabled, syncProfileId: profile.id),
+        );
+    ref.invalidate(vaultSettingsProvider);
+    ref.invalidate(syncProfilesProvider);
+    if (mounted) _snack('Saved');
+  }
+
+  Future<void> _syncNow() async {
+    await ref.read(syncProvider.notifier).syncNow();
+  }
+
+  void _snack(String msg) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final syncState = ref.watch(syncProvider);
+
+    return Scaffold(
+      backgroundColor: context.backgroundColor,
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: context.textPrimary),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Server Sync',
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            color: context.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+      ),
+      body: _loading
+          ? Center(
+              child: CircularProgressIndicator(color: context.accentColor),
+            )
+          : ListView(
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+              children: [
+                _buildStatusCard(context, syncState),
+                const SizedBox(height: 20),
+                _sectionTitle(context, 'Server'),
+                _textField(
+                  controller: _urlController,
+                  label: 'Server URL',
+                  hint: 'https://nas.local/dav',
+                  keyboardType: TextInputType.url,
+                  onChanged: (_) => setState(() {}),
+                ),
+                if (_isPlainHttp) _plainHttpWarning(context),
+                _textField(
+                  controller: _userController,
+                  label: 'Username (optional)',
+                  hint: 'app-password user',
+                ),
+                _textField(
+                  controller: _passwordController,
+                  label: 'Password',
+                  hint: _activeProfileId == null
+                      ? 'app password'
+                      : 'leave blank to keep current',
+                  obscure: true,
+                ),
+                _textField(
+                  controller: _basePathController,
+                  label: 'Base path',
+                  hint: '/locker',
+                ),
+                const SizedBox(height: 8),
+                InputDecorator(
+                  decoration: _inputDecoration('Direction'),
+                  child: DropdownButtonHideUnderline(
+                    child: DropdownButton<SyncDirection>(
+                      value: _direction,
+                      isExpanded: true,
+                      items: const [
+                        DropdownMenuItem(
+                          value: SyncDirection.pushOnly,
+                          child: Text('Push only (backup)',
+                              style: TextStyle(fontFamily: 'ProductSans')),
+                        ),
+                        DropdownMenuItem(
+                          value: SyncDirection.twoWay,
+                          child: Text('Two-way',
+                              style: TextStyle(fontFamily: 'ProductSans')),
+                        ),
+                      ],
+                      onChanged: (v) =>
+                          setState(() => _direction = v ?? _direction),
+                    ),
+                  ),
+                ),
+                SwitchListTile(
+                  title: const Text('Wi-Fi only',
+                      style: TextStyle(fontFamily: 'ProductSans')),
+                  subtitle: Text(
+                    'Skip sync on mobile data',
+                    style: _subStyle(context),
+                  ),
+                  value: _wifiOnly,
+                  onChanged: (v) => setState(() => _wifiOnly = v),
+                  activeThumbColor: context.accentColor,
+                  contentPadding: EdgeInsets.zero,
+                ),
+                SwitchListTile(
+                  title: const Text('Enabled',
+                      style: TextStyle(fontFamily: 'ProductSans')),
+                  subtitle: Text(
+                    'Use this profile as the active sync target',
+                    style: _subStyle(context),
+                  ),
+                  value: _enabled,
+                  onChanged: (v) => setState(() => _enabled = v),
+                  activeThumbColor: context.accentColor,
+                  contentPadding: EdgeInsets.zero,
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: _isTesting ? null : _testConnection,
+                        child: _isTesting
+                            ? SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                    strokeWidth: 2, color: context.accentColor),
+                              )
+                            : const Text('Test Connection',
+                                style: TextStyle(fontFamily: 'ProductSans')),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton(
+                        onPressed: _save,
+                        child: const Text('Save',
+                            style: TextStyle(fontFamily: 'ProductSans')),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                Divider(color: context.borderColor),
+                const SizedBox(height: 20),
+                _sectionTitle(context, 'Sync'),
+                Text(
+                  'Push-only backup ships the vault as encrypted blobs to your '
+                  'server. Two-way restore is a later phase.',
+                  style: _subStyle(context),
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    icon: syncState.isSyncing
+                        ? SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: context.backgroundColor),
+                          )
+                        : const Icon(Icons.sync),
+                    label: Text(
+                        syncState.isSyncing ? 'Syncing…' : 'Sync Now',
+                        style: const TextStyle(fontFamily: 'ProductSans')),
+                    onPressed: syncState.isSyncing ? null : _syncNow,
+                  ),
+                ),
+                if (syncState.status == SyncStatus.error &&
+                    syncState.error != null) ...[
+                  const SizedBox(height: 12),
+                  _errorBanner(context, syncState.error!),
+                ],
+              ],
+            ),
+    );
+  }
+
+  Widget _buildStatusCard(BuildContext context, SyncState s) {
+    final (label, color) = switch (s.status) {
+      SyncStatus.idle => ('Idle', context.textTertiary),
+      SyncStatus.syncing => ('Syncing…', context.accentColor),
+      SyncStatus.success => ('Up to date', Colors.green),
+      SyncStatus.error => ('Error', AppColors.error),
+    };
+    final last = s.lastSync;
+    final progress = s.progress;
+    String? detail;
+    if (s.isSyncing && progress != null && progress.total > 0) {
+      detail = '${progress.phase.name} ${progress.completed}/${progress.total}';
+    } else if (last != null) {
+      detail = 'Last sync ${_formatDate(last)}';
+    }
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        children: [
+          Icon(s.status == SyncStatus.success
+              ? Icons.cloud_done_outlined
+              : s.status == SyncStatus.error
+                  ? Icons.error_outline
+                  : Icons.cloud_sync_outlined, color: color),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label,
+                    style: TextStyle(
+                        fontFamily: 'ProductSans',
+                        fontWeight: FontWeight.w600,
+                        color: context.textPrimary)),
+                if (detail != null)
+                  Text(detail, style: _subStyle(context)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _plainHttpWarning(BuildContext context) => Container(
+        width: double.infinity,
+        margin: const EdgeInsets.only(top: 8, bottom: 8),
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: AppColors.error.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: AppColors.error.withValues(alpha: 0.18)),
+        ),
+        child: Text(
+          'This URL is unencrypted. Credentials and data travel in plain text '
+          'over the network. Only use on a trusted LAN.',
+          style: TextStyle(
+              fontFamily: 'ProductSans', fontSize: 12, color: AppColors.error),
+        ),
+      );
+
+  Widget _errorBanner(BuildContext context, String msg) => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: AppColors.error.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: AppColors.error.withValues(alpha: 0.18)),
+        ),
+        child: Text(msg,
+            style: TextStyle(
+                fontFamily: 'ProductSans', fontSize: 12, color: AppColors.error)),
+      );
+
+  Widget _sectionTitle(BuildContext context, String title) => Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Text(title,
+            style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: context.textPrimary)),
+      );
+
+  TextStyle _subStyle(BuildContext context) => TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 12,
+        color: context.textTertiary,
+      );
+
+  InputDecoration _inputDecoration(String label) => InputDecoration(
+        labelText: label,
+        labelStyle: const TextStyle(fontFamily: 'ProductSans'),
+        border: const OutlineInputBorder(),
+      );
+
+  Widget _textField({
+    required TextEditingController controller,
+    required String label,
+    String? hint,
+    bool obscure = false,
+    TextInputType? keyboardType,
+    void Function(String)? onChanged,
+  }) =>
+      Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: TextField(
+          controller: controller,
+          obscureText: obscure,
+          keyboardType: keyboardType,
+          decoration: InputDecoration(
+            labelText: label,
+            hintText: hint,
+            labelStyle: const TextStyle(fontFamily: 'ProductSans'),
+            hintStyle: const TextStyle(fontFamily: 'ProductSans'),
+            border: const OutlineInputBorder(),
+          ),
+          onChanged: (v) => onChanged?.call(v),
+        ),
+      );
+
+  String _formatDate(DateTime d) {
+    final local = d.toLocal();
+    return '${local.day}/${local.month}/${local.year} '
+        '${local.hour.toString().padLeft(2, '0')}:'
+        '${local.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/screens/sync_settings_screen.dart
+++ b/lib/screens/sync_settings_screen.dart
@@ -7,10 +7,12 @@ import '../providers/sync_provider.dart';
 import '../providers/vault_providers.dart';
 import '../services/remote/webdav_store.dart';
 import '../services/sync_profile_service.dart';
+import '../services/sync_service.dart' show SyncPhase, SyncProgress;
 import '../themes/app_colors.dart';
 
 /// Connection settings + sync status for the local-server sync feature
-/// (docs/local_server_sync.md). One profile per vault (v1).
+/// (docs/local_server_sync.md). Supports multiple profiles; exactly one is
+/// "active" (the sync target), held in vault settings as [syncProfileId].
 class SyncSettingsScreen extends ConsumerStatefulWidget {
   const SyncSettingsScreen({super.key});
 
@@ -26,15 +28,124 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
 
   SyncDirection _direction = SyncDirection.pushOnly;
   bool _wifiOnly = true;
-  bool _enabled = false;
+
+  /// Profile currently loaded into the editor form. Null = a fresh profile
+  /// being created.
+  String? _editingId;
+
+  String? _activeId;
+  bool _masterEnabled = false;
+
   bool _isTesting = false;
   bool _loading = true;
-  String? _activeProfileId;
+  bool _obscurePassword = true;
+  final List<_SyncLogEntry> _log = [];
 
   @override
   void initState() {
     super.initState();
-    _loadActiveProfile();
+    _bootstrap();
+    ref.listen<SyncState>(syncProvider, _onSyncStateChanged);
+  }
+
+  /// One-shot load of settings + profiles; seeds the form with the active (or
+  /// first) profile. Reactive updates afterwards come from watching the
+  /// providers in [build], but form seeding only happens here and on explicit
+  // user actions — never on a provider re-emit.
+  Future<void> _bootstrap() async {
+    final settings = await ref.read(vaultServiceProvider).getSettings();
+    final profiles = await SyncProfileService.instance.listProfiles();
+    _activeId = settings.syncProfileId;
+    _masterEnabled = settings.syncEnabled;
+    final target =
+        (profiles.where((p) => p.id == _activeId).toList()).firstOrNull ??
+            profiles.firstOrNull;
+    _seedForm(target);
+    if (mounted) setState(() => _loading = false);
+  }
+
+  void _seedForm(SyncProfile? p) {
+    _editingId = p?.id;
+    _urlController.text = p?.serverUrl ?? '';
+    _userController.text = p?.username ?? '';
+    _basePathController.text =
+        p?.basePath.isEmpty == true ? '/locker' : (p?.basePath ?? '/locker');
+    _passwordController.clear();
+    _direction = p?.direction ?? SyncDirection.pushOnly;
+    _wifiOnly = p?.wifiOnly ?? true;
+  }
+
+  void _onSyncStateChanged(SyncState? prev, SyncState next) {
+    if (next.status == SyncStatus.success &&
+        prev?.status != SyncStatus.success) {
+      _addLog(next.message ?? 'Sync completed', ok: true);
+      // Profile's lastSyncedAt was persisted by the notifier — refresh the list.
+      ref.invalidate(syncProfilesProvider);
+      _showSuccessSheet(next);
+    } else if (next.status == SyncStatus.error &&
+        prev?.status != SyncStatus.error) {
+      _addLog(next.error ?? 'Sync failed', ok: false);
+      _snack(next.error ?? 'Sync failed');
+    }
+  }
+
+  void _showSuccessSheet(SyncState s) {
+    if (!mounted) return;
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      backgroundColor: context.backgroundColor,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (ctx) => Padding(
+        padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.cloud_done, color: Colors.green, size: 48),
+            const SizedBox(height: 12),
+            Text(
+              'Sync complete',
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: ctx.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              s.message ?? 'Up to date',
+              textAlign: TextAlign.center,
+              style: _subStyle(ctx),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Completed in ${_formatDuration(s.duration)}',
+              style: _subStyle(ctx),
+            ),
+            const SizedBox(height: 20),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Done',
+                    style: TextStyle(fontFamily: 'ProductSans')),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _addLog(String message, {required bool ok}) {
+    if (!mounted) return;
+    setState(() {
+      _log.insert(0, _SyncLogEntry(DateTime.now(), message, ok));
+      if (_log.length > 50) _log.removeRange(50, _log.length);
+    });
   }
 
   @override
@@ -46,41 +157,23 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
     super.dispose();
   }
 
-  Future<void> _loadActiveProfile() async {
-    final settings = await ref.read(vaultServiceProvider).getSettings();
-    String? id = settings.syncProfileId;
-    SyncProfile? profile;
-    if (id != null) profile = await SyncProfileService.instance.getProfile(id);
-    profile ??= (await SyncProfileService.instance.listProfiles()).firstOrNull;
-
-    if (profile != null) {
-      _activeProfileId = profile.id;
-      _urlController.text = profile.serverUrl;
-      _userController.text = profile.username ?? '';
-      _basePathController.text = profile.basePath;
-      _direction = profile.direction;
-      _wifiOnly = profile.wifiOnly;
-      _enabled = profile.enabled;
-    }
-    if (mounted) setState(() => _loading = false);
-  }
-
   bool get _isPlainHttp =>
       _urlController.text.trim().toLowerCase().startsWith('http://');
 
+  bool get _editingActive => _editingId != null && _editingId == _activeId;
+
   SyncProfile _profileFromForm() => SyncProfile(
-        id: _activeProfileId ?? const Uuid().v4(),
+        id: _editingId ?? const Uuid().v4(),
         serverUrl: _urlController.text.trim(),
         username: _userController.text.trim().isEmpty
             ? null
             : _userController.text.trim(),
-        basePath:
-            _basePathController.text.trim().isEmpty
-                ? '/locker'
-                : _basePathController.text.trim(),
+        basePath: _basePathController.text.trim().isEmpty
+            ? '/locker'
+            : _basePathController.text.trim(),
         direction: _direction,
         wifiOnly: _wifiOnly,
-        enabled: _enabled,
+        enabled: true,
       );
 
   Future<void> _testConnection() async {
@@ -93,27 +186,56 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
     try {
       final password = _passwordController.text.isNotEmpty
           ? _passwordController.text
-          : (_activeProfileId == null
+          : (_editingId == null
               ? ''
-              : await SyncProfileService.instance
-                      .getPassword(_activeProfileId!) ??
+              : await SyncProfileService.instance.getPassword(_editingId!) ??
                   '');
       final store = WebDAVStore(
         baseUrl: url,
         username: _userController.text.trim(),
         password: password,
-        basePath:
-            _basePathController.text.trim().isEmpty
-                ? '/locker'
-                : _basePathController.text.trim(),
+        basePath: _basePathController.text.trim().isEmpty
+            ? '/locker'
+            : _basePathController.text.trim(),
       );
       await store.testConnection();
       _snack('Connected ✓');
+      _addLog('Connection test succeeded', ok: true);
     } catch (e) {
-      _snack('Connection failed: $e');
+      final msg = _describeConnError(e);
+      _snack(msg);
+      _addLog('Connection test failed: $msg', ok: false);
     } finally {
       if (mounted) setState(() => _isTesting = false);
     }
+  }
+
+  /// Map a WebDAV/Dio failure to something actionable. A connect timeout on a
+  /// LAN IP is always "server unreachable", never "timeout too short".
+  // ponytail: string-match on toString(); avoids importing transitive dio.
+  String _describeConnError(Object e) {
+    final s = e.toString().toLowerCase();
+    if (s.contains('connection timeout') || s.contains('connecttimeout')) {
+      return 'Couldn\'t reach the server (timed out). Check it\'s running on '
+          'the right port and bound to 0.0.0.0, not localhost.';
+    }
+    if (s.contains('connection refused') ||
+        s.contains('reset') ||
+        s.contains('broken pipe')) {
+      return 'Server refused the connection. Wrong port, or the WebDAV '
+          'service isn\'t running.';
+    }
+    if (s.contains('connection error') ||
+        s.contains('socket') ||
+        s.contains('network') ||
+        s.contains('host')) {
+      return 'Network error — wrong address, firewall, or device not on the '
+          'same LAN as the server.';
+    }
+    if (s.contains('401') || s.contains('unauthorized')) {
+      return 'Authentication failed — check username and password.';
+    }
+    return 'Connection failed: $e';
   }
 
   Future<void> _save() async {
@@ -121,6 +243,7 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
       _snack('Server URL is required');
       return;
     }
+    final isNew = _editingId == null;
     final profile = _profileFromForm();
     await SyncProfileService.instance.saveProfile(profile);
     if (_passwordController.text.isNotEmpty) {
@@ -128,19 +251,98 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
           .savePassword(profile.id, _passwordController.text);
       _passwordController.clear();
     }
-    _activeProfileId = profile.id;
+    _editingId = profile.id;
 
-    // Activate this profile in vault settings.
-    final settings = await ref.read(vaultServiceProvider).getSettings();
-    await ref.read(vaultServiceProvider).updateSettings(
-          settings.copyWith(syncEnabled: profile.enabled, syncProfileId: profile.id),
-        );
+    // New profiles (or when none is active yet) auto-activate so sync works.
+    if (isNew || _activeId == null) {
+      _activeId = profile.id;
+      _masterEnabled = true;
+      await _persistActivation(profile.id, enabled: true);
+    }
     ref.invalidate(vaultSettingsProvider);
     ref.invalidate(syncProfilesProvider);
     if (mounted) _snack('Saved');
   }
 
+  Future<void> _activate(SyncProfile p) async {
+    setState(() {
+      _activeId = p.id;
+      _masterEnabled = true;
+    });
+    await _persistActivation(p.id, enabled: true);
+    ref.invalidate(vaultSettingsProvider);
+    _snack('Active server: ${_hostOf(p.serverUrl)}');
+  }
+
+  Future<void> _setMasterEnabled(bool v) async {
+    setState(() => _masterEnabled = v);
+    final s = await ref.read(vaultServiceProvider).getSettings();
+    await ref
+        .read(vaultServiceProvider)
+        .updateSettings(s.copyWith(syncEnabled: v));
+    ref.invalidate(vaultSettingsProvider);
+  }
+
+  Future<void> _persistActivation(String id, {required bool enabled}) async {
+    final s = await ref.read(vaultServiceProvider).getSettings();
+    await ref.read(vaultServiceProvider).updateSettings(
+          s.copyWith(syncProfileId: id, syncEnabled: enabled),
+        );
+  }
+
+  Future<void> _confirmDelete(SyncProfile p) async {
+    final ok = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            backgroundColor: context.backgroundColor,
+            title: const Text('Remove server?',
+                style: TextStyle(fontFamily: 'ProductSans')),
+            content: Text(
+              'Delete the profile for ${_hostOf(p.serverUrl)}? '
+              'Encrypted blobs already on the server are left in place.',
+              style: _subStyle(ctx).copyWith(color: context.textSecondary),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Cancel',
+                    style: TextStyle(fontFamily: 'ProductSans')),
+              ),
+              FilledButton(
+                style: FilledButton.styleFrom(backgroundColor: AppColors.error),
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Delete',
+                    style: TextStyle(fontFamily: 'ProductSans')),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (!ok) return;
+    await SyncProfileService.instance.deleteProfile(p.id);
+    final wasActive = _activeId == p.id;
+    final wasEditing = _editingId == p.id;
+    if (wasActive) {
+      _activeId = null;
+      final s = await ref.read(vaultServiceProvider).getSettings();
+      await ref
+          .read(vaultServiceProvider)
+          .updateSettings(s.copyWith(syncProfileId: null));
+    }
+    if (wasEditing) {
+      final remaining = await SyncProfileService.instance.listProfiles();
+      _seedForm(remaining.firstOrNull);
+    }
+    ref.invalidate(vaultSettingsProvider);
+    ref.invalidate(syncProfilesProvider);
+    if (mounted) setState(() {});
+  }
+
   Future<void> _syncNow() async {
+    if (_activeId == null) {
+      _snack('Add and activate a server first');
+      return;
+    }
     await ref.read(syncProvider.notifier).syncNow();
   }
 
@@ -149,9 +351,17 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
   }
 
+  String _hostOf(String url) {
+    final u = Uri.tryParse(url);
+    return u?.host.isNotEmpty == true ? u!.host : url;
+  }
+
   @override
   Widget build(BuildContext context) {
     final syncState = ref.watch(syncProvider);
+    final profilesAsync = ref.watch(syncProfilesProvider);
+    final profiles = profilesAsync.asData?.value ?? const <SyncProfile>[];
+    final active = profiles.where((p) => p.id == _activeId).firstOrNull;
 
     return Scaffold(
       backgroundColor: context.backgroundColor,
@@ -176,86 +386,123 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
               child: CircularProgressIndicator(color: context.accentColor),
             )
           : ListView(
-              padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
               children: [
-                _buildStatusCard(context, syncState),
+                _HeroStatus(
+                  state: syncState,
+                  active: active,
+                  masterEnabled: _masterEnabled,
+                ),
                 const SizedBox(height: 20),
-                _sectionTitle(context, 'Server'),
-                _textField(
-                  controller: _urlController,
-                  label: 'Server URL',
-                  hint: 'https://nas.local/dav',
-                  keyboardType: TextInputType.url,
-                  onChanged: (_) => setState(() {}),
+
+                // ---- Profiles ----
+                _SectionHeader(
+                  title: 'Servers',
+                  trailing: TextButton.icon(
+                    onPressed: () => setState(_seedFormNull),
+                    icon: const Icon(Icons.add, size: 18),
+                    label: const Text('Add',
+                        style: TextStyle(fontFamily: 'ProductSans')),
+                  ),
                 ),
-                if (_isPlainHttp) _plainHttpWarning(context),
-                _textField(
-                  controller: _userController,
-                  label: 'Username (optional)',
-                  hint: 'app-password user',
-                ),
-                _textField(
-                  controller: _passwordController,
-                  label: 'Password',
-                  hint: _activeProfileId == null
-                      ? 'app password'
-                      : 'leave blank to keep current',
-                  obscure: true,
-                ),
-                _textField(
-                  controller: _basePathController,
-                  label: 'Base path',
-                  hint: '/locker',
-                ),
+                if (profiles.isEmpty)
+                  _emptyServersHint(context)
+                else
+                  ...profiles.map((p) => Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: _profileCard(context, p,
+                            isActive: p.id == _activeId),
+                      )),
                 const SizedBox(height: 8),
-                InputDecorator(
-                  decoration: _inputDecoration('Direction'),
-                  child: DropdownButtonHideUnderline(
-                    child: DropdownButton<SyncDirection>(
-                      value: _direction,
-                      isExpanded: true,
-                      items: const [
-                        DropdownMenuItem(
-                          value: SyncDirection.pushOnly,
-                          child: Text('Push only (backup)',
-                              style: TextStyle(fontFamily: 'ProductSans')),
+
+                // ---- Editor ----
+                _SectionHeader(
+                    title: _editingId == null ? 'New server' : 'Edit server'),
+                _card(context, [
+                  _field(
+                    controller: _urlController,
+                    label: 'Server URL',
+                    hint: 'https://nas.local/dav',
+                    keyboardType: TextInputType.url,
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  if (_isPlainHttp) _plainHttpWarning(context),
+                  _field(
+                    controller: _userController,
+                    label: 'Username (optional)',
+                    hint: 'app-password user',
+                  ),
+                  _passwordField(context),
+                  _field(
+                    controller: _basePathController,
+                    label: 'Base path',
+                    hint: '/locker',
+                  ),
+                ]),
+                const SizedBox(height: 12),
+                _SectionHeader(title: 'Options'),
+                _card(context, [
+                  _formLabel(context, 'Direction'),
+                  const SizedBox(height: 6),
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    child: InputDecorator(
+                      decoration: _fieldDecoration().copyWith(
+                        contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 4),
+                      ),
+                      child: DropdownButtonHideUnderline(
+                        child: DropdownButton<SyncDirection>(
+                          value: _direction,
+                          isExpanded: true,
+                          items: const [
+                            DropdownMenuItem(
+                              value: SyncDirection.pushOnly,
+                              child: Text('Push only (backup)',
+                                  style: TextStyle(fontFamily: 'ProductSans')),
+                            ),
+                            DropdownMenuItem(
+                              value: SyncDirection.twoWay,
+                              child: Text('Two-way',
+                                  style: TextStyle(fontFamily: 'ProductSans')),
+                            ),
+                          ],
+                          onChanged: (v) =>
+                              setState(() => _direction = v ?? _direction),
                         ),
-                        DropdownMenuItem(
-                          value: SyncDirection.twoWay,
-                          child: Text('Two-way',
-                              style: TextStyle(fontFamily: 'ProductSans')),
-                        ),
-                      ],
-                      onChanged: (v) =>
-                          setState(() => _direction = v ?? _direction),
+                      ),
                     ),
                   ),
-                ),
-                SwitchListTile(
-                  title: const Text('Wi-Fi only',
-                      style: TextStyle(fontFamily: 'ProductSans')),
-                  subtitle: Text(
-                    'Skip sync on mobile data',
-                    style: _subStyle(context),
+                  SwitchListTile(
+                    title: const Text('Wi-Fi only',
+                        style: TextStyle(fontFamily: 'ProductSans')),
+                    subtitle: Text('Skip sync on mobile data',
+                        style: _subStyle(context)),
+                    value: _wifiOnly,
+                    onChanged: (v) => setState(() => _wifiOnly = v),
+                    activeThumbColor: context.accentColor,
+                    contentPadding: EdgeInsets.zero,
                   ),
-                  value: _wifiOnly,
-                  onChanged: (v) => setState(() => _wifiOnly = v),
-                  activeThumbColor: context.accentColor,
-                  contentPadding: EdgeInsets.zero,
-                ),
-                SwitchListTile(
-                  title: const Text('Enabled',
-                      style: TextStyle(fontFamily: 'ProductSans')),
-                  subtitle: Text(
-                    'Use this profile as the active sync target',
-                    style: _subStyle(context),
+                ]),
+                const SizedBox(height: 8),
+                if (_editingActive)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Row(
+                      children: [
+                        Icon(Icons.check_circle,
+                            size: 16, color: context.accentColor),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            'This is the active sync target.',
+                            style: _subStyle(context)
+                                .copyWith(color: context.accentColor),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                  value: _enabled,
-                  onChanged: (v) => setState(() => _enabled = v),
-                  activeThumbColor: context.accentColor,
-                  contentPadding: EdgeInsets.zero,
-                ),
-                const SizedBox(height: 12),
                 Row(
                   children: [
                     Expanded(
@@ -268,7 +515,7 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
                                 child: CircularProgressIndicator(
                                     strokeWidth: 2, color: context.accentColor),
                               )
-                            : const Text('Test Connection',
+                            : const Text('Test',
                                 style: TextStyle(fontFamily: 'ProductSans')),
                       ),
                     ),
@@ -276,103 +523,240 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
                     Expanded(
                       child: FilledButton(
                         onPressed: _save,
-                        child: const Text('Save',
-                            style: TextStyle(fontFamily: 'ProductSans')),
+                        child: Text(_editingId == null ? 'Create' : 'Save',
+                            style: const TextStyle(fontFamily: 'ProductSans')),
                       ),
                     ),
                   ],
                 ),
-                const SizedBox(height: 20),
-                Divider(color: context.borderColor),
-                const SizedBox(height: 20),
-                _sectionTitle(context, 'Sync'),
-                Text(
-                  'Push-only backup ships the vault as encrypted blobs to your '
-                  'server. Two-way restore is a later phase.',
-                  style: _subStyle(context),
-                ),
-                const SizedBox(height: 12),
-                SizedBox(
-                  width: double.infinity,
-                  child: FilledButton.icon(
-                    icon: syncState.isSyncing
-                        ? SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: context.backgroundColor),
-                          )
-                        : const Icon(Icons.sync),
-                    label: Text(
-                        syncState.isSyncing ? 'Syncing…' : 'Sync Now',
-                        style: const TextStyle(fontFamily: 'ProductSans')),
-                    onPressed: syncState.isSyncing ? null : _syncNow,
+                const SizedBox(height: 24),
+
+                // ---- Sync ----
+                _SectionHeader(title: 'Sync'),
+                _card(context, [
+                  SwitchListTile(
+                    title: const Text('Enable server sync',
+                        style: TextStyle(fontFamily: 'ProductSans')),
+                    subtitle: Text(
+                        'Master switch for Sync Now and background runs',
+                        style: _subStyle(context)),
+                    value: _masterEnabled,
+                    onChanged: _activeId == null ? null : _setMasterEnabled,
+                    activeThumbColor: context.accentColor,
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 4),
                   ),
-                ),
-                if (syncState.status == SyncStatus.error &&
-                    syncState.error != null) ...[
-                  const SizedBox(height: 12),
-                  _errorBanner(context, syncState.error!),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+                    child: Text(
+                      'Push-only backs the vault up as encrypted blobs to your '
+                      'server. Two-way also pulls remote changes and deletions '
+                      'onto this device.',
+                      style: _subStyle(context),
+                    ),
+                  ),
+                  if (syncState.status == SyncStatus.error &&
+                      syncState.error != null)
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+                      child: _errorBanner(context, syncState.error!),
+                    ),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      icon: syncState.isSyncing
+                          ? SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: context.backgroundColor),
+                            )
+                          : const Icon(Icons.sync),
+                      label: Text(syncState.isSyncing ? 'Syncing…' : 'Sync Now',
+                          style: const TextStyle(fontFamily: 'ProductSans')),
+                      onPressed: syncState.isSyncing ||
+                              _activeId == null ||
+                              !_masterEnabled
+                          ? null
+                          : _syncNow,
+                    ),
+                  ),
+                ]),
+                if (_log.isNotEmpty) ...[
+                  const SizedBox(height: 24),
+                  _SectionHeader(title: 'History'),
+                  _card(
+                      context, _log.map((e) => _logTile(context, e)).toList()),
                 ],
               ],
             ),
     );
   }
 
-  Widget _buildStatusCard(BuildContext context, SyncState s) {
-    final (label, color) = switch (s.status) {
-      SyncStatus.idle => ('Idle', context.textTertiary),
-      SyncStatus.syncing => ('Syncing…', context.accentColor),
-      SyncStatus.success => ('Up to date', Colors.green),
-      SyncStatus.error => ('Error', AppColors.error),
-    };
-    final last = s.lastSync;
-    final progress = s.progress;
-    String? detail;
-    if (s.isSyncing && progress != null && progress.total > 0) {
-      detail = '${progress.phase.name} ${progress.completed}/${progress.total}';
-    } else if (last != null) {
-      detail = 'Last sync ${_formatDate(last)}';
-    }
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.08),
+  void _seedFormNull() => _seedForm(null);
+
+  Widget _profileCard(BuildContext context, SyncProfile p,
+      {required bool isActive}) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withValues(alpha: 0.2)),
-      ),
-      child: Row(
-        children: [
-          Icon(s.status == SyncStatus.success
-              ? Icons.cloud_done_outlined
-              : s.status == SyncStatus.error
-                  ? Icons.error_outline
-                  : Icons.cloud_sync_outlined, color: color),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(label,
-                    style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        fontWeight: FontWeight.w600,
-                        color: context.textPrimary)),
-                if (detail != null)
-                  Text(detail, style: _subStyle(context)),
-              ],
+        onTap: () => setState(() => _seedForm(p)),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(14, 12, 10, 12),
+          decoration: BoxDecoration(
+            color: isActive
+                ? context.accentColor.withValues(alpha: 0.08)
+                : context.textPrimary.withValues(alpha: 0.03),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: isActive
+                  ? context.accentColor.withValues(alpha: 0.5)
+                  : context.borderColor,
             ),
           ),
-        ],
+          child: Row(
+            children: [
+              Icon(Icons.dns_outlined,
+                  size: 22,
+                  color: isActive ? context.accentColor : context.textTertiary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            _hostOf(p.serverUrl),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                                fontFamily: 'ProductSans',
+                                fontWeight: FontWeight.w600,
+                                color: context.textPrimary),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          p.direction == SyncDirection.twoWay
+                              ? 'Two-way'
+                              : 'Push only',
+                          style: _subStyle(context),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      p.lastSyncedAt == null
+                          ? (p.basePath.isEmpty ? '/locker' : p.basePath)
+                          : 'Synced ${_formatDate(p.lastSyncedAt!)}',
+                      style: _subStyle(context),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 4),
+              if (isActive)
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: context.accentColor.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text('ACTIVE',
+                      style: TextStyle(
+                          fontFamily: 'ProductSans',
+                          fontSize: 10,
+                          fontWeight: FontWeight.w700,
+                          color: context.accentColor)),
+                )
+              else
+                IconButton(
+                  tooltip: 'Set as active',
+                  icon: Icon(Icons.radio_button_unchecked,
+                      size: 20, color: context.textTertiary),
+                  onPressed: () => _activate(p),
+                ),
+              PopupMenuButton<String>(
+                icon: Icon(Icons.more_vert,
+                    size: 20, color: context.textTertiary),
+                itemBuilder: (_) => [
+                  if (!isActive)
+                    const PopupMenuItem(
+                        value: 'activate', child: Text('Set as active')),
+                  const PopupMenuItem(value: 'edit', child: Text('Edit')),
+                  const PopupMenuItem(value: 'delete', child: Text('Delete')),
+                ],
+                onSelected: (v) {
+                  switch (v) {
+                    case 'activate':
+                      _activate(p);
+                      break;
+                    case 'edit':
+                      setState(() => _seedForm(p));
+                      break;
+                    case 'delete':
+                      _confirmDelete(p);
+                      break;
+                  }
+                },
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
 
+  Widget _emptyServersHint(BuildContext context) => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: context.textPrimary.withValues(alpha: 0.03),
+          borderRadius: BorderRadius.circular(12),
+          border:
+              Border.all(color: context.borderColor, style: BorderStyle.solid),
+        ),
+        child: Column(
+          children: [
+            Icon(Icons.cloud_off_outlined,
+                size: 32, color: context.textTertiary),
+            const SizedBox(height: 8),
+            Text('No servers yet',
+                style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontWeight: FontWeight.w600,
+                    color: context.textSecondary)),
+            const SizedBox(height: 4),
+            Text(
+              'Tap Add to configure a WebDAV server (NAS or cloud).',
+              textAlign: TextAlign.center,
+              style: _subStyle(context),
+            ),
+          ],
+        ),
+      );
+
+  Widget _card(BuildContext context, List<Widget> children) => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.fromLTRB(12, 10, 12, 14),
+        decoration: BoxDecoration(
+          color: context.textPrimary.withValues(alpha: 0.03),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: context.borderColor),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: children,
+        ),
+      );
+
   Widget _plainHttpWarning(BuildContext context) => Container(
         width: double.infinity,
-        margin: const EdgeInsets.only(top: 8, bottom: 8),
+        margin: const EdgeInsets.only(top: 4, bottom: 8),
         padding: const EdgeInsets.all(10),
         decoration: BoxDecoration(
           color: AppColors.error.withValues(alpha: 0.08),
@@ -397,17 +781,9 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
         ),
         child: Text(msg,
             style: TextStyle(
-                fontFamily: 'ProductSans', fontSize: 12, color: AppColors.error)),
-      );
-
-  Widget _sectionTitle(BuildContext context, String title) => Padding(
-        padding: const EdgeInsets.only(bottom: 8),
-        child: Text(title,
-            style: TextStyle(
                 fontFamily: 'ProductSans',
-                fontSize: 18,
-                fontWeight: FontWeight.w600,
-                color: context.textPrimary)),
+                fontSize: 12,
+                color: AppColors.error)),
       );
 
   TextStyle _subStyle(BuildContext context) => TextStyle(
@@ -416,13 +792,40 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
         color: context.textTertiary,
       );
 
-  InputDecoration _inputDecoration(String label) => InputDecoration(
-        labelText: label,
-        labelStyle: const TextStyle(fontFamily: 'ProductSans'),
-        border: const OutlineInputBorder(),
+  Widget _formLabel(BuildContext context, String text) => Text(
+        text,
+        style: TextStyle(
+            fontFamily: 'ProductSans',
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: context.textTertiary),
       );
 
-  Widget _textField({
+  InputDecoration _fieldDecoration({String? hint, Widget? suffixIcon}) =>
+      InputDecoration(
+        hintText: hint,
+        hintStyle: TextStyle(
+            fontFamily: 'ProductSans', fontSize: 13, color: context.textSecondary),
+        suffixIcon: suffixIcon,
+        filled: true,
+        fillColor: context.textPrimary.withValues(alpha: 0.03),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 13),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(color: context.borderColor),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(color: context.borderColor),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(color: context.accentColor),
+        ),
+      );
+
+  Widget _field({
     required TextEditingController controller,
     required String label,
     String? hint,
@@ -431,19 +834,50 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
     void Function(String)? onChanged,
   }) =>
       Padding(
-        padding: const EdgeInsets.only(bottom: 12),
-        child: TextField(
-          controller: controller,
-          obscureText: obscure,
-          keyboardType: keyboardType,
-          decoration: InputDecoration(
-            labelText: label,
-            hintText: hint,
-            labelStyle: const TextStyle(fontFamily: 'ProductSans'),
-            hintStyle: const TextStyle(fontFamily: 'ProductSans'),
-            border: const OutlineInputBorder(),
-          ),
-          onChanged: (v) => onChanged?.call(v),
+        padding: const EdgeInsets.only(bottom: 18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _formLabel(context, label),
+            const SizedBox(height: 6),
+            TextField(
+              controller: controller,
+              obscureText: obscure,
+              keyboardType: keyboardType,
+              decoration: _fieldDecoration(hint: hint),
+              onChanged: (v) => onChanged?.call(v),
+            ),
+          ],
+        ),
+      );
+
+  Widget _passwordField(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _formLabel(context, 'Password'),
+            const SizedBox(height: 6),
+            TextField(
+              controller: _passwordController,
+              obscureText: _obscurePassword,
+              decoration: _fieldDecoration(
+                hint: _editingId == null
+                    ? 'app password'
+                    : 'leave blank to keep current',
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscurePassword
+                        ? Icons.visibility_off_outlined
+                        : Icons.visibility_outlined,
+                  ),
+                  onPressed: () =>
+                      setState(() => _obscurePassword = !_obscurePassword),
+                  tooltip: _obscurePassword ? 'Show password' : 'Hide password',
+                ),
+              ),
+            ),
+          ],
         ),
       );
 
@@ -453,4 +887,243 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
         '${local.hour.toString().padLeft(2, '0')}:'
         '${local.minute.toString().padLeft(2, '0')}';
   }
+
+  String _formatDuration(Duration? d) {
+    if (d == null) return '—';
+    if (d.inMinutes > 0) {
+      return '${d.inMinutes}m ${d.inSeconds % 60}s';
+    }
+    return '${(d.inMilliseconds / 1000).toStringAsFixed(1)}s';
+  }
+
+  Widget _logTile(BuildContext context, _SyncLogEntry e) {
+    final color = e.ok ? Colors.green : AppColors.error;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(e.ok ? Icons.check_circle_outline : Icons.error_outline,
+              color: color, size: 16),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '${_formatDate(e.time)} — ${e.message}',
+              style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 12,
+                  color: context.textTertiary),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Big status banner for the active profile's current run state.
+class _HeroStatus extends StatelessWidget {
+  const _HeroStatus({
+    required this.state,
+    required this.active,
+    required this.masterEnabled,
+  });
+
+  final SyncState state;
+  final SyncProfile? active;
+  final bool masterEnabled;
+
+  @override
+  Widget build(BuildContext context) {
+    // No active server configured yet.
+    if (active == null) {
+      return _shell(
+        context,
+        color: context.textTertiary,
+        icon: Icons.cloud_off_outlined,
+        children: [
+          Text('No active server',
+              style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontWeight: FontWeight.w600,
+                  color: context.textPrimary)),
+          Text('Add a server below, then set it active.', style: _sub(context)),
+        ],
+      );
+    }
+
+    final (label, color, icon) = switch (state.status) {
+      SyncStatus.idle => (
+          'Idle',
+          context.textTertiary,
+          Icons.cloud_queue_outlined
+        ),
+      SyncStatus.syncing => (
+          'Syncing…',
+          context.accentColor,
+          Icons.cloud_sync_outlined
+        ),
+      SyncStatus.success => (
+          'Up to date',
+          Colors.green,
+          Icons.cloud_done_outlined
+        ),
+      SyncStatus.error => ('Error', AppColors.error, Icons.error_outline),
+    };
+
+    final progress = state.progress;
+    final showBar = state.isSyncing && progress != null && progress.total > 0;
+    final pct =
+        showBar ? (progress.completed / progress.total).clamp(0.0, 1.0) : 0.0;
+
+    String? detail;
+    if (state.isSyncing && progress != null && progress.total > 0) {
+      detail =
+          '${_phaseLabel(progress)} ${progress.completed}/${progress.total}';
+    } else if (state.status == SyncStatus.success && state.message != null) {
+      detail = state.message;
+    } else if (active!.lastSyncedAt != null) {
+      detail = 'Last sync ${_fmt(active!.lastSyncedAt!)}';
+    }
+
+    return _shell(
+      context,
+      color: color,
+      icon: icon,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(label,
+                  style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontWeight: FontWeight.w600,
+                      color: context.textPrimary)),
+            ),
+            if (state.status == SyncStatus.success && !masterEnabled)
+              _tag(context, 'Paused', context.textTertiary),
+            if (active!.direction == SyncDirection.twoWay &&
+                state.status != SyncStatus.error)
+              _tag(context, 'Two-way', context.accentColor),
+          ],
+        ),
+        if (detail != null) ...[
+          const SizedBox(height: 2),
+          Text(detail, style: _sub(context)),
+        ],
+        if (showBar) ...[
+          const SizedBox(height: 10),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: LinearProgressIndicator(
+              value: pct,
+              minHeight: 6,
+              backgroundColor: color.withValues(alpha: 0.15),
+              color: color,
+            ),
+          ),
+        ],
+        const SizedBox(height: 2),
+        Text(active!.serverUrl,
+            maxLines: 1, overflow: TextOverflow.ellipsis, style: _sub(context)),
+      ],
+    );
+  }
+
+  Widget _shell(BuildContext context,
+      {required Color color,
+      required IconData icon,
+      required List<Widget> children}) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: color, size: 28),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: children,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _tag(BuildContext context, String text, Color color) => Container(
+        margin: const EdgeInsets.only(left: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Text(text,
+            style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                color: color)),
+      );
+
+  TextStyle _sub(BuildContext context) => TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 12,
+        color: context.textTertiary,
+      );
+
+  static String _phaseLabel(SyncProgress p) => switch (p.phase) {
+        SyncPhase.connecting => 'Connecting',
+        SyncPhase.uploading => 'Uploading',
+        SyncPhase.downloading => 'Downloading',
+        SyncPhase.committing => 'Committing',
+        SyncPhase.done => 'Done',
+      };
+
+  static String _fmt(DateTime d) {
+    final local = d.toLocal();
+    return '${local.day}/${local.month}/${local.year} '
+        '${local.hour.toString().padLeft(2, '0')}:'
+        '${local.minute.toString().padLeft(2, '0')}';
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title, this.trailing});
+  final String title;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4, bottom: 8),
+      child: Row(
+        children: [
+          Text(title,
+              style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.5,
+                  color: context.textTertiary)),
+          const Spacer(),
+          if (trailing != null) trailing!,
+        ],
+      ),
+    );
+  }
+}
+
+class _SyncLogEntry {
+  final DateTime time;
+  final String message;
+  final bool ok;
+  const _SyncLogEntry(this.time, this.message, this.ok);
 }

--- a/lib/screens/vault_settings_screen.dart
+++ b/lib/screens/vault_settings_screen.dart
@@ -23,6 +23,7 @@ import 'encryption_settings_screen.dart';
 import 'local_backup_screen.dart';
 import 'performance_settings_screen.dart';
 import 'privacy_policy_screen.dart';
+import 'sync_settings_screen.dart';
 
 class VaultSettingsScreen extends ConsumerStatefulWidget {
   const VaultSettingsScreen({super.key});
@@ -329,6 +330,31 @@ class _VaultSettingsScreenState extends ConsumerState<VaultSettingsScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (context) => const LocalBackupScreen(),
+                    ),
+                  );
+                },
+                contentPadding: EdgeInsets.zero,
+              ),
+              ListTile(
+                leading: Icon(Icons.cloud_sync_outlined,
+                    color: context.accentColor),
+                title: const Text(
+                  'Server Sync',
+                  style: TextStyle(fontFamily: 'ProductSans'),
+                ),
+                subtitle: Text(
+                  'Encrypted backup to a WebDAV server (NAS/cloud)',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const SyncSettingsScreen(),
                     ),
                   );
                 },

--- a/lib/services/remote/webdav_store.dart
+++ b/lib/services/remote/webdav_store.dart
@@ -24,8 +24,16 @@ class WebDAVStore implements RemoteStore {
 
   webdav.Client? _client;
 
-  webdav.Client get _c =>
-      _client ??= webdav.newClient(baseUrl, user: username, password: password);
+  webdav.Client get _c {
+    if (_client != null) return _client!;
+    final c = webdav.newClient(baseUrl, user: username, password: password);
+    // ponytail: generous timeouts; .local NAS hosts + cold servers need room.
+    c.setConnectTimeout(15000);
+    c.setSendTimeout(30000);
+    c.setReceiveTimeout(30000);
+    _client = c;
+    return c;
+  }
 
   /// Join [base] and [name] with exactly one `/`.
   static String joinPath(String base, String name) {

--- a/lib/services/sync_profile_service.dart
+++ b/lib/services/sync_profile_service.dart
@@ -21,7 +21,7 @@ class SyncProfileService {
 
   Future<List<SyncProfile>> listProfiles() async {
     final raw = await _storage.read(key: profilesKey);
-    if (raw == null) return const [];
+    if (raw == null) return <SyncProfile>[];
     return (jsonDecode(raw) as List<dynamic>)
         .map((e) => SyncProfile.fromJson(e as Map<String, dynamic>))
         .toList();

--- a/lib/services/sync_profile_service.dart
+++ b/lib/services/sync_profile_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:uuid/uuid.dart';
 
 import '../models/sync_profile.dart';
 
@@ -16,6 +17,7 @@ class SyncProfileService {
   final FlutterSecureStorage _storage;
 
   static const String profilesKey = 'sync_profiles';
+  static const String deviceIdKey = 'sync_device_id';
 
   Future<List<SyncProfile>> listProfiles() async {
     final raw = await _storage.read(key: profilesKey);
@@ -66,4 +68,15 @@ class SyncProfileService {
 
   Future<void> deletePassword(String id) =>
       _storage.delete(key: SyncProfile.passwordStorageKeyFor(id));
+
+  /// Stable per-device id, generated once + cached in secure storage. Used as
+  /// the manifest author so reconcile can tell devices apart later.
+  Future<String> getDeviceId() async {
+    var id = await _storage.read(key: deviceIdKey);
+    if (id == null || id.isEmpty) {
+      id = const Uuid().v4();
+      await _storage.write(key: deviceIdKey, value: id);
+    }
+    return id;
+  }
 }

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:isolate';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -8,6 +9,7 @@ import 'package:pointycastle/export.dart';
 
 import '../crypto/aes_gcm_cipher.dart';
 import '../crypto/key_derivation.dart';
+import '../models/encryption_algorithm.dart';
 import '../models/remote_manifest.dart';
 import '../models/sync_profile.dart';
 import '../models/vaulted_file.dart';
@@ -17,7 +19,7 @@ import 'remote/webdav_store.dart';
 import 'vault_store.dart';
 
 /// Phase of an in-flight sync, surfaced to the UI via [SyncProgress].
-enum SyncPhase { connecting, uploading, committing, done }
+enum SyncPhase { connecting, uploading, downloading, committing, done }
 
 /// Coarse progress for the UI. [completed]/[total] are file counts.
 class SyncProgress {
@@ -39,6 +41,7 @@ class SyncResult {
   final int blobsPushed;
   final int blobsDeleted;
   final int blobsPulled;
+  final int blobsSkipped;
   final SyncPlan plan;
   final List<VaultedFile> refreshedLocal;
   final DateTime completedAt;
@@ -47,6 +50,7 @@ class SyncResult {
     required this.blobsPushed,
     required this.blobsDeleted,
     required this.blobsPulled,
+    this.blobsSkipped = 0,
     required this.plan,
     required this.refreshedLocal,
     required this.completedAt,
@@ -68,13 +72,32 @@ class SyncPlan {
   /// Content-addressed blob names to delete (tombstoned files).
   final List<String> toDelete;
 
+  /// Live local ids where both sides changed since the last sync. Last-write-
+  /// wins still resolves the outcome; this is surfaced as a UI note only.
+  /// ponytail: detects only the local-newer-and-remote-diverged case — the
+  /// remote-newer direction can't be detected without hashing local content,
+  /// so a stale local edit overwritten by a pull is silent. Three-way merge
+  /// is an explicit non-goal (docs/local_server_sync.md).
+  final List<String> conflicts;
+
+  /// Live local ids a remote tombstone should delete (two-way only, LWW: the
+  /// tombstone must be at least as new as the local copy).
+  final List<String> toTombstoneLocal;
+
   const SyncPlan({
     this.toPush = const [],
     this.toPull = const [],
     this.toDelete = const [],
+    this.conflicts = const [],
+    this.toTombstoneLocal = const [],
   });
 
-  bool get isEmpty => toPush.isEmpty && toPull.isEmpty && toDelete.isEmpty;
+  bool get isEmpty =>
+      toPush.isEmpty &&
+      toPull.isEmpty &&
+      toDelete.isEmpty &&
+      conflicts.isEmpty &&
+      toTombstoneLocal.isEmpty;
 }
 
 /// Vault sync. Pure diff/manifest logic lives as statics (tested directly);
@@ -96,7 +119,6 @@ class SyncService {
     required SyncProfile profile,
     required String password,
     required String deviceId,
-    void Function(SyncProgress)? onProgress,
   }) async {
     final remote = WebDAVStore(
       baseUrl: profile.serverUrl,
@@ -105,36 +127,51 @@ class SyncService {
       basePath: profile.basePath,
     );
     final local = await _store.loadFileIndex();
+    // Ensure the vault dir + subdirs exist before a two-way pull writes into it.
+    final dir = await _store.ensureVaultDirectory();
     final masterKey = await _crypto.getMasterKey();
-    return runSync(
+    // ponytail: run the engine off the UI isolate. runSync reads whole files
+    // into memory and hashes them synchronously (sha256.convert), which freezes
+    // the UI for any non-trivial file. Isolate.run moves all file + network
+    // I/O to a worker so the app stays responsive. Ceiling: per-file progress
+    // is dropped (phase-level status remains) — wire a SendPort through if a
+    // live x/y counter is needed.
+    return Isolate.run(() => runSync(
       local: local,
       masterKey: masterKey,
       remote: remote,
       deviceId: deviceId,
+      vaultRoot: dir.path,
       direction: profile.direction,
-      onProgress: onProgress,
-    );
+    ));
   }
 
-  /// Core push-only engine. Fetches + decrypts the remote manifest, reconciles,
-  /// uploads new/changed blobs, reaps tombstones, then commits the encrypted
-  /// manifest last (the commit point — a crash before this leaves the old
-  /// manifest describing a consistent state, and the next run is idempotent).
+  /// Core sync engine. Fetches + decrypts the remote manifest, reconciles,
+  /// then for two-way sync: uploads new/changed blobs, downloads missing/
+  /// changed blobs, reaps tombstoned remote blobs, applies remote tombstones
+  /// locally, and finally commits the encrypted manifest last (the commit
+  /// point — a crash before this leaves the old manifest describing a
+  /// consistent state, and the next run is idempotent).
   ///
-  /// Pull execution (two-way restore) is Phase S3.1 — [plan.toPull] is computed
-  /// but not imported yet. Throws if a non-deleted file's blob is unreadable;
-  /// the caller treats that as a failed sync (content-addressed puts are
-  /// idempotent, so a partial run is safe to retry).
+  /// Push-only (`direction == pushOnly`, the default) skips the pull and
+  /// local-tombstone phases: it is backup only. [vaultRoot] is the local vault
+  /// directory root; required for two-way pull (where downloaded blobs are
+  /// written). Throws if a blob to pull is missing or its sha256 does not match
+  /// the GCM-authenticated manifest — the caller treats that as a failed sync.
+  /// Content-addressed puts/deletes are idempotent, so a partial run is safe to
+  /// retry (the manifest write is the single commit point).
   static Future<SyncResult> runSync({
     required List<VaultedFile> local,
     required Uint8List masterKey,
     required RemoteStore remote,
     required String deviceId,
+    String? vaultRoot,
     SyncDirection direction = SyncDirection.pushOnly,
     DateTime? now,
     void Function(SyncProgress)? onProgress,
   }) async {
     final completedAt = (now ?? DateTime.now()).toUtc();
+    final twoWay = direction == SyncDirection.twoWay;
 
     onProgress?.call(const SyncProgress(phase: SyncPhase.connecting));
     final remoteBytes = await remote.getManifest();
@@ -150,27 +187,41 @@ class SyncService {
         : reconcile(local: local, remote: remoteManifest);
 
     final pushIds = <String>{for (final p in plan.toPush) p.id};
+    final tombstoneLocalIds = <String>{for (final id in plan.toTombstoneLocal) id};
     final refreshed = <VaultedFile>[];
     var pushed = 0;
-    final total = local.where((f) => !f.syncedDeleted).length;
+    var skipped = 0;
+    final totalPush = local.where((f) => !f.syncedDeleted).length;
     var processed = 0;
 
+    // ---- PUSH phase: upload new/changed local blobs ----
     for (final f in local) {
       if (f.syncedDeleted) {
         refreshed.add(f);
         continue;
       }
       if (pushIds.contains(f.id)) {
-        final blob = await File(f.vaultPath).readAsBytes();
-        final hash = sha256Hex(blob);
-        await remote.putBlob(blobNameFor(hash), blob);
-        pushed++;
-        refreshed.add(
-          f.copyWith(
-            remoteHash: hash,
-            modifiedAt: f.modifiedAt ?? completedAt,
-          ),
-        );
+        final file = File(f.vaultPath);
+        if (await file.exists()) {
+          final blob = await file.readAsBytes();
+          final hash = sha256Hex(blob);
+          await remote.putBlob(blobNameFor(hash), blob);
+          pushed++;
+          refreshed.add(
+            f.copyWith(
+              remoteHash: hash,
+              modifiedAt: f.modifiedAt ?? completedAt,
+            ),
+          );
+        } else {
+          // ponytail: referenced blob missing on disk (e.g. a deleted
+          // password's shadow VaultedFile). Skip — can't push bytes that
+          // aren't there; keep the index entry as-is so sync never silently
+          // mutates local state. Root cause is stale shadow cleanup, tracked
+          // separately.
+          skipped++;
+          refreshed.add(f);
+        }
       } else {
         refreshed.add(f);
       }
@@ -178,27 +229,96 @@ class SyncService {
       onProgress?.call(SyncProgress(
         phase: SyncPhase.uploading,
         completed: processed,
-        total: total,
+        total: totalPush,
       ));
     }
 
+    // ---- REMOTE-BLOB DELETE phase: reap tombstoned remote blobs ----
     for (final name in plan.toDelete) {
       await remote.deleteBlob(name);
     }
 
-    // ponytail: pull import is S3.1; reconcile computed toPull, we don't act.
+    var pulled = 0;
 
+    // ---- PULL phase (two-way only) ----
+    // ponytail: GCM auth on pull is satisfied transitively. The manifest is
+    // GCM-authenticated (root of trust) and each blob's sha256 must equal the
+    // manifest's contentHash — a tampered or swapped blob breaks the hash. A
+    // full decrypt-to-verify-the-tag is redundant: pushed files were created
+    // by our own encrypt path, so a hash-matching blob is always decryptable.
+    // Add explicit tag verification only if a non-vault blob could ever enter
+    // the store (it can't today).
+    if (twoWay && vaultRoot != null && plan.toPull.isNotEmpty) {
+      final totalPull = plan.toPull.length;
+      var done = 0;
+      for (final e in plan.toPull) {
+        final hash = e.contentHash;
+        if (hash == null) {
+          throw StateError('Remote entry ${e.id} has no content hash');
+        }
+        final blob = await remote.getBlob(blobNameFor(hash));
+        if (blob == null) {
+          throw StateError('Missing blob for remote entry ${e.id}');
+        }
+        if (sha256Hex(blob) != hash) {
+          // Blob does not match the authenticated manifest → tamper/corruption.
+          throw StateError('Blob hash mismatch for remote entry ${e.id}');
+        }
+        final vp = _localVaultPath(vaultRoot: vaultRoot, entry: e);
+        await File(vp).parent.create(recursive: true);
+        await File(vp).writeAsBytes(blob);
+        final existingIdx = refreshed.indexWhere((f) => f.id == e.id);
+        if (existingIdx >= 0) {
+          final old = refreshed[existingIdx];
+          if (old.vaultPath != vp) {
+            await _deleteIfExists(old.vaultPath);
+          }
+          refreshed[existingIdx] = _vaultedFileFromEntry(e, vaultPath: vp);
+        } else {
+          refreshed.add(_vaultedFileFromEntry(e, vaultPath: vp));
+        }
+        pulled++;
+        done++;
+        onProgress?.call(SyncProgress(
+          phase: SyncPhase.downloading,
+          completed: done,
+          total: totalPull,
+        ));
+      }
+    }
+
+    // ---- LOCAL TOMBSTONE phase: remote delete → local (two-way only) ----
+    if (twoWay && tombstoneLocalIds.isNotEmpty) {
+      for (var i = 0; i < refreshed.length; i++) {
+        final f = refreshed[i];
+        if (tombstoneLocalIds.contains(f.id) && !f.syncedDeleted) {
+          await _deleteIfExists(f.vaultPath);
+          refreshed[i] = f.copyWith(
+            syncedDeleted: true,
+            remoteHash: null,
+            modifiedAt: completedAt,
+          );
+        }
+      }
+    }
+
+    // ---- COMMIT manifest (single commit point) ----
     onProgress?.call(const SyncProgress(phase: SyncPhase.committing));
     final manifest =
         buildManifest(refreshed, deviceId: deviceId, now: completedAt);
     await remote.putManifest(encryptManifest(manifest, masterKey));
-    onProgress?.call(
-        SyncProgress(phase: SyncPhase.done, completed: total, total: total));
+    final grandTotal = totalPush + pulled;
+    onProgress?.call(SyncProgress(
+      phase: SyncPhase.done,
+      completed: grandTotal,
+      total: grandTotal,
+    ));
 
     return SyncResult(
       blobsPushed: pushed,
       blobsDeleted: plan.toDelete.length,
-      blobsPulled: 0,
+      blobsPulled: pulled,
+      blobsSkipped: skipped,
       plan: plan,
       refreshedLocal: refreshed,
       completedAt: completedAt,
@@ -227,7 +347,8 @@ class SyncService {
 
   /// Snapshot the current synced state of [files] into a manifest. Only files
   /// that carry a [VaultedFile.remoteHash] reference an uploaded blob; entries
-  /// for tombstones keep their last hash so the blob can be reaped.
+  /// for tombstones keep their last hash so the blob can be reaped. v2 carries
+  /// the full restore metadata (S3) so a fresh device can reconstruct files.
   static RemoteManifest buildManifest(
     List<VaultedFile> files, {
     required String deviceId,
@@ -241,11 +362,26 @@ class SyncService {
             contentHash: f.remoteHash,
             modifiedAt: f.modifiedAt ?? f.dateModified ?? f.dateAdded,
             deleted: f.syncedDeleted,
+            originalName: f.originalName,
+            type: f.type.name,
+            mimeType: f.mimeType,
+            fileSize: f.fileSize,
+            dateAdded: f.dateAdded,
+            dateModified: f.dateModified,
+            isEncrypted: f.isEncrypted,
+            encryptionIv: f.encryptionIv,
+            encryptionAlgorithm: f.encryptionAlgorithm?.name,
+            keyDerivationSalt: f.keyDerivationSalt,
+            kdfIterations: f.kdfIterations,
+            tags: f.tags,
+            isFavorite: f.isFavorite,
+            albumIds: f.albumIds,
+            folderId: f.folderId,
           ),
         )
         .toList(growable: false);
     return RemoteManifest(
-      version: 1,
+      version: 2,
       deviceId: deviceId,
       generatedAt: generated,
       entries: entries,
@@ -255,6 +391,13 @@ class SyncService {
   /// Diff local files against the remote manifest → a [SyncPlan].
   /// Convergence is last-write-wins by modifiedAt; local/remote null
   /// modifiedAt falls back to dateModified then dateAdded.
+  ///
+  /// Tombstone policy: a local tombstone reaps a still-live remote blob
+  /// (existing S2 semantics). A remote tombstone deletes the local copy, but
+  /// only when it is at least as new as the local file (LWW) — a strictly newer
+  /// local copy resurrects via push instead. ponytail ceiling: the local→remote
+  /// reap is unconditional, so a delete-then-edit race can lose the resurrected
+  /// edit; symmetric three-way tombstone LWW is deferred.
   static SyncPlan reconcile({
     required List<VaultedFile> local,
     required RemoteManifest remote,
@@ -264,35 +407,139 @@ class SyncService {
     final toPush = <VaultedFile>[];
     final toPull = <ManifestEntry>[];
     final toDelete = <String>[];
+    final conflicts = <String>[];
+    final toTombstoneLocal = <String>[];
 
     for (final f in local) {
       final r = remoteById[f.id];
       if (f.syncedDeleted) {
+        // Local tombstone → reap the remote blob if it's still live there.
         if (r != null && !r.deleted && r.contentHash != null) {
           toDelete.add(blobNameFor(r.contentHash!));
         }
         continue;
       }
-      if (r == null || r.deleted) {
+      if (r == null) {
         toPush.add(f);
-      } else {
+        continue;
+      }
+      if (r.deleted) {
+        // Remote tombstone: propagate delete locally (LWW), else resurrect.
         final localM = f.modifiedAt ?? f.dateModified ?? f.dateAdded;
-        if (localM.isAfter(r.modifiedAt)) {
+        if (!r.modifiedAt.isBefore(localM)) {
+          toTombstoneLocal.add(f.id);
+        } else {
           toPush.add(f);
-        } else if (r.modifiedAt.isAfter(localM)) {
-          toPull.add(r);
         }
+        continue;
+      }
+      // Both sides live.
+      final localM = f.modifiedAt ?? f.dateModified ?? f.dateAdded;
+      final remoteChanged =
+          f.remoteHash != null && f.remoteHash != r.contentHash;
+      if (localM.isAfter(r.modifiedAt)) {
+        toPush.add(f);
+        if (remoteChanged) {
+          // Local newer AND remote diverged since last sync → both changed.
+          conflicts.add(f.id);
+        }
+      } else if (r.modifiedAt.isAfter(localM)) {
+        toPull.add(r);
+      } else if (f.remoteHash != r.contentHash) {
+        // Equal timestamps, different content → deterministic tiebreak: pull.
+        toPull.add(r);
       }
     }
 
-    // Remote files unknown locally (two-way pull). Skipped in push-only v1.
+    // Remote files unknown locally → pull (two-way).
     for (final e in remote.entries) {
       if (!e.deleted && !localIds.contains(e.id)) {
         toPull.add(e);
       }
     }
 
-    return SyncPlan(toPush: toPush, toPull: toPull, toDelete: toDelete);
+    return SyncPlan(
+      toPush: toPush,
+      toPull: toPull,
+      toDelete: toDelete,
+      conflicts: conflicts,
+      toTombstoneLocal: toTombstoneLocal,
+    );
+  }
+
+  /// Destination vault path for a pulled blob. subdir by type (mirrors
+  /// VaultStore), filename derived from the content hash (deterministic +
+  /// dedup-friendly) with the original extension preserved.
+  static String _localVaultPath({
+    required String vaultRoot,
+    required ManifestEntry entry,
+  }) {
+    final type = _typeFromName(entry.type);
+    final subdir = VaultStore.subdirFor(type);
+    final hash = entry.contentHash ?? entry.id;
+    final stem = hash.length >= 16 ? hash.substring(0, 16) : hash;
+    final ext = _extOf(entry.originalName);
+    final name = ext.isEmpty ? '$stem.enc' : '$stem.$ext';
+    return '$vaultRoot/$subdir/$name';
+  }
+
+  /// Reconstruct a [VaultedFile] from a manifest entry at [vaultPath]. The
+  /// inverse of [buildManifest]'s per-file mapping.
+  static VaultedFile _vaultedFileFromEntry(
+    ManifestEntry e, {
+    required String vaultPath,
+  }) {
+    return VaultedFile(
+      id: e.id,
+      originalName: e.originalName ?? 'file',
+      vaultPath: vaultPath,
+      type: _typeFromName(e.type),
+      mimeType: e.mimeType ?? 'application/octet-stream',
+      fileSize: e.fileSize ?? 0,
+      dateAdded: e.dateAdded ?? e.modifiedAt,
+      dateModified: e.dateModified,
+      isEncrypted: e.isEncrypted,
+      encryptionIv: e.encryptionIv,
+      encryptionAlgorithm: _algoFromName(e.encryptionAlgorithm),
+      keyDerivationSalt: e.keyDerivationSalt,
+      kdfIterations: e.kdfIterations,
+      tags: e.tags,
+      isFavorite: e.isFavorite,
+      albumIds: e.albumIds,
+      folderId: e.folderId,
+      modifiedAt: e.modifiedAt,
+      remoteHash: e.contentHash,
+    );
+  }
+
+  static VaultedFileType _typeFromName(String? name) {
+    if (name == null) return VaultedFileType.other;
+    return VaultedFileType.values.firstWhere(
+      (t) => t.name == name,
+      orElse: () => VaultedFileType.other,
+    );
+  }
+
+  static EncryptionAlgorithm? _algoFromName(String? name) {
+    if (name == null) return null;
+    return EncryptionAlgorithm.values.firstWhere(
+      (a) => a.name == name,
+      orElse: () => EncryptionAlgorithm.aes256Ctr,
+    );
+  }
+
+  static String _extOf(String? originalName) {
+    if (originalName == null) return '';
+    final dot = originalName.lastIndexOf('.');
+    if (dot <= 0 || dot == originalName.length - 1) return '';
+    return originalName.substring(dot + 1).toLowerCase();
+  }
+
+  static Future<void> _deleteIfExists(String path) async {
+    try {
+      final f = File(path);
+      if (await f.exists()) await f.delete();
+    } catch (_) {}
   }
 
   /// Encrypt a manifest with the vault master key. Wire format:

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -1,14 +1,60 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
 import 'package:pointycastle/export.dart';
 
 import '../crypto/aes_gcm_cipher.dart';
 import '../crypto/key_derivation.dart';
 import '../models/remote_manifest.dart';
+import '../models/sync_profile.dart';
 import '../models/vaulted_file.dart';
+import 'encryption_service.dart';
 import 'remote/remote_store.dart';
+import 'remote/webdav_store.dart';
+import 'vault_store.dart';
+
+/// Phase of an in-flight sync, surfaced to the UI via [SyncProgress].
+enum SyncPhase { connecting, uploading, committing, done }
+
+/// Coarse progress for the UI. [completed]/[total] are file counts.
+class SyncProgress {
+  final SyncPhase phase;
+  final int completed;
+  final int total;
+
+  const SyncProgress({
+    this.phase = SyncPhase.uploading,
+    this.completed = 0,
+    this.total = 0,
+  });
+}
+
+/// Outcome of one [SyncService.runSync]. [refreshedLocal] is the local index
+/// with pushed files' `remoteHash`/`modifiedAt` refreshed — the caller persists
+/// it back into [VaultStore] so the next run skips unchanged files.
+class SyncResult {
+  final int blobsPushed;
+  final int blobsDeleted;
+  final int blobsPulled;
+  final SyncPlan plan;
+  final List<VaultedFile> refreshedLocal;
+  final DateTime completedAt;
+
+  const SyncResult({
+    required this.blobsPushed,
+    required this.blobsDeleted,
+    required this.blobsPulled,
+    required this.plan,
+    required this.refreshedLocal,
+    required this.completedAt,
+  });
+
+  bool get didAnything =>
+      blobsPushed > 0 || blobsDeleted > 0 || blobsPulled > 0;
+}
 
 /// The result of diffing local vault state against a remote manifest.
 class SyncPlan {
@@ -16,7 +62,7 @@ class SyncPlan {
   final List<VaultedFile> toPush;
 
   /// Remote entries newer than local, or absent locally — download these.
-  /// Empty in push-only v1; populated by the two-way path in Phase S3.
+  /// Populated only for two-way sync (Phase S3); push-only ignores it.
   final List<ManifestEntry> toPull;
 
   /// Content-addressed blob names to delete (tombstoned files).
@@ -31,13 +77,135 @@ class SyncPlan {
   bool get isEmpty => toPush.isEmpty && toPull.isEmpty && toDelete.isEmpty;
 }
 
-/// Pure sync logic. Stateless helpers — no I/O, no Riverpod, no network.
+/// Vault sync. Pure diff/manifest logic lives as statics (tested directly);
+/// [syncNow] is the Riverpod-constructed entrypoint that wires real I/O.
 ///
-/// ponytail: the stateful orchestration (runSync, connectivity guard,
-/// VaultStore + EncryptionService injection) lands Riverpod-native after the
-/// Phase 4 refactor; these pure pieces are callable from there and tested now.
+/// ponytail: NOT a singleton — constructed by `syncServiceProvider` with
+/// [VaultStore] + [EncryptionService], matching the Phase 2 service style.
+/// Per locked decision #5 this avoids a 13th `instance` singleton.
 class SyncService {
-  SyncService._();
+  SyncService(this._store, this._crypto);
+
+  final VaultStore _store;
+  final EncryptionService _crypto;
+
+  /// One-shot sync against [profile]'s WebDAV server. Reads the local index +
+  /// master key, builds the transport, delegates to [runSync]. The caller
+  /// persists [SyncResult.refreshedLocal] (the SyncProvider does this).
+  Future<SyncResult> syncNow({
+    required SyncProfile profile,
+    required String password,
+    required String deviceId,
+    void Function(SyncProgress)? onProgress,
+  }) async {
+    final remote = WebDAVStore(
+      baseUrl: profile.serverUrl,
+      username: profile.username ?? '',
+      password: password,
+      basePath: profile.basePath,
+    );
+    final local = await _store.loadFileIndex();
+    final masterKey = await _crypto.getMasterKey();
+    return runSync(
+      local: local,
+      masterKey: masterKey,
+      remote: remote,
+      deviceId: deviceId,
+      direction: profile.direction,
+      onProgress: onProgress,
+    );
+  }
+
+  /// Core push-only engine. Fetches + decrypts the remote manifest, reconciles,
+  /// uploads new/changed blobs, reaps tombstones, then commits the encrypted
+  /// manifest last (the commit point — a crash before this leaves the old
+  /// manifest describing a consistent state, and the next run is idempotent).
+  ///
+  /// Pull execution (two-way restore) is Phase S3.1 — [plan.toPull] is computed
+  /// but not imported yet. Throws if a non-deleted file's blob is unreadable;
+  /// the caller treats that as a failed sync (content-addressed puts are
+  /// idempotent, so a partial run is safe to retry).
+  static Future<SyncResult> runSync({
+    required List<VaultedFile> local,
+    required Uint8List masterKey,
+    required RemoteStore remote,
+    required String deviceId,
+    SyncDirection direction = SyncDirection.pushOnly,
+    DateTime? now,
+    void Function(SyncProgress)? onProgress,
+  }) async {
+    final completedAt = (now ?? DateTime.now()).toUtc();
+
+    onProgress?.call(const SyncProgress(phase: SyncPhase.connecting));
+    final remoteBytes = await remote.getManifest();
+    final remoteManifest = remoteBytes == null
+        ? null
+        : decryptManifest(remoteBytes, masterKey);
+
+    // First sync (no remote manifest) → everything non-deleted is a push.
+    final plan = remoteManifest == null
+        ? SyncPlan(
+            toPush: local.where((f) => !f.syncedDeleted).toList(),
+          )
+        : reconcile(local: local, remote: remoteManifest);
+
+    final pushIds = <String>{for (final p in plan.toPush) p.id};
+    final refreshed = <VaultedFile>[];
+    var pushed = 0;
+    final total = local.where((f) => !f.syncedDeleted).length;
+    var processed = 0;
+
+    for (final f in local) {
+      if (f.syncedDeleted) {
+        refreshed.add(f);
+        continue;
+      }
+      if (pushIds.contains(f.id)) {
+        final blob = await File(f.vaultPath).readAsBytes();
+        final hash = sha256Hex(blob);
+        await remote.putBlob(blobNameFor(hash), blob);
+        pushed++;
+        refreshed.add(
+          f.copyWith(
+            remoteHash: hash,
+            modifiedAt: f.modifiedAt ?? completedAt,
+          ),
+        );
+      } else {
+        refreshed.add(f);
+      }
+      processed++;
+      onProgress?.call(SyncProgress(
+        phase: SyncPhase.uploading,
+        completed: processed,
+        total: total,
+      ));
+    }
+
+    for (final name in plan.toDelete) {
+      await remote.deleteBlob(name);
+    }
+
+    // ponytail: pull import is S3.1; reconcile computed toPull, we don't act.
+
+    onProgress?.call(const SyncProgress(phase: SyncPhase.committing));
+    final manifest =
+        buildManifest(refreshed, deviceId: deviceId, now: completedAt);
+    await remote.putManifest(encryptManifest(manifest, masterKey));
+    onProgress?.call(
+        SyncProgress(phase: SyncPhase.done, completed: total, total: total));
+
+    return SyncResult(
+      blobsPushed: pushed,
+      blobsDeleted: plan.toDelete.length,
+      blobsPulled: 0,
+      plan: plan,
+      refreshedLocal: refreshed,
+      completedAt: completedAt,
+    );
+  }
+
+  // ---- Pure helpers (no I/O) ----
 
   /// Encrypted manifest blob name on the remote store.
   static const String manifestName = RemoteStore.manifestName;
@@ -49,8 +217,9 @@ class SyncService {
   /// Sharding keeps any one directory from bloating; the hash is the sha256 of
   /// the ciphertext, so identical ciphertext dedups to one blob.
   static String blobNameFor(String contentHashHex) {
-    final padded =
-        contentHashHex.length >= 4 ? contentHashHex : contentHashHex.padLeft(4, '0');
+    final padded = contentHashHex.length >= 4
+        ? contentHashHex
+        : contentHashHex.padLeft(4, '0');
     final a = padded.substring(0, 2);
     final b = padded.substring(2, 4);
     return '$a/$b/$contentHashHex.enc';

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -40,6 +40,10 @@ class VaultService {
   late final VaultStore _store = VaultStore();
   late final EncryptionService _encryptionService = EncryptionService.instance;
 
+  /// The shared vault state holder. Exposed so Riverpod-constructed services
+  /// (e.g. SyncService) can share the same caches without a new singleton.
+  VaultStore get store => _store;
+
   // ponytail: File↔Thumbnail form a construction cycle (each calls the other
   // at runtime, never at construction). Break it with a late non-final
   // back-reference on ThumbnailService that's wired after both exist.

--- a/lib/services/vault_store.dart
+++ b/lib/services/vault_store.dart
@@ -114,8 +114,10 @@ class VaultStore {
     }
   }
 
-  /// Get subdirectory path for file type.
-  String getSubdirectory(VaultedFileType type) {
+  /// Subdirectory name for a file type. Static so the sync pull path (which
+  /// computes a destination before a VaultedFile exists) can reuse it without
+  /// an instance — `getSubdirectory` delegates here.
+  static String subdirFor(VaultedFileType type) {
     switch (type) {
       case VaultedFileType.image:
         return 'images';
@@ -128,6 +130,9 @@ class VaultStore {
         return 'documents';
     }
   }
+
+  /// Get subdirectory path for file type.
+  String getSubdirectory(VaultedFileType type) => subdirFor(type);
 
   // ---- Load / save primitive indexes ----
 

--- a/lib/widgets/floating_capsule_bottom_bar.dart
+++ b/lib/widgets/floating_capsule_bottom_bar.dart
@@ -1,0 +1,310 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import '../themes/app_colors.dart';
+
+/// Which end the import (feature) button parks on when the total item count
+/// is even and there is no exact middle slot.
+enum FeatureSide { left, right }
+
+/// A single tappable entry in the bottom bar.
+class NavTab {
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const NavTab({
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+}
+
+/// A squircle (superellipse) rotated 45° into a curved-diamond orientation.
+/// Convex continuously-curved sides with smoothly rounded points.
+/// `n` is the superellipse exponent: 2 = circle, higher = squarer
+/// (~4-5 is the premium squircle sweet spot).
+class CurvedDiamondBorder extends OutlinedBorder {
+  final double n;
+  final double rotation;
+
+  const CurvedDiamondBorder({
+    this.n = 4.5,
+    this.rotation = math.pi / 4,
+    super.side,
+  });
+
+  static double _sgnPow(double v, double e) =>
+      (v < 0 ? -1.0 : 1.0) * math.pow(v.abs(), e).toDouble();
+
+  @override
+  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) {
+    const steps = 80;
+    final cx = rect.center.dx;
+    final cy = rect.center.dy;
+    final cosR = math.cos(rotation);
+    final sinR = math.sin(rotation);
+
+    final pts = <Offset>[];
+    var maxExt = 0.0;
+    for (var i = 0; i < steps; i++) {
+      final t = 2 * math.pi * i / steps;
+      final ux = _sgnPow(math.cos(t), 2 / n);
+      final uy = _sgnPow(math.sin(t), 2 / n);
+      final x = ux * cosR - uy * sinR;
+      final y = ux * sinR + uy * cosR;
+      final ext = x.abs() > y.abs() ? x.abs() : y.abs();
+      if (ext > maxExt) maxExt = ext;
+      pts.add(Offset(x, y));
+    }
+    final half = rect.width < rect.height ? rect.width / 2 : rect.height / 2;
+    final s = half / maxExt;
+
+    final path = Path();
+    for (var i = 0; i < steps; i++) {
+      final dx = cx + pts[i].dx * s;
+      final dy = cy + pts[i].dy * s;
+      if (i == 0) {
+        path.moveTo(dx, dy);
+      } else {
+        path.lineTo(dx, dy);
+      }
+    }
+    return path..close();
+  }
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) =>
+      getOuterPath(rect, textDirection: textDirection);
+
+  @override
+  ShapeBorder scale(double t) =>
+      CurvedDiamondBorder(n: n, rotation: rotation, side: side.scale(t));
+
+  @override
+  CurvedDiamondBorder copyWith({
+    BorderSide? side,
+    double? n,
+    double? rotation,
+  }) =>
+      CurvedDiamondBorder(
+        n: n ?? this.n,
+        rotation: rotation ?? this.rotation,
+        side: side ?? this.side,
+      );
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {}
+}
+
+/// Floating capsule bottom bar.
+///
+/// Total slots = tabs + the feature (import) button, capped to 5.
+/// When the total is odd the feature sits dead-center and the diamond pokes
+/// above the capsule; when even it parks on [featureSide] inside the capsule.
+class FloatingCapsuleBottomBar extends StatelessWidget {
+  static const int _maxSlots = 5;
+
+  final List<NavTab> tabs;
+  final NavTab feature;
+  final FeatureSide featureSide;
+  final bool showFeature;
+
+  // Geometry
+  static const double _capsuleHeight = 62;
+  static const double _capsuleRadius = 31;
+  static const double _tabWidth = 64;
+  static const double _elevatedDiamond = 58;
+  static const double _inlineDiamond = 44;
+  static const double _protrusion = 20;
+  static const double _squircleN = 4.5;
+
+  const FloatingCapsuleBottomBar({
+    super.key,
+    required this.tabs,
+    required this.feature,
+    this.featureSide = FeatureSide.right,
+    this.showFeature = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // ponytail: hard cap at 5 total slots (feature + up to 4 tabs).
+    final visibleTabs = (tabs.length >= _maxSlots)
+        ? tabs.sublist(0, _maxSlots - 1)
+        : tabs;
+
+    final slots = visibleTabs.length + (showFeature ? 1 : 0);
+    final featureInMiddle = showFeature && slots.isOdd;
+
+    final accent = context.accentColor;
+    final totalHeight = featureInMiddle
+        ? _capsuleHeight + _protrusion
+        : _capsuleHeight;
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        16,
+        0,
+        16,
+        MediaQuery.of(context).padding.bottom + 10,
+      ),
+      child: SizedBox(
+        height: totalHeight,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: Center(
+                child: _capsule(context, visibleTabs, accent, featureInMiddle),
+              ),
+            ),
+            if (featureInMiddle)
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: Center(child: _diamond(context, accent, elevated: true)),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _capsule(
+    BuildContext context,
+    List<NavTab> tabs,
+    Color accent,
+    bool featureInMiddle,
+  ) {
+    List<Widget> rowChildren;
+    if (featureInMiddle) {
+      // Reserve a centered gap for the protruding diamond.
+      final half = tabs.length ~/ 2;
+      final left = tabs.sublist(0, half);
+      final right = tabs.sublist(half);
+      rowChildren = [
+        for (final t in left) _tab(context, t),
+        SizedBox(width: _elevatedDiamond + 6),
+        for (final t in right) _tab(context, t),
+      ];
+    } else {
+      final tabsRow = tabs.map((t) => _tab(context, t)).toList();
+      if (!showFeature) {
+        rowChildren = tabsRow;
+      } else if (featureSide == FeatureSide.left) {
+        rowChildren = [_inlineDiamondSlot(context, accent), ...tabsRow];
+      } else {
+        rowChildren = [...tabsRow, _inlineDiamondSlot(context, accent)];
+      }
+    }
+
+    return Container(
+      height: _capsuleHeight,
+      decoration: BoxDecoration(
+        color: context.backgroundColor,
+        borderRadius: BorderRadius.circular(_capsuleRadius),
+        border: Border.all(color: context.borderColor.withValues(alpha: 0.5)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: context.isDarkMode ? 0.5 : 0.18),
+            blurRadius: 20,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 6),
+      child: Row(mainAxisSize: MainAxisSize.min, children: rowChildren),
+    );
+  }
+
+  Widget _tab(BuildContext context, NavTab tab) {
+    final accent = context.accentColor;
+    final color = tab.selected ? accent : context.textTertiary;
+    return SizedBox(
+      width: _tabWidth,
+      child: Tooltip(
+        message: tab.label,
+        child: InkWell(
+          onTap: tab.onTap,
+          customBorder: const StadiumBorder(),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(tab.icon, size: 22, color: color),
+                const SizedBox(height: 3),
+                Text(
+                  tab.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 10,
+                    fontWeight: tab.selected ? FontWeight.w600 : FontWeight.normal,
+                    color: color,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _inlineDiamondSlot(BuildContext context, Color accent) {
+    return SizedBox(
+      width: _tabWidth,
+      child: Center(child: _diamond(context, accent, elevated: false)),
+    );
+  }
+
+  Widget _diamond(BuildContext context, Color accent, {required bool elevated}) {
+    final size = elevated ? _elevatedDiamond : _inlineDiamond;
+    return Tooltip(
+      message: feature.label,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: feature.onTap,
+          customBorder: const CurvedDiamondBorder(n: _squircleN),
+          child: Container(
+            width: size,
+            height: size,
+            decoration: ShapeDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [accent, accent.withValues(alpha: 0.82)],
+              ),
+              shadows: [
+                BoxShadow(
+                  color: accent.withValues(alpha: 0.45),
+                  blurRadius: elevated ? 16 : 8,
+                  offset: const Offset(0, 6),
+                ),
+              ],
+              shape: const CurvedDiamondBorder(n: _squircleN),
+            ),
+            child: Icon(
+              feature.icon,
+              color: Colors.white,
+              size: elevated ? 28 : 24,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -1,9 +1,11 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:locker/models/remote_manifest.dart';
 import 'package:locker/models/sync_profile.dart';
 import 'package:locker/models/vaulted_file.dart';
+import 'package:locker/services/remote/remote_store.dart';
 import 'package:locker/services/sync_service.dart';
 import 'package:pointycastle/export.dart';
 
@@ -262,4 +264,174 @@ void main() {
       expect(rt.entries.single.deleted, isFalse);
     });
   });
+
+  group('runSync', () {
+    test('push-only: every local file gets a remote blob + manifest lists it, '
+        'and re-running is idempotent', () async {
+      final dir = await Directory.systemTemp.createTemp('locker_sync_');
+      final payloads = [
+        Uint8List.fromList([1, 2, 3, 4]),
+        Uint8List.fromList([5, 6, 7, 8, 9]),
+      ];
+      final paths = <String>[];
+      for (var i = 0; i < payloads.length; i++) {
+        final f = File('${dir.path}/blob$i.enc');
+        await f.writeAsBytes(payloads[i]);
+        paths.add(f.path);
+      }
+
+      final local = [
+        VaultedFile(
+          id: 'a',
+          originalName: 'a.jpg',
+          vaultPath: paths[0],
+          type: VaultedFileType.image,
+          mimeType: 'image/jpeg',
+          fileSize: 4,
+          dateAdded: DateTime(2024, 1, 1),
+          modifiedAt: DateTime(2024, 1, 1),
+        ),
+        VaultedFile(
+          id: 'b',
+          originalName: 'b.mp4',
+          vaultPath: paths[1],
+          type: VaultedFileType.video,
+          mimeType: 'video/mp4',
+          fileSize: 5,
+          dateAdded: DateTime(2024, 1, 2),
+          modifiedAt: DateTime(2024, 1, 2),
+        ),
+      ];
+      final masterKey = Uint8List.fromList(List<int>.generate(32, (i) => i));
+      final remote = _MemStore();
+
+      final result = await SyncService.runSync(
+        local: local,
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'dev1',
+        now: DateTime.utc(2024, 6, 1),
+      );
+
+      expect(result.blobsPushed, 2);
+      expect(result.blobsDeleted, 0);
+      expect(result.blobsPulled, 0);
+
+      final listed = await remote.listBlobs();
+      expect(listed.length, 2);
+
+      final manifest = SyncService.decryptManifest(
+        (await remote.getManifest())!,
+        masterKey,
+      );
+      expect(manifest.deviceId, 'dev1');
+      expect(manifest.entries.map((e) => e.id).toSet(), {'a', 'b'});
+      expect(manifest.entries.every((e) => e.contentHash != null), isTrue);
+
+      // Each manifest entry resolves to a real, matching blob.
+      for (final entry in manifest.entries) {
+        final blob =
+            await remote.getBlob(SyncService.blobNameFor(entry.contentHash!));
+        expect(blob, isNotNull);
+        expect(SyncService.sha256Hex(blob!), entry.contentHash);
+      }
+
+      // Refreshed local carries the new remoteHashes.
+      expect(
+        result.refreshedLocal.every((f) => f.remoteHash != null),
+        isTrue,
+      );
+
+      // Re-running with the refreshed index pushes nothing (in-sync).
+      final result2 = await SyncService.runSync(
+        local: result.refreshedLocal,
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'dev1',
+        now: DateTime.utc(2024, 6, 2),
+      );
+      expect(result2.blobsPushed, 0);
+      expect((await remote.listBlobs()).length, 2);
+
+      await dir.delete(recursive: true);
+    });
+
+    test('tombstone: reaps the remote blob and records a deleted entry',
+        () async {
+      final dir = await Directory.systemTemp.createTemp('locker_sync_tomb_');
+      final f = File('${dir.path}/blob.enc');
+      await f.writeAsBytes(Uint8List.fromList([10, 20, 30]));
+      final masterKey = Uint8List(32);
+
+      // First sync: push one live file.
+      final remote = _MemStore();
+      final live = VaultedFile(
+        id: 'a',
+        originalName: 'a',
+        vaultPath: f.path,
+        type: VaultedFileType.image,
+        mimeType: 'image/jpeg',
+        fileSize: 3,
+        dateAdded: DateTime(2024, 1, 1),
+        modifiedAt: DateTime(2024, 1, 1),
+      );
+      final r1 = await SyncService.runSync(
+        local: [live],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'dev1',
+        now: DateTime.utc(2024, 6, 1),
+      );
+      expect((await remote.listBlobs()).length, 1);
+
+      // Second sync: the file is now a tombstone locally.
+      final tombstoned = r1.refreshedLocal.first
+          .copyWith(syncedDeleted: true, modifiedAt: DateTime(2024, 6, 2));
+      final r2 = await SyncService.runSync(
+        local: [tombstoned],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'dev1',
+        now: DateTime.utc(2024, 6, 3),
+      );
+      expect(r2.blobsDeleted, 1);
+      expect((await remote.listBlobs()).length, 0);
+
+      final manifest = SyncService.decryptManifest(
+        (await remote.getManifest())!,
+        masterKey,
+      );
+      expect(manifest.entries.single.deleted, isTrue);
+
+      await dir.delete(recursive: true);
+    });
+  });
+}
+
+/// In-memory RemoteStore for runSync tests — no network.
+class _MemStore implements RemoteStore {
+  final Map<String, Uint8List> _blobs = {};
+  Uint8List? _manifest;
+
+  @override
+  Future<void> testConnection() async {}
+
+  @override
+  Future<Uint8List?> getManifest() async => _manifest;
+
+  @override
+  Future<void> putManifest(Uint8List bytes) async => _manifest = bytes;
+
+  @override
+  Future<void> putBlob(String name, Uint8List bytes) async =>
+      _blobs[name] = bytes;
+
+  @override
+  Future<Uint8List?> getBlob(String name) async => _blobs[name];
+
+  @override
+  Future<void> deleteBlob(String name) async => _blobs.remove(name);
+
+  @override
+  Future<List<String>> listBlobs() async => _blobs.keys.toList();
 }

--- a/test/sync_service_test.dart
+++ b/test/sync_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/models/encryption_algorithm.dart';
 import 'package:locker/models/remote_manifest.dart';
 import 'package:locker/models/sync_profile.dart';
 import 'package:locker/models/vaulted_file.dart';
@@ -164,6 +165,85 @@ void main() {
       );
       expect(SyncService.reconcile(local: local, remote: remote).isEmpty, isTrue);
     });
+
+    test('conflict: local newer AND remote diverged since last sync', () {
+      final local = [
+        _file(id: 'a', modifiedAt: DateTime(2024, 6, 5), remoteHash: 'old'),
+      ];
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: DateTime(2024, 6, 1),
+        entries: [
+          ManifestEntry(
+            id: 'a',
+            contentHash: 'new',
+            modifiedAt: DateTime(2024, 6, 4),
+          ),
+        ],
+      );
+      final plan = SyncService.reconcile(local: local, remote: remote);
+      expect(plan.toPush.map((f) => f.id), ['a']); // LWW: local still wins
+      expect(plan.conflicts, ['a']); // but flagged
+    });
+
+    test('no conflict when remote unchanged though local is newer', () {
+      final local = [
+        _file(id: 'a', modifiedAt: DateTime(2024, 6, 5), remoteHash: 'same'),
+      ];
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: DateTime(2024, 6, 1),
+        entries: [
+          ManifestEntry(
+            id: 'a',
+            contentHash: 'same',
+            modifiedAt: DateTime(2024, 6, 1),
+          ),
+        ],
+      );
+      final plan = SyncService.reconcile(local: local, remote: remote);
+      expect(plan.toPush.map((f) => f.id), ['a']);
+      expect(plan.conflicts, isEmpty);
+    });
+
+    test('remote tombstone schedules local deletion (LWW: tombstone newer)',
+        () {
+      final local = [_file(id: 'a', modifiedAt: DateTime(2024, 1, 1))];
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: DateTime(2024, 6, 1),
+        entries: [
+          ManifestEntry(
+            id: 'a',
+            contentHash: 'h',
+            modifiedAt: DateTime(2024, 6, 1),
+            deleted: true,
+          ),
+        ],
+      );
+      final plan = SyncService.reconcile(local: local, remote: remote);
+      expect(plan.toTombstoneLocal, ['a']);
+      expect(plan.toPush, isEmpty);
+    });
+
+    test('local newer than remote tombstone resurrects (push)', () {
+      final local = [_file(id: 'a', modifiedAt: DateTime(2024, 6, 5))];
+      final remote = RemoteManifest(
+        deviceId: 'd',
+        generatedAt: DateTime(2024, 1, 1),
+        entries: [
+          ManifestEntry(
+            id: 'a',
+            contentHash: 'h',
+            modifiedAt: DateTime(2024, 1, 1),
+            deleted: true,
+          ),
+        ],
+      );
+      final plan = SyncService.reconcile(local: local, remote: remote);
+      expect(plan.toTombstoneLocal, isEmpty);
+      expect(plan.toPush.map((f) => f.id), ['a']);
+    });
   });
 
   group('manifest crypto', () {
@@ -188,7 +268,7 @@ void main() {
       expect(enc.length, greaterThan(16 + 16));
 
       final dec = SyncService.decryptManifest(enc, masterKey);
-      expect(dec.version, 1);
+      expect(dec.version, 2);
       expect(dec.deviceId, 'device-1');
       expect(dec.entries.map((e) => e.id), ['a', 'b']);
       expect(dec.entries.first.contentHash, 'hash-a');
@@ -262,6 +342,59 @@ void main() {
       expect(rt.entries.single.id, 'a');
       expect(rt.entries.single.contentHash, 'h');
       expect(rt.entries.single.deleted, isFalse);
+    });
+
+    test('manifest v2 round-trips restore metadata + tolerates v1 entries', () {
+      final manifest = SyncService.buildManifest(
+        [
+          VaultedFile(
+            id: 'a',
+            originalName: 'a.jpg',
+            vaultPath: '/v/a',
+            type: VaultedFileType.image,
+            mimeType: 'image/jpeg',
+            fileSize: 5,
+            dateAdded: DateTime(2024, 1, 1),
+            modifiedAt: DateTime(2024, 1, 1),
+            isEncrypted: true,
+            encryptionIv: 'iv',
+            keyDerivationSalt: 'salt',
+            kdfIterations: 1000,
+            encryptionAlgorithm: EncryptionAlgorithm.aes256Gcm,
+            tags: const ['t'],
+            isFavorite: true,
+            albumIds: const ['al'],
+            folderId: 'f1',
+          ),
+        ],
+        deviceId: 'd',
+        now: DateTime.utc(2024, 6, 1),
+      );
+      expect(manifest.version, 2);
+      final e = RemoteManifest.fromJsonString(manifest.toJsonString())
+          .entries
+          .single;
+      expect(e.originalName, 'a.jpg');
+      expect(e.type, 'image');
+      expect(e.mimeType, 'image/jpeg');
+      expect(e.isEncrypted, isTrue);
+      expect(e.encryptionIv, 'iv');
+      expect(e.encryptionAlgorithm, 'aes256Gcm');
+      expect(e.kdfIterations, 1000);
+      expect(e.tags, ['t']);
+      expect(e.isFavorite, isTrue);
+      expect(e.albumIds, ['al']);
+      expect(e.folderId, 'f1');
+
+      // v1 read-compat: a manifest missing the v2 keys defaults sanely.
+      const v1Json = '{"version":1,"deviceId":"d",'
+          '"generatedAt":"2024-01-01T00:00:00.000Z",'
+          '"entries":[{"id":"x","contentHash":null,'
+          '"modifiedAt":"2024-01-01T00:00:00.000Z","deleted":false}]}';
+      final v1 = RemoteManifest.fromJsonString(v1Json);
+      expect(v1.entries.single.tags, isEmpty);
+      expect(v1.entries.single.isEncrypted, isFalse);
+      expect(v1.entries.single.encryptionAlgorithm, isNull);
     });
   });
 
@@ -356,6 +489,58 @@ void main() {
       await dir.delete(recursive: true);
     });
 
+    test(
+        'push-only: a local file whose blob is missing on disk is skipped, '
+        'not fatal (e.g. a deleted password shadow entry)', () async {
+      final dir = await Directory.systemTemp.createTemp('locker_sync_skip_');
+      final live = File('${dir.path}/live.enc');
+      await live.writeAsBytes(Uint8List.fromList([1, 2, 3, 4]));
+      final masterKey = Uint8List.fromList(List<int>.generate(32, (i) => i));
+
+      final local = [
+        VaultedFile(
+          id: 'live',
+          originalName: 'live.jpg',
+          vaultPath: live.path,
+          type: VaultedFileType.image,
+          mimeType: 'image/jpeg',
+          fileSize: 4,
+          dateAdded: DateTime(2024, 1, 1),
+          modifiedAt: DateTime(2024, 1, 1),
+        ),
+        VaultedFile(
+          id: 'orphan',
+          originalName: 'orphan.pwd',
+          vaultPath: '${dir.path}/passwords/never-written.enc',
+          type: VaultedFileType.document,
+          mimeType: 'application/octet-stream',
+          fileSize: 0,
+          dateAdded: DateTime(2024, 1, 2),
+          modifiedAt: DateTime(2024, 1, 2),
+        ),
+      ];
+      final remote = _MemStore();
+
+      final result = await SyncService.runSync(
+        local: local,
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'dev1',
+        now: DateTime.utc(2024, 6, 1),
+      );
+
+      expect(result.blobsPushed, 1);
+      expect(result.blobsSkipped, 1);
+      // Only the live file produced a blob.
+      expect((await remote.listBlobs()).length, 1);
+      // The orphan is retained unchanged (sync never mutates local state
+      // destructively) and carries no remote hash.
+      final orphan = result.refreshedLocal.firstWhere((f) => f.id == 'orphan');
+      expect(orphan.remoteHash, isNull);
+
+      await dir.delete(recursive: true);
+    });
+
     test('tombstone: reaps the remote blob and records a deleted entry',
         () async {
       final dir = await Directory.systemTemp.createTemp('locker_sync_tomb_');
@@ -404,6 +589,239 @@ void main() {
       expect(manifest.entries.single.deleted, isTrue);
 
       await dir.delete(recursive: true);
+    });
+
+    test('two-way: device B pulls a file device A pushed', () async {
+      final dirA = await Directory.systemTemp.createTemp('locker_tw_a_');
+      final dirB = await Directory.systemTemp.createTemp('locker_tw_b_');
+      final masterKey = Uint8List(32);
+      final remote = _MemStore();
+
+      final blobA = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final pathA = '${dirA.path}/images/a.jpg';
+      await File(pathA).parent.create(recursive: true);
+      await File(pathA).writeAsBytes(blobA);
+      final fileA = VaultedFile(
+        id: 'a',
+        originalName: 'a.jpg',
+        vaultPath: pathA,
+        type: VaultedFileType.image,
+        mimeType: 'image/jpeg',
+        fileSize: 5,
+        dateAdded: DateTime(2024, 1, 1),
+        modifiedAt: DateTime(2024, 1, 1),
+        isEncrypted: true,
+        encryptionIv: 'iv',
+        keyDerivationSalt: 'salt',
+        kdfIterations: 1000,
+        encryptionAlgorithm: EncryptionAlgorithm.aes256Gcm,
+        tags: const ['t'],
+      );
+
+      // A pushes.
+      final rA = await SyncService.runSync(
+        local: [fileA],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 1),
+      );
+      expect(rA.blobsPushed, 1);
+
+      // B pulls (empty local).
+      final rB = await SyncService.runSync(
+        local: const [],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'B',
+        vaultRoot: dirB.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 2),
+      );
+      expect(rB.blobsPulled, 1);
+      expect(rB.refreshedLocal.length, 1);
+      final pulled = rB.refreshedLocal.single;
+      expect(pulled.id, 'a');
+      expect(pulled.originalName, 'a.jpg');
+      expect(pulled.type, VaultedFileType.image);
+      expect(pulled.isEncrypted, isTrue);
+      expect(pulled.encryptionIv, 'iv');
+      expect(pulled.encryptionAlgorithm, EncryptionAlgorithm.aes256Gcm);
+      expect(pulled.kdfIterations, 1000);
+      expect(pulled.tags, ['t']);
+      expect(pulled.remoteHash, rA.refreshedLocal.first.remoteHash);
+      expect(await File(pulled.vaultPath).exists(), isTrue);
+      expect(await File(pulled.vaultPath).readAsBytes(), blobA);
+
+      await dirA.delete(recursive: true);
+      await dirB.delete(recursive: true);
+    });
+
+    test('two-way: device B edits → device A pulls the edit', () async {
+      final dirA = await Directory.systemTemp.createTemp('locker_edit_a_');
+      final dirB = await Directory.systemTemp.createTemp('locker_edit_b_');
+      final masterKey = Uint8List(32);
+      final remote = _MemStore();
+
+      // Seed A with a file and push.
+      final pathA = '${dirA.path}/images/a.jpg';
+      await File(pathA).parent.create(recursive: true);
+      await File(pathA).writeAsBytes(Uint8List.fromList([1, 1, 1]));
+      final seeded = VaultedFile(
+        id: 'a',
+        originalName: 'a.jpg',
+        vaultPath: pathA,
+        type: VaultedFileType.image,
+        mimeType: 'image/jpeg',
+        fileSize: 3,
+        dateAdded: DateTime(2024, 1, 1),
+        modifiedAt: DateTime(2024, 1, 1),
+      );
+      await SyncService.runSync(
+        local: [seeded],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 1),
+      );
+
+      // B pulls.
+      final rB = await SyncService.runSync(
+        local: const [],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'B',
+        vaultRoot: dirB.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 2),
+      );
+      final onB = rB.refreshedLocal.single;
+
+      // B edits: new ciphertext bytes + bumped modifiedAt (remoteHash goes stale).
+      final edited = Uint8List.fromList([2, 2, 2, 2]);
+      await File(onB.vaultPath).writeAsBytes(edited);
+      final bEdited = onB.copyWith(modifiedAt: DateTime(2024, 6, 3));
+
+      // B pushes the edit.
+      await SyncService.runSync(
+        local: [bEdited],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'B',
+        vaultRoot: dirB.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 3),
+      );
+
+      // A pulls the edit using A's refreshed index from the first push.
+      final rA2 = await SyncService.runSync(
+        local: [
+          VaultedFile(
+            id: 'a',
+            originalName: 'a.jpg',
+            vaultPath: pathA,
+            type: VaultedFileType.image,
+            mimeType: 'image/jpeg',
+            fileSize: 3,
+            dateAdded: DateTime(2024, 1, 1),
+            modifiedAt: DateTime(2024, 1, 1),
+            remoteHash: rB.refreshedLocal.first.remoteHash,
+          ),
+        ],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 4),
+      );
+      expect(rA2.blobsPulled, 1);
+      final onA = rA2.refreshedLocal.single;
+      expect(await File(onA.vaultPath).readAsBytes(), edited);
+      expect(onA.remoteHash, isNot(rB.refreshedLocal.first.remoteHash));
+
+      await dirA.delete(recursive: true);
+      await dirB.delete(recursive: true);
+    });
+
+    test('two-way: device A deletes → device B tombstones locally', () async {
+      final dirA = await Directory.systemTemp.createTemp('locker_del_a_');
+      final dirB = await Directory.systemTemp.createTemp('locker_del_b_');
+      final masterKey = Uint8List(32);
+      final remote = _MemStore();
+
+      // A seeds + pushes.
+      final pathA = '${dirA.path}/images/a.jpg';
+      await File(pathA).parent.create(recursive: true);
+      await File(pathA).writeAsBytes(Uint8List.fromList([9, 9]));
+      final rA = await SyncService.runSync(
+        local: [
+          VaultedFile(
+            id: 'a',
+            originalName: 'a.jpg',
+            vaultPath: pathA,
+            type: VaultedFileType.image,
+            mimeType: 'image/jpeg',
+            fileSize: 2,
+            dateAdded: DateTime(2024, 1, 1),
+            modifiedAt: DateTime(2024, 1, 1),
+          ),
+        ],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 1),
+      );
+
+      // B pulls the live file.
+      final rB = await SyncService.runSync(
+        local: const [],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'B',
+        vaultRoot: dirB.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 2),
+      );
+      final onB = rB.refreshedLocal.single;
+      expect(await File(onB.vaultPath).exists(), isTrue);
+
+      // A deletes (tombstone) + pushes; blob reaped.
+      final tombstoned =
+          rA.refreshedLocal.first.copyWith(syncedDeleted: true);
+      await SyncService.runSync(
+        local: [tombstoned],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 3),
+      );
+      expect((await remote.listBlobs()).length, 0);
+
+      // B syncs again → remote tombstone propagates, B's file is deleted.
+      final rB2 = await SyncService.runSync(
+        local: rB.refreshedLocal,
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'B',
+        vaultRoot: dirB.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 4),
+      );
+      final bAfter = rB2.refreshedLocal.single;
+      expect(bAfter.syncedDeleted, isTrue);
+      expect(await File(onB.vaultPath).exists(), isFalse);
+
+      await dirA.delete(recursive: true);
+      await dirB.delete(recursive: true);
     });
   });
 }


### PR DESCRIPTION
# Summary

Adds two-way vault sync with conflict detection, a v2 manifest carrying full restore metadata (tags, favorites, albums, folders, encryption params), WebDAV transport with generous timeouts, a sync settings screen with multi-profile support, and comprehensive sync tests.

# Changes

## Sync Engine

- Add two-way sync support with conflict detection (LWW, tombstones, local resurrection)
- Run sync engine in an isolate to keep UI responsive
- Add progress reporting and instance-based `SyncService`
- Add sync result summary and duration to `SyncState`
- Add per-device id generation and caching to `SyncProfileService`

## Manifest v2

- Bump manifest schema to v2 with full restore metadata (`originalName`, `type`, `mimeType`, `fileSize`, encryption fields, `tags`, `isFavorite`, `albumIds`, `folderId`)
- Enable fresh-device reconstruction from remote manifest

## WebDAV

- Set generous timeouts on WebDAV client for NAS and cold server connections
- Allow cleartext traffic in network security config

## UI

- Add sync settings screen for local-server sync
- Refactor sync settings screen for multi-profile support (one active sync target, delete confirmation, auto-activation)
- Add sync provider with Riverpod state management + connectivity guard
- Add Server Sync option to vault settings
- Add `FloatingCapsuleBottomBar` widget with curved diamond border
- Replace custom bottom bar with configurable import button side

## VaultStore

- Add `VaultStore.getSubdirectory` refactored into static `subdirFor`
- Expose `VaultStore` getter on `VaultService` for shared access

## Testing

- Add conflict resolution tests (LWW divergence, remote tombstone, resurrection)
- Add manifest v2 round-trip test with v1 backward-compat defaults
- Add two-way sync integration tests (pull pushed file, pull remote edit, propagate tombstone)
- Add `runSync` tests for push and tombstone scenarios with in-memory store

## Documentation

- Add embedded PocketBase local store design doc
- Update `local_server_sync.md` (S3 implemented, manifest v2, S3 ceilings)