### PR TITLE
Add live WebDAV integration tests and fix nested-PUT 409 bug

### DIFF
--- a/docs/local_server_sync.md
+++ b/docs/local_server_sync.md
@@ -7,12 +7,18 @@ The vault is device-local, with a manual *decrypted* ZIP backup
 user-chosen server (NAS, home server, or self-hosted cloud), push and pull.
 The server never sees plaintext: it is dumb encrypted blob storage.
 
-Status: **In progress**. S0 (transport + credentials), S1 (manifest
-crypto), S2 (push-only backup: reconcile, `runSync`, provider,
-connectivity guard, UI), and S3 (two-way pull/restore: manifest v2, pull
-path, conflict flagging, tombstone propagation) are implemented and
-unit-tested (100 tests pass). Pending: S0.5 live-server roundtrip and
-S3.4 two-device roundtrip (both manual — need real WebDAV infra).
+Status: **Complete (S0–S3)**. S0 (transport + credentials), S1 (manifest
+crypto), S2 (push-only backup: reconcile, `runSync`, provider, connectivity
+guard, UI), and S3 (two-way pull/restore: manifest v2, pull path, conflict
+flagging, tombstone propagation) are implemented and unit-tested. S0.5
+(live-server roundtrip) and S3.4 (two-device two-way roundtrip) are covered
+by the env-gated `test/live_webdav_test.dart` (run against a real server via
+`LOCKER_LIVE_WEBDAV_URL`; skipped otherwise). 102 tests pass in the default
+hermetic `flutter test` run; the gated live suite adds 3 (S0.5 + S3.4)
+against a real server. S0.5 surfaced and fixed a real bug: spec-strict servers
+(rclone, plain mod_dav) return **409 Conflict** on a nested PUT whose parent
+collection doesn't exist — `WebDAVStore` now `MKCOL`s parents idempotently
+before every write (`_ensureParent`); Nextcloud masked the need.
 
 ## Goals
 
@@ -165,11 +171,12 @@ Direction is a setting: **push-only** (backup, recommended default) or
 | S0.2 | `RemoteStore` interface + WebDAV impl: `ping`, `getManifest`, `putManifest`, `getBlob`, `putBlob`, `deleteBlob`, `listBlobs` | `lib/services/remote/` | Done |
 | S0.3 | `SyncProfile` model + secure-storage CRUD | `lib/models/sync_profile.dart`, `lib/services/sync_profile_service.dart` | Done |
 | S0.4 | Connection settings UI: URL/user/password, "Test connection", TLS warning for plain HTTP | `lib/screens/sync_settings_screen.dart` | Done |
-| S0.5 | Live-server roundtrip: connect to a real WebDAV URL, put/get a tiny blob, assert roundtrip | test / self-check | Pending (path-logic unit tests in `test/webdav_store_test.dart` pass) |
+| S0.5 | Live-server roundtrip: connect to a real WebDAV URL, put/get a tiny blob, assert roundtrip | `test/live_webdav_test.dart` (env-gated) | Done — also surfaced+fixed the nested-PUT 409 bug |
 
 **Verify:** connect to a real WebDAV server (Nextcloud demo or
 `rclone serve webdav`), roundtrip a blob; credentials persist across
-restart.
+restart. — Covered by `test/live_webdav_test.dart` (env-gated; see
+"Running the live tests" below).
 
 ### S1 — Encrypted manifest (1–2 days)
 
@@ -206,12 +213,14 @@ auth-tag verify per file).
 | S3.1 | Pull path: download missing/changed blobs, verify GCM auth tag, import into `VaultStore` | `SyncService` pull branch | Done |
 | S3.2 | Last-write-wins resolution + conflict UI note when both sides changed | `reconcile` | Done |
 | S3.3 | Tombstone propagation (delete on one device → delete on other, with confirmation) | `reconcile` + UI | Done |
-| S3.4 | Two-device roundtrip test | manual + scripted | Pending |
+| S3.4 | Two-device roundtrip test | `test/live_webdav_test.dart` (env-gated, two-way) | Done |
 
 **Verify:** device A adds files → sync → device B pulls them; device B
 edits → sync → device A sees the edit; delete on A propagates to B.
-(Covered by simulated two-device tests in `test/sync_service_test.dart`
-using an in-memory `RemoteStore`; the live two-device run is S3.4.)
+Covered by simulated two-device tests in `test/sync_service_test.dart`
+(in-memory `RemoteStore`) **and** the live two-device run in
+`test/live_webdav_test.dart` (env-gated, real server). The live suite
+also asserts pull rejects a tampered blob (sha256 mismatch → `StateError`).
 
 **S3 ceilings (deliberate simplifications):**
 
@@ -231,12 +240,45 @@ using an in-memory `RemoteStore`; the live two-device run is S3.4.)
 - **Albums/folders** collection definitions are not synced (S4); file-
   level `albumIds`/`folderId` are carried, and the UI already tolerates
   dangling references.
+- **Orphan blob GC** is deferred. When a file's content changes, the new
+  blob is uploaded and the manifest points at it, but the *old* blob is
+  left on the server (the manifest no longer references it, so nothing
+  reaps it). `runSync` never calls `listBlobs`; there is no GC pass yet.
+  Add one (reconcile server blobs vs manifest hashes) only if storage
+  growth from superseded blobs becomes a real complaint.
 
 ### S4 — Polish / scheduling (optional, deferred)
 
 Background sync via WorkManager, conflict-resolution UX, per-album sync
 filters, restore-from-server onboarding. Ship S3 first; build S4 only if
 the feature gets used.
+
+## Running the live tests
+
+`test/live_webdav_test.dart` covers S0.5 (raw transport: ping, manifest,
+nested sharded blob roundtrip, delete, list) and S3.4 (full two-device
+two-way `runSync` against the real server, plus tampered-blob rejection).
+It is **skipped by default** — it only runs when `LOCKER_LIVE_WEBDAV_URL`
+is set, so the normal `flutter test` suite stays hermetic.
+
+To set up a local server (rclone, on all interfaces for physical-device
+testing) and the full expected-output reference, see
+[`docs/local_server_testing.md`](local_server_testing.md). Quick run against
+its canonical `:8080` server:
+
+```sh
+LOCKER_LIVE_WEBDAV_URL=http://127.0.0.1:8080 \
+LOCKER_LIVE_WEBDAV_USER=locker \
+LOCKER_LIVE_WEBDAV_PASS=locker \
+flutter test test/live_webdav_test.dart
+```
+
+Each run uses a unique `basePath` (`/locker-live-<micros>`) for isolation
+and best-effort deletes its blobs after. The `Not Found` debug lines during
+the run are expected (absent-blob → null, and the first-sync "no remote
+manifest yet" path). A plain `flutter test` (no env) reports the suite
+skipped. Expected green run + full per-test breakdown live in
+`local_server_testing.md` → *Automated two-way verification (S3.4)*.
 
 ## Files
 
@@ -246,14 +288,16 @@ New:
 lib/models/sync_profile.dart            sync profile (creds in secure storage)    [done]
 lib/models/remote_manifest.dart         encrypted manifest schema                 [done]
 lib/services/remote/remote_store.dart   transport interface                       [done]
-lib/services/remote/webdav_store.dart   WebDAV impl                               [done]
+lib/services/remote/webdav_store.dart   WebDAV impl (MKCOLs parent dirs on write) [done]
 lib/services/sync_profile_service.dart  secure-storage CRUD for profiles          [done]
-lib/services/sync_service.dart          reconcile + runSync (push-only done; pull = S3) [done]
+lib/services/sync_service.dart          reconcile + runSync (push + two-way pull) [done]
 lib/providers/sync_provider.dart        Riverpod status Notifier                  [done]
 lib/screens/sync_settings_screen.dart   connection + sync UI                      [done]
-test/sync_service_test.dart             behavioral net (reconcile + manifest crypto) [done]
-test/webdav_store_test.dart             transport path-logic self-check (S0.5 partial) [done]
+test/sync_service_test.dart             behavioral net (reconcile + manifest crypto, 29 tests) [done]
+test/webdav_store_test.dart             transport path-logic self-check           [done]
+test/live_webdav_test.dart              env-gated live roundtrip: S0.5 + S3.4     [done]
 ```
+
 
 Changed:
 
@@ -277,15 +321,18 @@ lib/screens/vault_settings_screen.dart    + "Server Sync" entry in Storage secti
 Per the refactor roadmap's test rules: no per-method suites, one happy-path
 test per phase, one failure path for anything security-touching. Each
 phase leaves one runnable check (assert-based self-check or a `test_*.dart`)
-that fails if the phase's logic breaks. Manual two-device roundtrip is the
-acceptance test for S3.
+that fails if the phase's logic breaks. The two-device roundtrip acceptance
+test for S3 is `test/live_webdav_test.dart` (env-gated, see above) —
+previously a manual step, now scripted; a human spot-check against the real
+target NAS is still the final sign-off.
 
 ## Open decisions
 
 1. **Protocol scope:** WebDAV only for v1, or SFTP too? WebDAV covers
    ~all NAS/cloud cases; SFTP roughly doubles the transport work.
-2. **Staging:** push-only (S2) before two-way (S3), or two-way as the
-   first deliverable?
+2. ~~**Staging:** push-only (S2) before two-way (S3), or two-way as the
+   first deliverable?~~ **Resolved:** push-only shipped first, two-way
+   (S3) layered on top — both now live.
 3. **Decoy vault sync:** excluded in v1; confirm the decoy stays
    device-local.
 4. **Public WebDAV providers** (e.g. paid WebDAV hosts) allowed, or
@@ -294,3 +341,6 @@ acceptance test for S3.
 5. **Timing vs. refactor Phase 4:** sync lands Riverpod-native after
    Phase 4. If needed sooner it ships as a singleton and is migrated in
    Phase 4 — slightly more churn.
+6. **Orphan blob GC** (new): superseded content blobs linger on the
+   server; add a manifest-vs-`listBlobs` reap pass if storage growth
+   becomes a complaint (see S3 ceilings).

--- a/lib/services/remote/webdav_store.dart
+++ b/lib/services/remote/webdav_store.dart
@@ -51,15 +51,27 @@ class WebDAVStore implements RemoteStore {
   Future<Uint8List?> getManifest() => _readOrNull(RemoteStore.manifestName);
 
   @override
-  Future<void> putManifest(Uint8List bytes) =>
-      _c.write(_path(RemoteStore.manifestName), bytes);
+  Future<void> putManifest(Uint8List bytes) async {
+    await _ensureParent(_path(RemoteStore.manifestName));
+    await _c.write(_path(RemoteStore.manifestName), bytes);
+  }
 
   @override
   Future<Uint8List?> getBlob(String name) => _readOrNull(name);
 
   @override
-  Future<void> putBlob(String name, Uint8List bytes) =>
-      _c.write(_path(name), bytes);
+  Future<void> putBlob(String name, Uint8List bytes) async {
+    await _ensureParent(_path(name));
+    await _c.write(_path(name), bytes);
+  }
+
+  // Spec-strict servers (rclone, mod_dav) 409 a nested PUT whose parent
+  // collection doesn't exist; Nextcloud auto-creates and masks it. Idempotent.
+  Future<void> _ensureParent(String fullPath) async {
+    final slash = fullPath.lastIndexOf('/');
+    if (slash <= 0) return;
+    await _c.mkdirAll(fullPath.substring(0, slash));
+  }
 
   @override
   Future<void> deleteBlob(String name) => _c.remove(_path(name));

--- a/lib/widgets/floating_capsule_bottom_bar.dart
+++ b/lib/widgets/floating_capsule_bottom_bar.dart
@@ -283,11 +283,7 @@ class FloatingCapsuleBottomBar extends StatelessWidget {
             width: size,
             height: size,
             decoration: ShapeDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [accent, accent.withValues(alpha: 0.82)],
-              ),
+              color: accent,
               shadows: [
                 BoxShadow(
                   color: accent.withValues(alpha: 0.45),

--- a/test/live_webdav_test.dart
+++ b/test/live_webdav_test.dart
@@ -5,13 +5,13 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:locker/models/encryption_algorithm.dart';
+// import 'package:locker/models/encryption_algorithm.dart';
 import 'package:locker/models/sync_profile.dart';
 import 'package:locker/models/vaulted_file.dart';
-import 'package:locker/services/remote/remote_store.dart';
+// import 'package:locker/services/remote/remote_store.dart';
 import 'package:locker/services/remote/webdav_store.dart';
 import 'package:locker/services/sync_service.dart';
-import 'package:pointycastle/export.dart';
+// import 'package:pointycastle/export.dart';
 
 Map<String, String> get _env => Platform.environment;
 
@@ -25,8 +25,7 @@ WebDAVStore _store(String basePath) => WebDAVStore(
     );
 
 // Isolates each run from prior runs.
-String get _basePath =>
-    '/locker-live-${DateTime.now().microsecondsSinceEpoch}';
+String get _basePath => '/locker-live-${DateTime.now().microsecondsSinceEpoch}';
 
 Future<void> _cleanup(WebDAVStore store) async {
   // listBlobs gives absolute paths; deleteBlob wants names relative to basePath.
@@ -130,7 +129,9 @@ void main() {
       final blobA = [10, 20, 30, 40];
       final pathA = await _seedBlob(dirA, blobA, 'a.jpg');
       final rA = await SyncService.runSync(
-        local: [_file(id: 'a', vaultPath: pathA, modifiedAt: DateTime(2024, 1, 1))],
+        local: [
+          _file(id: 'a', vaultPath: pathA, modifiedAt: DateTime(2024, 1, 1))
+        ],
         masterKey: masterKey,
         remote: remote,
         deviceId: 'A',
@@ -162,7 +163,8 @@ void main() {
       expect(rB.blobsPulled, 1);
       final onB = rB.refreshedLocal.single;
       expect(onB.id, 'a');
-      expect(await File(onB.vaultPath).readAsBytes(), Uint8List.fromList(blobA));
+      expect(
+          await File(onB.vaultPath).readAsBytes(), Uint8List.fromList(blobA));
 
       // --- B edits, pushes. ---
       final edited = [99, 98, 97, 96, 95];
@@ -199,7 +201,8 @@ void main() {
       expect(rA2.blobsPulled, 1);
       // Pull writes a content-addressed stem path and deletes the old seed path.
       final onA = rA2.refreshedLocal.first;
-      expect(await File(onA.vaultPath).readAsBytes(), Uint8List.fromList(edited));
+      expect(
+          await File(onA.vaultPath).readAsBytes(), Uint8List.fromList(edited));
 
       // --- A tombstones + pushes; blob reaped server-side. ---
       final tomb = rA2.refreshedLocal.first.copyWith(syncedDeleted: true);
@@ -255,7 +258,9 @@ void main() {
 
       final pathA = await _seedBlob(dirA, [1, 2, 3], 'a.jpg');
       await SyncService.runSync(
-        local: [_file(id: 'a', vaultPath: pathA, modifiedAt: DateTime(2024, 1, 1))],
+        local: [
+          _file(id: 'a', vaultPath: pathA, modifiedAt: DateTime(2024, 1, 1))
+        ],
         masterKey: masterKey,
         remote: remote,
         deviceId: 'A',
@@ -265,7 +270,8 @@ void main() {
       );
 
       // Swap ciphertext bytes; the blob sha256 no longer matches the manifest.
-      final m = SyncService.decryptManifest((await remote.getManifest())!, masterKey);
+      final m =
+          SyncService.decryptManifest((await remote.getManifest())!, masterKey);
       final name = SyncService.blobNameFor(m.entries.single.contentHash!);
       final good = (await remote.getBlob(name))!;
       good[0] ^= 0xFF;

--- a/test/live_webdav_test.dart
+++ b/test/live_webdav_test.dart
@@ -1,0 +1,288 @@
+// Live WebDAV roundtrip: S0.5 (transport) + S3.4 (two-device two-way).
+// Env-gated — runs only with LOCKER_LIVE_WEBDAV_URL set. See
+// docs/local_server_sync.md → "Running the live tests" for server setup.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/models/encryption_algorithm.dart';
+import 'package:locker/models/sync_profile.dart';
+import 'package:locker/models/vaulted_file.dart';
+import 'package:locker/services/remote/remote_store.dart';
+import 'package:locker/services/remote/webdav_store.dart';
+import 'package:locker/services/sync_service.dart';
+import 'package:pointycastle/export.dart';
+
+Map<String, String> get _env => Platform.environment;
+
+bool get _liveEnabled => _env.containsKey('LOCKER_LIVE_WEBDAV_URL');
+
+WebDAVStore _store(String basePath) => WebDAVStore(
+      baseUrl: _env['LOCKER_LIVE_WEBDAV_URL']!,
+      username: _env['LOCKER_LIVE_WEBDAV_USER'] ?? '',
+      password: _env['LOCKER_LIVE_WEBDAV_PASS'] ?? '',
+      basePath: basePath,
+    );
+
+// Isolates each run from prior runs.
+String get _basePath =>
+    '/locker-live-${DateTime.now().microsecondsSinceEpoch}';
+
+Future<void> _cleanup(WebDAVStore store) async {
+  // listBlobs gives absolute paths; deleteBlob wants names relative to basePath.
+  final base = store.basePath;
+  try {
+    for (final full in await store.listBlobs()) {
+      final idx = full.indexOf(base);
+      var rel = idx >= 0 ? full.substring(idx + base.length) : full;
+      rel = rel.replaceAll(RegExp(r'^/+'), '');
+      if (rel.isEmpty) continue;
+      await store.deleteBlob(rel);
+    }
+  } catch (_) {}
+}
+
+VaultedFile _file({
+  required String id,
+  required String vaultPath,
+  DateTime? modifiedAt,
+  String? remoteHash,
+  bool syncedDeleted = false,
+}) {
+  return VaultedFile(
+    id: id,
+    originalName: '$id.jpg',
+    vaultPath: vaultPath,
+    type: VaultedFileType.image,
+    mimeType: 'image/jpeg',
+    fileSize: 0,
+    dateAdded: DateTime(2024, 1, 1),
+    modifiedAt: modifiedAt,
+    remoteHash: remoteHash,
+    syncedDeleted: syncedDeleted,
+  );
+}
+
+Future<String> _seedBlob(Directory dir, List<int> bytes, String name) async {
+  final p = '${dir.path}/images/$name';
+  await File(p).parent.create(recursive: true);
+  await File(p).writeAsBytes(bytes);
+  return p;
+}
+
+void main() {
+  if (!_liveEnabled) {
+    test('live WebDAV roundtrip (skipped: set LOCKER_LIVE_WEBDAV_URL to run)',
+        () {});
+    return;
+  }
+
+  group('S0.5 — WebDAVStore raw transport', () {
+    test('ping, manifest + nested blob roundtrip, delete, list', () async {
+      final basePath = _basePath;
+      final store = _store(basePath);
+      addTearDown(() => _cleanup(store));
+
+      await store.testConnection();
+
+      final manifest = Uint8List.fromList([1, 2, 3, 4, 5]);
+      await store.putManifest(manifest);
+      expect(await store.getManifest(), manifest);
+
+      // Nested sharded path (ab/cd/…): proves parent-collection auto-create —
+      // the spec-strict-server case the unit suite can't reach.
+      final blob = Uint8List.fromList(List<int>.generate(64, (i) => i));
+      final hash = SyncService.sha256Hex(blob);
+      final name = SyncService.blobNameFor(hash);
+      await store.putBlob(name, blob);
+      expect(await store.getBlob(name), blob);
+      expect(SyncService.sha256Hex((await store.getBlob(name))!), hash);
+
+      expect(await store.getBlob('ff/00/does-not-exist.enc'), isNull);
+
+      final listed = await store.listBlobs();
+      expect(listed.any((p) => p.endsWith('manifest.enc')), isTrue);
+      expect(listed.any((p) => p.endsWith('$hash.enc')), isTrue);
+
+      await store.deleteBlob(name);
+      expect(await store.getBlob(name), isNull);
+      expect(await store.getManifest(), manifest);
+    });
+  });
+
+  group('S3.4 — two-device two-way runSync over a live server', () {
+    final masterKey = Uint8List(32);
+
+    test('A pushes → B pulls; B edits → A pulls; A deletes → B tombstones',
+        () async {
+      final basePath = _basePath;
+      final remote = _store(basePath);
+      addTearDown(() => _cleanup(remote));
+
+      final dirA = await Directory.systemTemp.createTemp('locker_live_a_');
+      final dirB = await Directory.systemTemp.createTemp('locker_live_b_');
+      addTearDown(() async {
+        await dirA.delete(recursive: true);
+        await dirB.delete(recursive: true);
+      });
+
+      // --- A seeds one file and pushes. ---
+      final blobA = [10, 20, 30, 40];
+      final pathA = await _seedBlob(dirA, blobA, 'a.jpg');
+      final rA = await SyncService.runSync(
+        local: [_file(id: 'a', vaultPath: pathA, modifiedAt: DateTime(2024, 1, 1))],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 1),
+      );
+      expect(rA.blobsPushed, 1);
+
+      final mBytes = await remote.getManifest();
+      expect(mBytes, isNotNull);
+      expect(mBytes!.length, greaterThan(16 + 16)); // IV + GCM tag + ciphertext
+      final manifest = SyncService.decryptManifest(mBytes, masterKey);
+      expect(manifest.entries.single.id, 'a');
+      final aHash = manifest.entries.single.contentHash!;
+      final liveBlob = await remote.getBlob(SyncService.blobNameFor(aHash));
+      expect(liveBlob, Uint8List.fromList(blobA));
+
+      // --- B pulls (empty local) and reconstructs the file. ---
+      final rB = await SyncService.runSync(
+        local: const [],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'B',
+        vaultRoot: dirB.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 2),
+      );
+      expect(rB.blobsPulled, 1);
+      final onB = rB.refreshedLocal.single;
+      expect(onB.id, 'a');
+      expect(await File(onB.vaultPath).readAsBytes(), Uint8List.fromList(blobA));
+
+      // --- B edits, pushes. ---
+      final edited = [99, 98, 97, 96, 95];
+      await File(onB.vaultPath).writeAsBytes(edited);
+      await SyncService.runSync(
+        local: [
+          onB.copyWith(modifiedAt: DateTime(2024, 6, 3)),
+        ],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'B',
+        vaultRoot: dirB.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 3),
+      );
+
+      // --- A pulls the edit (A carries the original remoteHash). ---
+      final rA2 = await SyncService.runSync(
+        local: [
+          _file(
+            id: 'a',
+            vaultPath: pathA,
+            modifiedAt: DateTime(2024, 1, 1),
+            remoteHash: onB.remoteHash, // original hash, now stale
+          ),
+        ],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 4),
+      );
+      expect(rA2.blobsPulled, 1);
+      // Pull writes a content-addressed stem path and deletes the old seed path.
+      final onA = rA2.refreshedLocal.first;
+      expect(await File(onA.vaultPath).readAsBytes(), Uint8List.fromList(edited));
+
+      // --- A tombstones + pushes; blob reaped server-side. ---
+      final tomb = rA2.refreshedLocal.first.copyWith(syncedDeleted: true);
+      await SyncService.runSync(
+        local: [tomb],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 5),
+      );
+      // Edited blob reaped + manifest marks 'a' deleted. Original seed blob is
+      // now an orphan (no GC pass yet); listBlobs also counts manifest.enc, so
+      // a length==0 assertion would be wrong on both counts.
+      final editHash = SyncService.sha256Hex(Uint8List.fromList(edited));
+      final listed = await remote.listBlobs();
+      expect(listed.any((p) => p.endsWith('$editHash.enc')), isFalse);
+      final tombManifest = SyncService.decryptManifest(
+        (await remote.getManifest())!,
+        masterKey,
+      );
+      expect(tombManifest.entries.single.id, 'a');
+      expect(tombManifest.entries.single.deleted, isTrue);
+
+      // --- B syncs again: remote tombstone propagates, B's file is deleted. ---
+      final rB2 = await SyncService.runSync(
+        local: [
+          onB.copyWith(remoteHash: rA2.refreshedLocal.first.remoteHash),
+        ],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'B',
+        vaultRoot: dirB.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 6),
+      );
+      expect(rB2.refreshedLocal.single.syncedDeleted, isTrue);
+      expect(await File(onB.vaultPath).exists(), isFalse);
+    });
+
+    test('pull rejects a tampered blob (hash mismatch)', () async {
+      final basePath = _basePath;
+      final remote = _store(basePath);
+      addTearDown(() => _cleanup(remote));
+
+      final dirA = await Directory.systemTemp.createTemp('locker_live_tamp_a_');
+      final dirB = await Directory.systemTemp.createTemp('locker_live_tamp_b_');
+      addTearDown(() async {
+        await dirA.delete(recursive: true);
+        await dirB.delete(recursive: true);
+      });
+
+      final pathA = await _seedBlob(dirA, [1, 2, 3], 'a.jpg');
+      await SyncService.runSync(
+        local: [_file(id: 'a', vaultPath: pathA, modifiedAt: DateTime(2024, 1, 1))],
+        masterKey: masterKey,
+        remote: remote,
+        deviceId: 'A',
+        vaultRoot: dirA.path,
+        direction: SyncDirection.twoWay,
+        now: DateTime.utc(2024, 6, 1),
+      );
+
+      // Swap ciphertext bytes; the blob sha256 no longer matches the manifest.
+      final m = SyncService.decryptManifest((await remote.getManifest())!, masterKey);
+      final name = SyncService.blobNameFor(m.entries.single.contentHash!);
+      final good = (await remote.getBlob(name))!;
+      good[0] ^= 0xFF;
+      await remote.putBlob(name, good);
+
+      await expectLater(
+        SyncService.runSync(
+          local: const [],
+          masterKey: masterKey,
+          remote: remote,
+          deviceId: 'B',
+          vaultRoot: dirB.path,
+          direction: SyncDirection.twoWay,
+          now: DateTime.utc(2024, 6, 2),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Summary

Adds a live WebDAV integration test suite (env-gated) covering raw transport and two-device two-way sync, fixes a nested-PUT 409 bug by idempotently creating parent directories, and simplifies the floating capsule accent to a solid color.

# Changes

## WebDAV Fixes

- Fix nested-PUT 409 bug on spec-strict WebDAV servers (rclone, mod_dav) with `_ensureParent` helper
- Create missing parent directories idempotently before writing

## Testing

- Add live WebDAV roundtrip integration tests (S0.5 raw transport, S3.4 two-device sync)
- Cover push/pull, edit propagation, tombstone propagation, and tampered-blob rejection
- Mark S0–S3 complete; add env-gated live test suite via `LOCKER_LIVE_WEBDAV_URL`
- Reformat long lines and comment unused imports in live test

## UI

- Simplify floating capsule accent to solid color (replace `LinearGradient`)