### PR TITLE
Add media hold preview and decoy password/note support with error message hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.44.4
       - run: flutter pub get
       - run: flutter analyze
       - run: flutter test

--- a/lib/providers/explorer_providers.dart
+++ b/lib/providers/explorer_providers.dart
@@ -36,6 +36,8 @@ final explorerFileTypeFilterProvider = StateProvider<VaultedFileType?>((ref) {
 
 /// Provider for unfiled files (files that do not belong to any folder)
 final unfiledFilesProvider = FutureProvider<List<VaultedFile>>((ref) async {
+  // ponytail: depend on the vault list so deletes/imports invalidate this too
+  ref.watch(vaultNotifierProvider);
   final vaultService = ref.watch(vaultServiceProvider);
   final isDecoy = ref.watch(isDecoyModeProvider);
   final allFiles = await vaultService.getAllFiles(isDecoy: isDecoy);

--- a/lib/providers/password_providers.dart
+++ b/lib/providers/password_providers.dart
@@ -12,8 +12,6 @@ final passwordServiceProvider = Provider<PasswordService>((ref) {
 
 final passwordSearchQueryProvider = StateProvider<String>((ref) => '');
 
-final selectedPasswordTagProvider = StateProvider<String?>((ref) => null);
-
 class PasswordsNotifier extends Notifier<AsyncValue<List<PasswordEntry>>> {
   @override
   AsyncValue<List<PasswordEntry>> build() {

--- a/lib/providers/sync_provider.dart
+++ b/lib/providers/sync_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/sync_profile.dart';
 import '../services/encryption_service.dart';
+import '../services/remote/server_errors.dart';
 import '../services/sync_profile_service.dart';
 import '../services/sync_service.dart';
 import 'vault_providers.dart';
@@ -130,7 +131,7 @@ class SyncNotifier extends Notifier<SyncState> {
         duration: sw.elapsed,
       );
     } catch (e) {
-      state = SyncState(status: SyncStatus.error, error: e.toString());
+      state = SyncState(status: SyncStatus.error, error: describeServerError(e));
     }
   }
 

--- a/lib/providers/vault_providers.dart
+++ b/lib/providers/vault_providers.dart
@@ -99,6 +99,8 @@ final filteredFilesProvider = FutureProvider<List<VaultedFile>>((ref) async {
 final filesByTypeProvider =
     FutureProvider.family<List<VaultedFile>, VaultedFileType>(
         (ref, type) async {
+  // ponytail: depend on the vault list so deletes/imports invalidate this too
+  ref.watch(vaultNotifierProvider);
   final vaultService = ref.watch(vaultServiceProvider);
   final isDecoy = ref.watch(isDecoyModeProvider);
   final sortOption = ref.watch(sortOptionProvider);
@@ -123,6 +125,8 @@ final albumProvider =
 /// Provider for files in album
 final filesInAlbumProvider =
     FutureProvider.family<List<VaultedFile>, String>((ref, albumId) async {
+  // ponytail: depend on the vault list so deletes/imports invalidate this too
+  ref.watch(vaultNotifierProvider);
   final vaultService = ref.watch(vaultServiceProvider);
   final sortOption = ref.watch(sortOptionProvider);
 
@@ -159,6 +163,8 @@ final subfoldersProvider =
 /// Provider for files in folder
 final filesInFolderProvider =
     FutureProvider.family<List<VaultedFile>, String>((ref, folderId) async {
+  // ponytail: depend on the vault list so deletes/imports invalidate this too
+  ref.watch(vaultNotifierProvider);
   final vaultService = ref.watch(vaultServiceProvider);
   final sortOption = ref.watch(sortOptionProvider);
 
@@ -175,6 +181,8 @@ final tagsProvider = FutureProvider<List<TagInfo>>((ref) async {
 /// Provider for files by tag
 final filesByTagProvider =
     FutureProvider.family<List<VaultedFile>, String>((ref, tag) async {
+  // ponytail: depend on the vault list so deletes/imports invalidate this too
+  ref.watch(vaultNotifierProvider);
   final vaultService = ref.watch(vaultServiceProvider);
   final sortOption = ref.watch(sortOptionProvider);
 
@@ -184,6 +192,8 @@ final filesByTagProvider =
 
 /// Provider for favorite files
 final favoriteFilesProvider = FutureProvider<List<VaultedFile>>((ref) async {
+  // ponytail: depend on the vault list so deletes/imports invalidate this too
+  ref.watch(vaultNotifierProvider);
   final vaultService = ref.watch(vaultServiceProvider);
   final sortOption = ref.watch(sortOptionProvider);
 
@@ -206,6 +216,8 @@ final decoySettingsProvider = FutureProvider<DecoySettings>((ref) async {
 /// Provider for file counts by type
 final fileCountsProvider =
     FutureProvider<Map<VaultedFileType, int>>((ref) async {
+  // ponytail: depend on the vault list so deletes/imports invalidate this too
+  ref.watch(vaultNotifierProvider);
   final vaultService = ref.watch(vaultServiceProvider);
   return await vaultService.getFileCounts();
 });

--- a/lib/screens/album_detail_screen.dart
+++ b/lib/screens/album_detail_screen.dart
@@ -670,7 +670,7 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error exporting file: $e');
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 
@@ -711,7 +711,7 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error opening file: $e');
-      ToastUtils.showError('Failed to open file: $e');
+      ToastUtils.showError('Failed to open file');
     }
   }
 

--- a/lib/screens/audio_recorder_screen.dart
+++ b/lib/screens/audio_recorder_screen.dart
@@ -125,7 +125,7 @@ class _AudioRecorderScreenState extends State<AudioRecorderScreen>
       });
     } catch (e) {
       if (mounted) {
-        ToastUtils.showError('Failed to start recording: $e');
+        ToastUtils.showError('Failed to start recording');
       }
     }
   }
@@ -187,7 +187,7 @@ class _AudioRecorderScreenState extends State<AudioRecorderScreen>
       }
     } catch (e) {
       if (mounted) {
-        ToastUtils.showError('Failed to stop recording: $e');
+        ToastUtils.showError('Failed to stop recording');
       }
     }
   }
@@ -210,7 +210,7 @@ class _AudioRecorderScreenState extends State<AudioRecorderScreen>
       }
     } catch (e) {
       if (mounted) {
-        ToastUtils.showError('Playback failed: $e');
+        ToastUtils.showError('Playback failed');
       }
     }
   }

--- a/lib/screens/change_security_screen.dart
+++ b/lib/screens/change_security_screen.dart
@@ -1,22 +1,13 @@
 import 'dart:async';
-import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '../themes/app_colors.dart';
+
 import '../services/auth_service.dart';
 import '../services/encryption_service.dart';
+import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
-import '../widgets/adaptive_logo.dart';
 import 'gallery_vault_screen.dart';
-
-/// Security option type for the change security screen
-enum SecurityOption {
-  changePassword,
-  changePIN,
-  switchToPassword,
-  switchToPIN,
-  enableBiometric,
-}
 
 /// Screen for changing security credentials
 class ChangeSecurityScreen extends StatefulWidget {
@@ -50,245 +41,79 @@ class _ChangeSecurityScreenState extends State<ChangeSecurityScreen> {
     }
   }
 
-  void _navigateToChangePassword() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => ChangePasswordScreen(
-          currentAuthMethod: _currentAuthMethod!,
-        ),
-      ),
-    );
-  }
-
-  void _navigateToChangePIN() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => ChangePINScreen(
-          currentAuthMethod: _currentAuthMethod!,
-        ),
-      ),
-    );
-  }
-
-  void _navigateToSetupBiometric() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => const BiometricSetupScreen(),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: context.backgroundColor,
-      appBar: AppBar(
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: context.textPrimary),
-          onPressed: () => Navigator.pop(context),
-        ),
-        title: Text(
-          'Security',
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            color: context.textPrimary,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-      ),
-      body: Stack(
-        children: [
-          _isLoading
-              ? Center(
-                  child: CircularProgressIndicator(
+      appBar: AppBar(title: const Text('Security')),
+      body: _isLoading
+          ? Center(
+              child: CircularProgressIndicator(color: context.accentColor),
+            )
+          : ListView(
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+              children: [
+                _sectionTitle('Current'),
+                _currentMethodTile(),
+                const SizedBox(height: 24),
+                _sectionTitle('Authentication'),
+                ..._authOptionTiles(),
+                FutureBuilder<bool>(
+                  future: _authService.isBiometricAvailable(),
+                  builder: (context, snapshot) {
+                    if (snapshot.data == true &&
+                        _currentAuthMethod != 'biometric') {
+                      return _tile(
+                        icon: Icons.fingerprint,
+                        title: 'Biometric Unlock',
+                        subtitle: 'Use fingerprint or face to unlock',
+                        onTap: () => Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const BiometricSetupScreen(),
+                          ),
+                        ),
+                      );
+                    }
+                    return const SizedBox.shrink();
+                  },
+                ),
+                const SizedBox(height: 24),
+                _sectionTitle('Convenience'),
+                SwitchListTile(
+                  value: _autofillEnabled,
+                  onChanged: _handleAutofillToggle,
+                  contentPadding: EdgeInsets.zero,
+                  secondary: Icon(
+                    Icons.password_outlined,
                     color: context.accentColor,
                   ),
-                )
-              : SafeArea(
-                  child: SingleChildScrollView(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        _buildHeader(),
-                        const SizedBox(height: 32),
-                        _buildCurrentMethodCard(),
-                        const SizedBox(height: 28),
-                        _buildSectionTitle('Authentication options'),
-                        const SizedBox(height: 12),
-                        ..._buildAuthOptions(),
-                        const SizedBox(height: 24),
-                        FutureBuilder<bool>(
-                          future: _authService.isBiometricAvailable(),
-                          builder: (context, snapshot) {
-                            if (snapshot.data == true &&
-                                _currentAuthMethod != 'biometric') {
-                              return Column(
-                                crossAxisAlignment: CrossAxisAlignment.stretch,
-                                children: [
-                                  _buildSectionTitle('Biometric'),
-                                  const SizedBox(height: 12),
-                                  _buildOptionCard(
-                                    icon: Icons.fingerprint,
-                                    title: 'Enable Biometric',
-                                    subtitle:
-                                        'Use fingerprint or face to unlock',
-                                    onTap: _navigateToSetupBiometric,
-                                    accentColor: AppColors.darkSuccess,
-                                  ),
-                                ],
-                              );
-                            }
-                            return const SizedBox.shrink();
-                          },
-                        ),
-                        const SizedBox(height: 24),
-                        _buildSectionTitle('Unlock convenience'),
-                        const SizedBox(height: 12),
-                        _buildAutofillToggleCard(),
-                      ],
-                    ),
+                  title: const Text('Autofill Credential'),
+                  subtitle: Text(
+                    'Let password managers fill your PIN or password',
+                    style: TextStyle(fontSize: 12, color: context.textTertiary),
                   ),
                 ),
-        ],
+              ],
+            ),
+    );
+  }
+
+  Widget _sectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Text(
+        title.toUpperCase(),
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+          color: context.accentColor,
+        ),
       ),
     );
   }
 
-  List<Widget> _buildAuthOptions() {
-    switch (_currentAuthMethod) {
-      case 'password':
-        return [
-          _buildOptionCard(
-            icon: Icons.lock_outline,
-            title: 'Change Password',
-            subtitle: 'Update your current password',
-            onTap: _navigateToChangePassword,
-            isPrimary: true,
-          ),
-          const SizedBox(height: 12),
-          _buildOptionCard(
-            icon: Icons.pin_outlined,
-            title: 'Switch to PIN',
-            subtitle: 'Change from password to 6-digit PIN',
-            onTap: _navigateToChangePIN,
-          ),
-        ];
-      case 'pin':
-        return [
-          _buildOptionCard(
-            icon: Icons.pin_outlined,
-            title: 'Change PIN',
-            subtitle: 'Update your current 6-digit PIN',
-            onTap: _navigateToChangePIN,
-            isPrimary: true,
-          ),
-          const SizedBox(height: 12),
-          _buildOptionCard(
-            icon: Icons.lock_outline,
-            title: 'Switch to Password',
-            subtitle: 'Change from PIN to alphanumeric password',
-            onTap: _navigateToChangePassword,
-          ),
-        ];
-      case 'biometric':
-        return [
-          _buildOptionCard(
-            icon: Icons.fingerprint,
-            title: 'Change Biometric',
-            subtitle: 'Update your biometric settings',
-            onTap: _navigateToSetupBiometric,
-            isPrimary: true,
-          ),
-          const SizedBox(height: 12),
-          _buildOptionCard(
-            icon: Icons.lock_outline,
-            title: 'Switch to Password',
-            subtitle: 'Use alphanumeric password instead',
-            onTap: _navigateToChangePassword,
-          ),
-          const SizedBox(height: 12),
-          _buildOptionCard(
-            icon: Icons.pin_outlined,
-            title: 'Switch to PIN',
-            subtitle: 'Use 6-digit PIN instead',
-            onTap: _navigateToChangePIN,
-          ),
-        ];
-      default:
-        return [
-          _buildOptionCard(
-            icon: Icons.lock_outline,
-            title: 'Set Password',
-            subtitle: 'Create an alphanumeric password',
-            onTap: _navigateToChangePassword,
-            isPrimary: true,
-          ),
-        ];
-    }
-  }
-
-  Widget _buildHeader() {
-    return Column(
-      children: [
-        Container(
-          width: 80,
-          height: 80,
-          decoration: BoxDecoration(
-            color: context.accentColor.withValues(alpha: 0.12),
-            shape: BoxShape.circle,
-          ),
-          child: Icon(
-            Icons.shield_outlined,
-            size: 40,
-            color: context.accentColor,
-          ),
-        ),
-        const SizedBox(height: 20),
-        Text(
-          'Secure your vault',
-          style: TextStyle(
-            fontSize: 24,
-            fontWeight: FontWeight.w700,
-            fontFamily: 'ProductSans',
-            color: context.textPrimary,
-          ),
-          textAlign: TextAlign.center,
-        ),
-        const SizedBox(height: 8),
-        Text(
-          'Choose how you want to unlock and protect your files',
-          style: TextStyle(
-            fontSize: 15,
-            fontFamily: 'ProductSans',
-            color: context.textSecondary,
-            height: 1.4,
-          ),
-          textAlign: TextAlign.center,
-        ),
-      ],
-    );
-  }
-
-  Widget _buildSectionTitle(String title) {
-    return Text(
-      title,
-      style: TextStyle(
-        fontSize: 13,
-        fontWeight: FontWeight.w600,
-        fontFamily: 'ProductSans',
-        color: context.textTertiary,
-        letterSpacing: 0.5,
-      ),
-    );
-  }
-
-  Widget _buildCurrentMethodCard() {
+  Widget _currentMethodTile() {
     final (icon, label) = switch (_currentAuthMethod) {
       'password' => (Icons.lock_outline, 'Password'),
       'pin' => (Icons.pin_outlined, 'PIN'),
@@ -296,226 +121,119 @@ class _ChangeSecurityScreenState extends State<ChangeSecurityScreen> {
       _ => (Icons.security, 'None'),
     };
 
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(16),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.06)
-                : Colors.white.withValues(alpha: 0.25),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.12)
-                  : Colors.white.withValues(alpha: 0.35),
-              width: 1,
-            ),
-          ),
-          child: Row(
-            children: [
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: context.accentColor.withValues(alpha: 0.15),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Icon(icon, color: context.accentColor, size: 26),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Current method',
-                      style: TextStyle(
-                        fontSize: 13,
-                        fontFamily: 'ProductSans',
-                        color: context.textTertiary,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      label,
-                      style: TextStyle(
-                        fontSize: 17,
-                        fontWeight: FontWeight.w600,
-                        fontFamily: 'ProductSans',
-                        color: context.textPrimary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-                decoration: BoxDecoration(
-                  color: AppColors.darkSuccess.withValues(alpha: 0.15),
-                  borderRadius: BorderRadius.circular(20),
-                ),
-                child: Text(
-                      'Active',
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w600,
-                        fontFamily: 'ProductSans',
-                        color: AppColors.darkSuccess,
-                      ),
-                    ),
-              ),
-            ],
-          ),
-        ),
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(icon, color: context.accentColor),
+      title: Text(label),
+      subtitle: Text(
+        'Current unlock method',
+        style: TextStyle(fontSize: 12, color: context.textTertiary),
       ),
     );
   }
 
-  Widget _buildOptionCard({
+  List<Widget> _authOptionTiles() {
+    switch (_currentAuthMethod) {
+      case 'password':
+        return [
+          _tile(
+            icon: Icons.lock_outline,
+            title: 'Change Password',
+            subtitle: 'Use a new password',
+            onTap: _push(() => ChangePasswordScreen(
+                  currentAuthMethod: _currentAuthMethod!,
+                )),
+          ),
+          _tile(
+            icon: Icons.pin_outlined,
+            title: 'Switch to PIN',
+            subtitle: 'Replace password with a 6-digit PIN',
+            onTap: _push(() => ChangePINScreen(
+                  currentAuthMethod: _currentAuthMethod!,
+                )),
+          ),
+        ];
+      case 'pin':
+        return [
+          _tile(
+            icon: Icons.pin_outlined,
+            title: 'Change PIN',
+            subtitle: 'Use a new 6-digit PIN',
+            onTap: _push(() => ChangePINScreen(
+                  currentAuthMethod: _currentAuthMethod!,
+                )),
+          ),
+          _tile(
+            icon: Icons.lock_outline,
+            title: 'Switch to Password',
+            subtitle: 'Replace PIN with a password',
+            onTap: _push(() => ChangePasswordScreen(
+                  currentAuthMethod: _currentAuthMethod!,
+                )),
+          ),
+        ];
+      case 'biometric':
+        return [
+          _tile(
+            icon: Icons.fingerprint,
+            title: 'Change Biometric',
+            subtitle: 'Re-enroll fingerprint or face',
+            onTap: _push(() => const BiometricSetupScreen()),
+          ),
+          _tile(
+            icon: Icons.lock_outline,
+            title: 'Switch to Password',
+            subtitle: 'Replace biometric unlock with a password',
+            onTap: _push(() => ChangePasswordScreen(
+                  currentAuthMethod: _currentAuthMethod!,
+                )),
+          ),
+          _tile(
+            icon: Icons.pin_outlined,
+            title: 'Switch to PIN',
+            subtitle: 'Replace biometric unlock with a 6-digit PIN',
+            onTap: _push(() => ChangePINScreen(
+                  currentAuthMethod: _currentAuthMethod!,
+                )),
+          ),
+        ];
+      default:
+        return [
+          _tile(
+            icon: Icons.lock_outline,
+            title: 'Set Password',
+            subtitle: 'Create an alphanumeric password',
+            onTap: _push(() => ChangePasswordScreen(
+                  currentAuthMethod: _currentAuthMethod ?? 'none',
+                )),
+          ),
+        ];
+    }
+  }
+
+  VoidCallback _push(Widget Function() builder) {
+    return () => Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => builder()),
+        );
+  }
+
+  Widget _tile({
     required IconData icon,
     required String title,
     required String subtitle,
     required VoidCallback onTap,
-    bool isPrimary = false,
-    Color? accentColor,
   }) {
-    final color = accentColor ?? context.accentColor;
-
-    return Material(
-      color: Colors.transparent,
-      borderRadius: BorderRadius.circular(14),
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.all(18),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.05)
-                : Colors.white.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(14),
-            border: Border.all(
-              color: isPrimary
-                  ? color.withValues(alpha: 0.35)
-                  : context.isDarkMode
-                      ? Colors.white.withValues(alpha: 0.1)
-                      : Colors.white.withValues(alpha: 0.2),
-              width: isPrimary ? 1.5 : 1,
-            ),
-          ),
-          child: Row(
-            children: [
-              Container(
-                padding: const EdgeInsets.all(11),
-                decoration: BoxDecoration(
-                  color: color.withValues(alpha: 0.12),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Icon(icon, color: color, size: 24),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                        fontFamily: 'ProductSans',
-                        color: context.textPrimary,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      subtitle,
-                      style: TextStyle(
-                        fontSize: 13,
-                        fontFamily: 'ProductSans',
-                        color: context.textSecondary,
-                        height: 1.3,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Icon(
-                Icons.chevron_right,
-                color: context.textTertiary,
-              ),
-            ],
-          ),
-        ),
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: Icon(icon, color: context.accentColor),
+      title: Text(title),
+      subtitle: Text(
+        subtitle,
+        style: TextStyle(fontSize: 12, color: context.textTertiary),
       ),
-    );
-  }
-
-  Widget _buildAutofillToggleCard() {
-    return Container(
-      padding: const EdgeInsets.all(18),
-      decoration: BoxDecoration(
-        color: context.isDarkMode
-            ? Colors.white.withValues(alpha: 0.05)
-            : Colors.white.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(
-          color: context.isDarkMode
-              ? Colors.white.withValues(alpha: 0.1)
-              : Colors.white.withValues(alpha: 0.2),
-          width: 1,
-        ),
-      ),
-      child: Row(
-        children: [
-          Container(
-            padding: const EdgeInsets.all(11),
-            decoration: BoxDecoration(
-              color: AppColors.error.withValues(alpha: 0.12),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Icon(
-              Icons.lock_outline,
-              color: AppColors.error,
-              size: 24,
-            ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Autofill Credential',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    fontFamily: 'ProductSans',
-                    color: context.textPrimary,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  'Let password managers fill your PIN or password',
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontFamily: 'ProductSans',
-                    color: context.textSecondary,
-                    height: 1.3,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Switch(
-            value: _autofillEnabled,
-            onChanged: _handleAutofillToggle,
-          ),
-        ],
-      ),
+      trailing: Icon(Icons.chevron_right, color: context.textTertiary),
+      onTap: onTap,
     );
   }
 
@@ -570,47 +288,27 @@ class _AutofillWarningDialogState extends State<_AutofillWarningDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final errorColor = Theme.of(context).colorScheme.error;
     return AlertDialog(
-      icon: Icon(
-        Icons.warning_amber_rounded,
-        size: 48,
-        color: AppColors.error,
-      ),
-      title: Text(
-        'Enable Autofill?',
-        style: TextStyle(
-          fontFamily: 'ProductSans',
-          fontWeight: FontWeight.w600,
-        ),
-      ),
+      icon: Icon(Icons.warning_amber_rounded, size: 40, color: errorColor),
+      title: const Text('Enable Autofill?'),
       content: Column(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
+          const Text(
             'This lets password managers (Google, Bitwarden, Samsung Pass) store and fill your vault PIN or password.',
-            style: TextStyle(
-              fontSize: 14,
-              height: 1.4,
-              fontFamily: 'ProductSans',
-            ),
           ),
           const SizedBox(height: 12),
           Text(
             'Your master credential will be stored outside Latch. If that password manager is ever compromised, your vault is at risk.',
-            style: TextStyle(
-              fontSize: 14,
-              height: 1.4,
-              fontFamily: 'ProductSans',
-              color: AppColors.error,
-            ),
+            style: TextStyle(color: errorColor),
           ),
           const SizedBox(height: 12),
           Text(
             'Biometric unlock is the safer no-type alternative — your key never leaves the hardware Keystore.',
             style: TextStyle(
               fontSize: 13,
-              height: 1.4,
-              fontFamily: 'ProductSans',
               color: context.textSecondary,
             ),
           ),
@@ -619,26 +317,19 @@ class _AutofillWarningDialogState extends State<_AutofillWarningDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
-          child: Text(
-            'Cancel',
-            style: TextStyle(fontFamily: 'ProductSans'),
-          ),
+          child: const Text('Cancel'),
         ),
-        FilledButton(
-          onPressed: _countdown > 0
-              ? null
-              : () => Navigator.of(context).pop(true),
-          child: Text(
-            _countdown > 0 ? 'Wait ${_countdown}s' : 'Enable',
-            style: TextStyle(fontFamily: 'ProductSans'),
-          ),
+        FilledButton.tonal(
+          onPressed:
+              _countdown > 0 ? null : () => Navigator.of(context).pop(true),
+          child: Text(_countdown > 0 ? 'Wait ${_countdown}s' : 'Enable'),
         ),
       ],
     );
   }
 }
 
-/// Screen for changing password
+/// Screen for changing or setting the vault password
 class ChangePasswordScreen extends StatefulWidget {
   final String currentAuthMethod;
 
@@ -650,420 +341,183 @@ class ChangePasswordScreen extends StatefulWidget {
 
 class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
   final AuthService _authService = AuthService();
-  final TextEditingController _currentCredentialController =
-      TextEditingController();
-  final TextEditingController _newPasswordController = TextEditingController();
-  final TextEditingController _confirmPasswordController =
-      TextEditingController();
-  final FocusNode _currentPinFocusNode = FocusNode();
-  int _step = 0;
-  String? _errorMessage;
-  bool _isLoading = false;
+  final TextEditingController _currentController = TextEditingController();
+  final TextEditingController _newController = TextEditingController();
+  final TextEditingController _confirmController = TextEditingController();
+  final FocusNode _currentFocusNode = FocusNode();
   bool _obscureCurrent = true;
   bool _obscureNew = true;
   bool _obscureConfirm = true;
+  String? _errorMessage;
+  bool _isLoading = false;
+
+  bool get _isChange => widget.currentAuthMethod == 'password';
 
   @override
   void dispose() {
-    _currentCredentialController.dispose();
-    _newPasswordController.dispose();
-    _confirmPasswordController.dispose();
-    _currentPinFocusNode.dispose();
+    _currentController.dispose();
+    _newController.dispose();
+    _confirmController.dispose();
+    _currentFocusNode.dispose();
     super.dispose();
   }
 
-  Future<void> _handleContinue() async {
-    if (_step == 0) {
-      // When current auth is biometric, verify with the system biometric prompt.
-      if (widget.currentAuthMethod == 'biometric') {
-        final isAuthenticated = await _authService.authenticateWithBiometrics(
-          reason: 'Authenticate to change your security method',
-        );
-        if (!isAuthenticated) {
-          setState(() {
-            _errorMessage = 'Biometric verification failed or was cancelled';
-          });
-          return;
-        }
-        setState(() {
-          _step = 1;
-          _errorMessage = null;
-        });
-        return;
-      }
+  Future<void> _submit() async {
+    final current = _currentController.text;
+    final next = _newController.text;
 
-      if (_currentCredentialController.text.isEmpty) {
-        setState(() {
-          _errorMessage = widget.currentAuthMethod == 'password'
-              ? 'Please enter your current password'
-              : 'Please enter your current PIN';
-        });
+    if (widget.currentAuthMethod != 'biometric' && current.isEmpty) {
+      _fail(widget.currentAuthMethod == 'pin'
+          ? 'Enter your current PIN'
+          : 'Enter your current password');
+      return;
+    }
+    if (next.length < AuthService.minPasswordLength) {
+      _fail('Use at least ${AuthService.minPasswordLength} characters');
+      return;
+    }
+    if (next != _confirmController.text) {
+      _fail('Passwords do not match');
+      return;
+    }
+
+    if (widget.currentAuthMethod == 'biometric') {
+      final ok = await _authService.authenticateWithBiometrics(
+        reason: 'Authenticate to change your security method',
+      );
+      if (!ok) {
+        _fail('Biometric verification failed or was cancelled');
         return;
       }
-      final isCurrentCredentialValid = widget.currentAuthMethod == 'password'
-          ? await _authService.verifyPassword(_currentCredentialController.text)
-          : await _authService.verifyPIN(_currentCredentialController.text);
-      if (!isCurrentCredentialValid) {
-        setState(() {
-          _errorMessage = widget.currentAuthMethod == 'password'
-              ? 'Current password is incorrect'
-              : 'Current PIN is incorrect';
-        });
-        return;
-      }
-      setState(() {
-        _step = 1;
-        _errorMessage = null;
-      });
-    } else if (_step == 1) {
-      if (_newPasswordController.text.length <
-          AuthService.minPasswordLength) {
-        setState(() {
-          _errorMessage =
-              'Use at least ${AuthService.minPasswordLength} characters';
-        });
-        return;
-      }
-      setState(() {
-        _step = 2;
-        _errorMessage = null;
-      });
     } else {
-      if (_confirmPasswordController.text.isEmpty) {
-        setState(() {
-          _errorMessage = 'Please confirm your new password';
-        });
+      final valid = widget.currentAuthMethod == 'password'
+          ? await _authService.verifyPassword(current)
+          : await _authService.verifyPIN(current);
+      if (!valid) {
+        _fail(widget.currentAuthMethod == 'password'
+            ? 'Current password is incorrect'
+            : 'Current PIN is incorrect');
         return;
-      }
-      if (_newPasswordController.text != _confirmPasswordController.text) {
-        setState(() {
-          _errorMessage = 'Passwords do not match';
-        });
-        return;
-      }
-
-      setState(() {
-        _isLoading = true;
-        _errorMessage = null;
-      });
-
-      bool success;
-      if (widget.currentAuthMethod == 'password') {
-        success = await _authService.changePassword(
-          _currentCredentialController.text,
-          _newPasswordController.text,
-        );
-      } else if (widget.currentAuthMethod == 'biometric') {
-        success =
-            await _authService.createPassword(_newPasswordController.text);
-        // Update auth method to password
-        if (success) {
-          await _authService.setAuthMethod('password');
-          await EncryptionService.instance.reWrapKey(_newPasswordController.text);
-          await EncryptionService.instance.removeBiometricKwk();
-        }
-      } else {
-        success = await _authService.switchFromPINToPassword(
-          _currentCredentialController.text,
-          _newPasswordController.text,
-        );
-      }
-
-      if (success && mounted) {
-        ToastUtils.showSuccess('Password changed successfully');
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(
-            builder: (context) => const GalleryVaultScreen(),
-          ),
-          (route) => false,
-        );
-      } else if (mounted) {
-        setState(() {
-          _isLoading = false;
-          _errorMessage = widget.currentAuthMethod == 'password'
-              ? 'Current password is incorrect'
-              : 'Current PIN is incorrect';
-        });
       }
     }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    bool success;
+    if (widget.currentAuthMethod == 'password') {
+      success = await _authService.changePassword(current, next);
+    } else if (widget.currentAuthMethod == 'biometric') {
+      success = await _authService.createPassword(next);
+      if (success) {
+        await _authService.setAuthMethod('password');
+        await EncryptionService.instance.reWrapKey(next);
+        await EncryptionService.instance.removeBiometricKwk();
+      }
+    } else {
+      success = await _authService.switchFromPINToPassword(current, next);
+    }
+
+    if (!mounted) return;
+    if (success) {
+      ToastUtils.showSuccess('Password changed successfully');
+      Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (context) => const GalleryVaultScreen()),
+        (route) => false,
+      );
+    } else {
+      setState(() {
+        _isLoading = false;
+        _errorMessage = 'Could not change password. Check your credentials.';
+      });
+    }
+  }
+
+  void _fail(String message) {
+    setState(() => _errorMessage = message);
+  }
+
+  void _clearError([Object? _]) {
+    if (_errorMessage != null) setState(() => _errorMessage = null);
   }
 
   @override
   Widget build(BuildContext context) {
-    final titles = widget.currentAuthMethod == 'biometric'
-        ? ['Verify Biometric', 'New Password', 'Confirm Password']
-        : widget.currentAuthMethod == 'pin'
-            ? ['Verify Current PIN', 'New Password', 'Confirm Password']
-            : ['Verify Current Password', 'New Password', 'Confirm Password'];
-    final subtitles = [
-      widget.currentAuthMethod == 'biometric'
-          ? 'Use your fingerprint or face to verify'
-          : widget.currentAuthMethod == 'pin'
-              ? 'Enter your current 6-digit PIN to verify'
-              : 'Enter your current password to verify',
-      'Create a new secure password',
-      'Enter your new password again to confirm',
-    ];
-    final controllers = [
-      _currentCredentialController,
-      _newPasswordController,
-      _confirmPasswordController,
-    ];
-    final obscureValues = [_obscureCurrent, _obscureNew, _obscureConfirm];
-    final obscureIcons = [
-      _obscureCurrent
-          ? Icons.visibility_outlined
-          : Icons.visibility_off_outlined,
-      _obscureNew ? Icons.visibility_outlined : Icons.visibility_off_outlined,
-      _obscureConfirm
-          ? Icons.visibility_outlined
-          : Icons.visibility_off_outlined,
-    ];
-    final toggleCallbacks = [
-      () => setState(() => _obscureCurrent = !_obscureCurrent),
-      () => setState(() => _obscureNew = !_obscureNew),
-      () => setState(() => _obscureConfirm = !_obscureConfirm),
-    ];
-    final labels = [
-      'Device PIN',
-      'New Password',
-      'Confirm Password',
-    ];
-    final hints = [
-      'Enter your device PIN',
-      'Enter new password',
-      'Re-enter password',
-      'Enter new password',
-      'Re-enter new password',
-    ];
-
     return Scaffold(
-      backgroundColor: context.backgroundColor,
       appBar: AppBar(
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: context.textPrimary),
-          onPressed: _isLoading
-              ? null
-              : () {
-                  if (_step > 0) {
-                    setState(() {
-                      _step--;
-                      _errorMessage = null;
-                    });
-                  } else {
-                    Navigator.pop(context);
-                  }
-                },
-        ),
-        title: Text(
-          titles[_step],
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            color: context.textPrimary,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.transparent,
-        elevation: 0,
+        title: Text(_isChange ? 'Change Password' : 'Set Password'),
+        automaticallyImplyLeading: !_isLoading,
       ),
-      body: Stack(
-        children: [
-          _isLoading
-              ? Center(
-                  child: CircularProgressIndicator(
-                    color: context.accentColor,
-                  ),
-                )
-              : SafeArea(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        const Spacer(),
-                        _buildIcon(),
-                        const SizedBox(height: 32),
-                        Text(
-                          subtitles[_step],
-                          style: TextStyle(
-                            fontSize: 18,
-                            color: context.textSecondary,
-                            fontFamily: 'ProductSans',
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 48),
-                        if (widget.currentAuthMethod == 'biometric' &&
-                            _step == 0)
-                          _buildBiometricPrompt()
-                        else if (widget.currentAuthMethod == 'pin' &&
-                            _step == 0)
-                          _buildCurrentPINInputField()
-                        else
-                          _buildInputField(
-                            controller: controllers[_step],
-                            obscureText: obscureValues[_step],
-                            label: labels[_step],
-                            hint: hints[_step],
-                            icon: obscureIcons[_step],
-                            onToggle: toggleCallbacks[_step],
-                          ),
-                        const SizedBox(height: 16),
-                        if (_errorMessage != null) _buildError(),
-                        const Spacer(),
-                        _buildContinueButton(),
-                        const SizedBox(height: 24),
-                      ],
-                    ),
-                  ),
-                ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildIcon() {
-    return Center(
-      child: Container(
-        width: 100,
-        height: 100,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(14),
-          color: context.isDarkMode
-              ? Colors.white.withValues(alpha: 0.08)
-              : Colors.white.withValues(alpha: 0.15),
-          border: Border.all(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.15)
-                : Colors.white.withValues(alpha: 0.2),
-            width: 1.5,
-          ),
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(14),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: const AdaptiveLogo(size: 60),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildInputField({
-    required TextEditingController controller,
-    required bool obscureText,
-    required String label,
-    required String hint,
-    required IconData icon,
-    required VoidCallback onToggle,
-  }) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(16),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.05)
-                : Colors.white.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.1)
-                  : Colors.white.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
-          child: TextField(
-            controller: controller,
-            obscureText: obscureText,
-            style: TextStyle(
-              fontFamily: 'ProductSans',
-              fontSize: 16,
-              color: context.textPrimary,
-            ),
-            decoration: InputDecoration(
-              labelText: label,
-              hintText: hint,
-              labelStyle: TextStyle(
-                fontFamily: 'ProductSans',
-                color: context.textSecondary,
-              ),
-              hintStyle: TextStyle(
-                fontFamily: 'ProductSans',
-                color: context.textTertiary,
-              ),
-              filled: true,
-              fillColor: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.05)
-                  : Colors.black.withValues(alpha: 0.03),
-              suffixIcon: IconButton(
-                icon: Icon(icon, color: context.textTertiary),
-                onPressed: onToggle,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: context.accentColor, width: 2),
-              ),
-            ),
-            onChanged: (_) {
-              if (_errorMessage != null) {
-                setState(() {
-                  _errorMessage = null;
-                });
-              }
-            },
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildBiometricPrompt() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(16),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.05)
-                : Colors.white.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.1)
-                  : Colors.white.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
-          child: Row(
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Icon(Icons.fingerprint, color: context.accentColor, size: 28),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  'Tap Continue to verify with biometrics',
+              if (widget.currentAuthMethod == 'pin') ...[
+                _PinField(
+                  label: 'Current PIN',
+                  controller: _currentController,
+                  focusNode: _currentFocusNode,
+                  obscure: true,
+                  onChanged: _clearError,
+                ),
+                const SizedBox(height: 20),
+              ] else if (widget.currentAuthMethod == 'password')
+                _textField(
+                  controller: _currentController,
+                  label: 'Current password',
+                  obscure: _obscureCurrent,
+                  onToggle: () => setState(
+                    () => _obscureCurrent = !_obscureCurrent,
+                  ),
+                  onChanged: _clearError,
+                )
+              else
+                _biometricNotice(),
+              const SizedBox(height: 8),
+              _textField(
+                controller: _newController,
+                label: 'New password',
+                helper:
+                    'At least ${AuthService.minPasswordLength} characters',
+                obscure: _obscureNew,
+                onToggle: () => setState(() => _obscureNew = !_obscureNew),
+                onChanged: _clearError,
+              ),
+              const SizedBox(height: 8),
+              _textField(
+                controller: _confirmController,
+                label: 'Confirm new password',
+                obscure: _obscureConfirm,
+                onToggle: () =>
+                    setState(() => _obscureConfirm = !_obscureConfirm),
+                onChanged: _clearError,
+                onSubmitted: (_) => _isLoading ? null : _submit(),
+              ),
+              if (_errorMessage != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  _errorMessage!,
                   style: TextStyle(
-                    fontFamily: 'ProductSans',
-                    fontSize: 15,
-                    color: context.textSecondary,
+                    color: Theme.of(context).colorScheme.error,
+                    fontSize: 13,
                   ),
                 ),
+              ],
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _isLoading ? null : _submit,
+                child: _isLoading
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(_isChange ? 'Change Password' : 'Set Password'),
               ),
             ],
           ),
@@ -1072,191 +526,51 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
     );
   }
 
-  Widget _buildCurrentPINInputField() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(16),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.05)
-                : Colors.white.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.1)
-                  : Colors.white.withValues(alpha: 0.2),
-              width: 1,
-            ),
+  Widget _textField({
+    required TextEditingController controller,
+    required String label,
+    required bool obscure,
+    required VoidCallback onToggle,
+    ValueChanged<String>? onChanged,
+    ValueChanged<String>? onSubmitted,
+    String? helper,
+  }) {
+    return TextField(
+      controller: controller,
+      obscureText: obscure,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      decoration: InputDecoration(
+        labelText: label,
+        helperText: helper,
+        suffixIcon: IconButton(
+          icon: Icon(
+            obscure ? Icons.visibility_outlined : Icons.visibility_off_outlined,
+            color: context.textTertiary,
           ),
-          child: GestureDetector(
-            onTap: () =>
-                FocusScope.of(context).requestFocus(_currentPinFocusNode),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Current PIN',
-                  style: TextStyle(
-                    fontFamily: 'ProductSans',
-                    color: context.textSecondary,
-                  ),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  'Enter your 6-digit PIN',
-                  style: TextStyle(
-                    fontFamily: 'ProductSans',
-                    color: context.textTertiary,
-                    fontSize: 13,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: List.generate(6, (index) {
-                    final isFilled =
-                        index < _currentCredentialController.text.length;
-                    return Container(
-                      width: 44,
-                      height: 52,
-                      decoration: BoxDecoration(
-                        color: context.isDarkMode
-                            ? Colors.white.withValues(alpha: 0.05)
-                            : Colors.black.withValues(alpha: 0.03),
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(
-                          color: isFilled
-                              ? context.accentColor.withValues(alpha: 0.8)
-                              : context.isDarkMode
-                                  ? Colors.white.withValues(alpha: 0.15)
-                                  : Colors.black.withValues(alpha: 0.08),
-                        ),
-                      ),
-                      child: Center(
-                        child: isFilled
-                            ? Text(
-                                '•',
-                                style: TextStyle(
-                                  color: context.textPrimary,
-                                  fontSize: 20,
-                                  fontFamily: 'ProductSans',
-                                ),
-                              )
-                            : const SizedBox.shrink(),
-                      ),
-                    );
-                  }),
-                ),
-                SizedBox(
-                  width: 0,
-                  height: 0,
-                  child: TextField(
-                    controller: _currentCredentialController,
-                    focusNode: _currentPinFocusNode,
-                    keyboardType: TextInputType.number,
-                    obscureText: true,
-                    maxLength: 6,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.digitsOnly,
-                      LengthLimitingTextInputFormatter(6),
-                    ],
-                    decoration: const InputDecoration(
-                      border: InputBorder.none,
-                      counterText: '',
-                    ),
-                    onChanged: (_) {
-                      if (_errorMessage != null) {
-                        setState(() {
-                          _errorMessage = null;
-                        });
-                      } else {
-                        setState(() {});
-                      }
-                    },
-                  ),
-                ),
-              ],
-            ),
-          ),
+          onPressed: onToggle,
         ),
       ),
     );
   }
 
-  Widget _buildError() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(12),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-        child: Container(
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: AppColors.error.withValues(alpha: 0.1),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: AppColors.error.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
+  Widget _biometricNotice() {
+    return Row(
+      children: [
+        Icon(Icons.fingerprint, color: context.accentColor, size: 20),
+        const SizedBox(width: 8),
+        Expanded(
           child: Text(
-            _errorMessage!,
-            style: TextStyle(
-              color: AppColors.error,
-              fontSize: 14,
-              fontFamily: 'ProductSans',
-            ),
+            'You will verify with your fingerprint before saving.',
+            style: TextStyle(fontSize: 13, color: context.textSecondary),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildContinueButton() {
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
-        gradient: LinearGradient(
-          colors: [
-            context.accentColor,
-            context.accentColor.withValues(alpha: 0.8),
-          ],
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: context.accentColor.withValues(alpha: 0.4),
-            blurRadius: 12,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      child: ElevatedButton(
-        onPressed: _handleContinue,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.transparent,
-          shadowColor: Colors.transparent,
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-        ),
-        child: Text(
-          _step == 2 ? 'Change Password' : 'Continue',
-          style: const TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-            fontFamily: 'ProductSans',
-            color: Colors.white,
-          ),
-        ),
-      ),
+      ],
     );
   }
 }
 
-/// Screen for changing PIN
+/// Screen for changing or setting the vault PIN
 class ChangePINScreen extends StatefulWidget {
   final String currentAuthMethod;
 
@@ -1268,575 +582,206 @@ class ChangePINScreen extends StatefulWidget {
 
 class _ChangePINScreenState extends State<ChangePINScreen> {
   final AuthService _authService = AuthService();
-  final TextEditingController _currentCredentialController =
-      TextEditingController();
-  final TextEditingController _newPINController = TextEditingController();
-  final TextEditingController _confirmPINController = TextEditingController();
-  final FocusNode _currentPinFocusNode = FocusNode();
-  final FocusNode _newPinFocusNode = FocusNode();
-  final FocusNode _confirmPinFocusNode = FocusNode();
-  bool _showPinDigits = true;
-  int _step = 0;
+  final TextEditingController _currentController = TextEditingController();
+  final TextEditingController _newController = TextEditingController();
+  final TextEditingController _confirmController = TextEditingController();
+  final FocusNode _currentFocusNode = FocusNode();
+  final FocusNode _newFocusNode = FocusNode();
+  final FocusNode _confirmFocusNode = FocusNode();
+  bool _obscureCurrentPassword = true;
   String? _errorMessage;
   bool _isLoading = false;
 
+  bool get _isChange => widget.currentAuthMethod == 'pin';
+
+  static bool _isSixDigits(String value) => RegExp(r'^[0-9]{6}$').hasMatch(value);
+
   @override
   void dispose() {
-    _currentCredentialController.dispose();
-    _newPINController.dispose();
-    _confirmPINController.dispose();
-    _currentPinFocusNode.dispose();
-    _newPinFocusNode.dispose();
-    _confirmPinFocusNode.dispose();
+    _currentController.dispose();
+    _newController.dispose();
+    _confirmController.dispose();
+    _currentFocusNode.dispose();
+    _newFocusNode.dispose();
+    _confirmFocusNode.dispose();
     super.dispose();
   }
 
-  Future<void> _handleContinue() async {
-    if (_step == 0) {
-      // When current auth is biometric, verify with the system biometric prompt.
-      if (widget.currentAuthMethod == 'biometric') {
-        final isAuthenticated = await _authService.authenticateWithBiometrics(
-          reason: 'Authenticate to change your security method',
-        );
-        if (!isAuthenticated) {
-          setState(() {
-            _errorMessage = 'Biometric verification failed or was cancelled';
-          });
-          return;
-        }
-        setState(() {
-          _step = 1;
-          _errorMessage = null;
-        });
-        return;
-      }
+  void _clearError([Object? _]) {
+    if (_errorMessage != null) setState(() => _errorMessage = null);
+  }
 
-      if (_currentCredentialController.text.isEmpty) {
-        setState(() {
-          _errorMessage = widget.currentAuthMethod == 'pin'
-              ? 'Please enter your current PIN'
-              : 'Please enter your current password';
-        });
-        return;
-      }
-      final isCurrentCredentialValid = widget.currentAuthMethod == 'pin'
-          ? await _authService.verifyPIN(_currentCredentialController.text)
-          : await _authService
-              .verifyPassword(_currentCredentialController.text);
-      if (!isCurrentCredentialValid) {
-        setState(() {
-          _errorMessage = widget.currentAuthMethod == 'pin'
-              ? 'Current PIN is incorrect'
-              : 'Current password is incorrect';
-        });
-        return;
-      }
-      setState(() {
-        _step = 1;
-        _errorMessage = null;
-      });
-    } else if (_step == 1) {
-      if (_newPINController.text.isEmpty ||
-          _newPINController.text.length != 6) {
-        setState(() {
-          _errorMessage = 'PIN must be 6 digits';
-        });
-        return;
-      }
-      if (!RegExp(r'^[0-9]{6}$').hasMatch(_newPINController.text)) {
-        setState(() {
-          _errorMessage = 'PIN must contain only digits';
-        });
-        return;
-      }
-      setState(() {
-        _step = 2;
-        _errorMessage = null;
-      });
-    } else {
-      if (_confirmPINController.text.isEmpty ||
-          _confirmPINController.text.length != 6) {
-        setState(() {
-          _errorMessage = 'PIN must be 6 digits';
-        });
-        return;
-      }
-      if (_newPINController.text != _confirmPINController.text) {
-        setState(() {
-          _errorMessage = 'PINs do not match';
-        });
-        return;
-      }
+  Future<void> _submit() async {
+    final current = _currentController.text;
+    final next = _newController.text;
 
-      setState(() {
-        _isLoading = true;
-        _errorMessage = null;
-      });
-
-      bool success;
-      if (widget.currentAuthMethod == 'pin') {
-        success = await _authService.changePIN(
-          _currentCredentialController.text,
-          _newPINController.text,
-        );
-      } else if (widget.currentAuthMethod == 'biometric') {
-        success = await _authService.createPIN(_newPINController.text);
-        // Update auth method to PIN
-        if (success) {
-          await _authService.setAuthMethod('pin');
-          await EncryptionService.instance.reWrapKey(_newPINController.text);
-          await EncryptionService.instance.removeBiometricKwk();
-        }
-      } else {
-        success = await _authService.switchFromPasswordToPIN(
-          _currentCredentialController.text,
-          _newPINController.text,
-        );
-      }
-
-      if (success && mounted) {
-        ToastUtils.showSuccess('PIN changed successfully');
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(
-            builder: (context) => const GalleryVaultScreen(),
-          ),
-          (route) => false,
-        );
-      } else if (mounted) {
-        setState(() {
-          _isLoading = false;
-          _errorMessage = widget.currentAuthMethod == 'pin'
-              ? 'Current PIN is incorrect'
-              : 'Current password is incorrect';
-        });
-      }
+    if (widget.currentAuthMethod == 'password' && current.isEmpty) {
+      _fail('Enter your current password');
+      return;
     }
+    if (widget.currentAuthMethod == 'pin' && !_isSixDigits(current)) {
+      _fail('Enter your current 6-digit PIN');
+      return;
+    }
+    if (!_isSixDigits(next)) {
+      _fail('New PIN must be 6 digits');
+      return;
+    }
+    if (next != _confirmController.text) {
+      _fail('PINs do not match');
+      return;
+    }
+
+    if (widget.currentAuthMethod == 'biometric') {
+      final ok = await _authService.authenticateWithBiometrics(
+        reason: 'Authenticate to change your security method',
+      );
+      if (!ok) {
+        _fail('Biometric verification failed or was cancelled');
+        return;
+      }
+    } else if (widget.currentAuthMethod == 'password') {
+      if (!await _authService.verifyPassword(current)) {
+        _fail('Current password is incorrect');
+        return;
+      }
+    } else if (!await _authService.verifyPIN(current)) {
+      _fail('Current PIN is incorrect');
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    bool success;
+    if (widget.currentAuthMethod == 'pin') {
+      success = await _authService.changePIN(current, next);
+    } else if (widget.currentAuthMethod == 'biometric') {
+      success = await _authService.createPIN(next);
+      if (success) {
+        await _authService.setAuthMethod('pin');
+        await EncryptionService.instance.reWrapKey(next);
+        await EncryptionService.instance.removeBiometricKwk();
+      }
+    } else {
+      success = await _authService.switchFromPasswordToPIN(current, next);
+    }
+
+    if (!mounted) return;
+    if (success) {
+      ToastUtils.showSuccess('PIN changed successfully');
+      Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (context) => const GalleryVaultScreen()),
+        (route) => false,
+      );
+    } else {
+      setState(() {
+        _isLoading = false;
+        _errorMessage = 'Could not change PIN. Check your credentials.';
+      });
+    }
+  }
+
+  void _fail(String message) {
+    setState(() => _errorMessage = message);
   }
 
   @override
   Widget build(BuildContext context) {
-    final titles = widget.currentAuthMethod == 'biometric'
-        ? ['Verify Biometric', 'New PIN', 'Confirm PIN']
-        : widget.currentAuthMethod == 'password'
-            ? ['Verify Current Password', 'New PIN', 'Confirm PIN']
-            : ['Verify Current PIN', 'New PIN', 'Confirm PIN'];
-    final subtitles = [
-      widget.currentAuthMethod == 'biometric'
-          ? 'Use your fingerprint or face to verify'
-          : widget.currentAuthMethod == 'password'
-              ? 'Type your current password to verify'
-              : 'Enter your current PIN to verify',
-      'Enter a new 6-digit PIN',
-      'Enter your new PIN again to confirm',
-    ];
-    final controllers = [
-      _currentCredentialController,
-      _newPINController,
-      _confirmPINController,
-    ];
-    final labels = [
-      widget.currentAuthMethod == 'password'
-          ? 'Current Password'
-          : 'Current PIN',
-      'New PIN',
-      'Confirm PIN',
-    ];
-    final hints = [
-      widget.currentAuthMethod == 'password'
-          ? 'Type your current password'
-          : 'Enter current 6-digit PIN',
-      'Enter 6-digit PIN',
-      'Re-enter PIN',
-    ];
-
     return Scaffold(
-      backgroundColor: context.backgroundColor,
       appBar: AppBar(
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: context.textPrimary),
-          onPressed: _isLoading
-              ? null
-              : () {
-                  if (_step > 0) {
-                    setState(() {
-                      _step--;
-                      _errorMessage = null;
-                    });
-                  } else {
-                    Navigator.pop(context);
-                  }
-                },
-        ),
-        title: Text(
-          titles[_step],
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            color: context.textPrimary,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.transparent,
-        elevation: 0,
+        title: Text(_isChange ? 'Change PIN' : 'Set PIN'),
+        automaticallyImplyLeading: !_isLoading,
       ),
-      body: Stack(
-        children: [
-          _isLoading
-              ? Center(
-                  child: CircularProgressIndicator(
-                    color: context.accentColor,
-                  ),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (widget.currentAuthMethod == 'pin')
+                _PinField(
+                  label: 'Current PIN',
+                  controller: _currentController,
+                  focusNode: _currentFocusNode,
+                  obscure: true,
+                  autofocus: true,
+                  onChanged: _clearError,
+                  onFilled: () => _newFocusNode.requestFocus(),
                 )
-              : SafeArea(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        const Spacer(),
-                        _buildIcon(),
-                        const SizedBox(height: 32),
-                        Text(
-                          subtitles[_step],
-                          style: TextStyle(
-                            fontSize: 18,
-                            color: context.textSecondary,
-                            fontFamily: 'ProductSans',
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 48),
-                        if (widget.currentAuthMethod == 'biometric' &&
-                            _step == 0)
-                          _buildBiometricPrompt()
-                        else if (_step >= 1 ||
-                            (widget.currentAuthMethod == 'pin' && _step == 0))
-                          _buildPINInputField(
-                            controller: controllers[_step],
-                            label: labels[_step],
-                            hint: hints[_step],
-                            focusNode: _step == 0
-                                ? _currentPinFocusNode
-                                : _step == 1
-                                    ? _newPinFocusNode
-                                    : _confirmPinFocusNode,
-                          )
-                        else
-                          _buildInputField(
-                            controller: controllers[_step],
-                            label: labels[_step],
-                            hint: hints[_step],
-                          ),
-                        const SizedBox(height: 16),
-                        if (_errorMessage != null) _buildError(),
-                        const Spacer(),
-                        _buildContinueButton(),
-                        const SizedBox(height: 24),
-                      ],
+              else if (widget.currentAuthMethod == 'password')
+                TextField(
+                  controller: _currentController,
+                  obscureText: _obscureCurrentPassword,
+                  autofocus: true,
+                  onChanged: _clearError,
+                  decoration: InputDecoration(
+                    labelText: 'Current password',
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _obscureCurrentPassword
+                            ? Icons.visibility_outlined
+                            : Icons.visibility_off_outlined,
+                        color: context.textTertiary,
+                      ),
+                      onPressed: () => setState(() => _obscureCurrentPassword =
+                          !_obscureCurrentPassword),
                     ),
                   ),
+                )
+              else
+                Row(
+                  children: [
+                    Icon(Icons.fingerprint,
+                        color: context.accentColor, size: 20),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'You will verify with your fingerprint before saving.',
+                        style: TextStyle(
+                            fontSize: 13, color: context.textSecondary),
+                      ),
+                    ),
+                  ],
                 ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildIcon() {
-    return Center(
-      child: Container(
-        width: 100,
-        height: 100,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(14),
-          color: context.isDarkMode
-              ? Colors.white.withValues(alpha: 0.08)
-              : Colors.white.withValues(alpha: 0.15),
-          border: Border.all(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.15)
-                : Colors.white.withValues(alpha: 0.2),
-            width: 1.5,
-          ),
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(14),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: const AdaptiveLogo(size: 60),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildInputField({
-    required TextEditingController controller,
-    required String label,
-    required String hint,
-  }) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(16),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.05)
-                : Colors.white.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.1)
-                  : Colors.white.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
-          child: TextField(
-            controller: controller,
-            obscureText: true,
-            keyboardType: TextInputType.text,
-            style: TextStyle(
-              fontFamily: 'ProductSans',
-              fontSize: 16,
-              color: context.textPrimary,
-            ),
-            decoration: InputDecoration(
-              labelText: label,
-              hintText: hint,
-              labelStyle: TextStyle(
-                fontFamily: 'ProductSans',
-                color: context.textSecondary,
+              const SizedBox(height: 24),
+              _PinField(
+                label: 'New PIN',
+                controller: _newController,
+                focusNode: _newFocusNode,
+                onChanged: _clearError,
+                onFilled: () => _confirmFocusNode.requestFocus(),
               ),
-              hintStyle: TextStyle(
-                fontFamily: 'ProductSans',
-                color: context.textTertiary,
+              const SizedBox(height: 24),
+              _PinField(
+                label: 'Confirm new PIN',
+                controller: _confirmController,
+                focusNode: _confirmFocusNode,
+                onChanged: _clearError,
               ),
-              filled: true,
-              fillColor: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.05)
-                  : Colors.black.withValues(alpha: 0.03),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: context.accentColor, width: 2),
-              ),
-            ),
-            onChanged: (_) {
-              if (_errorMessage != null) {
-                setState(() {
-                  _errorMessage = null;
-                });
-              }
-            },
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPINInputField({
-    required TextEditingController controller,
-    required String label,
-    required String hint,
-    required FocusNode focusNode,
-  }) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(16),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.05)
-                : Colors.white.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.1)
-                  : Colors.white.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
-          child: GestureDetector(
-            onTap: () => FocusScope.of(context).requestFocus(focusNode),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
+              if (_errorMessage != null) ...[
+                const SizedBox(height: 16),
                 Text(
-                  label,
+                  _errorMessage!,
                   style: TextStyle(
-                    fontFamily: 'ProductSans',
-                    color: context.textSecondary,
-                  ),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  hint,
-                  style: TextStyle(
-                    fontFamily: 'ProductSans',
-                    color: context.textTertiary,
+                    color: Theme.of(context).colorScheme.error,
                     fontSize: 13,
                   ),
                 ),
-                const SizedBox(height: 16),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: List.generate(6, (index) {
-                    final isFilled = index < controller.text.length;
-                    return Container(
-                      width: 44,
-                      height: 52,
-                      decoration: BoxDecoration(
-                        color: context.isDarkMode
-                            ? Colors.white.withValues(alpha: 0.05)
-                            : Colors.black.withValues(alpha: 0.03),
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(
-                          color: isFilled
-                              ? context.accentColor.withValues(alpha: 0.8)
-                              : context.isDarkMode
-                                  ? Colors.white.withValues(alpha: 0.15)
-                                  : Colors.black.withValues(alpha: 0.08),
-                        ),
-                      ),
-                      child: Center(
-                        child: isFilled
-                            ? Text(
-                                _showPinDigits ? controller.text[index] : '•',
-                                style: TextStyle(
-                                  color: context.textPrimary,
-                                  fontSize: 20,
-                                  fontFamily: 'ProductSans',
-                                ),
-                              )
-                            : const SizedBox.shrink(),
-                      ),
-                    );
-                  }),
-                ),
-                const SizedBox(height: 10),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: TextButton.icon(
-                    onPressed: () {
-                      setState(() {
-                        _showPinDigits = !_showPinDigits;
-                      });
-                    },
-                    icon: Icon(
-                      _showPinDigits
-                          ? Icons.visibility_off_outlined
-                          : Icons.visibility_outlined,
-                      size: 18,
-                      color: context.textSecondary,
-                    ),
-                    label: Text(
-                      _showPinDigits ? 'Hide PIN' : 'Show PIN',
-                      style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        color: context.textSecondary,
-                      ),
-                    ),
-                  ),
-                ),
-                SizedBox(
-                  width: 0,
-                  height: 0,
-                  child: TextField(
-                    controller: controller,
-                    focusNode: focusNode,
-                    keyboardType: TextInputType.number,
-                    obscureText: false,
-                    maxLength: 6,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.digitsOnly,
-                      LengthLimitingTextInputFormatter(6),
-                    ],
-                    decoration: const InputDecoration(
-                      counterText: '',
-                      border: InputBorder.none,
-                    ),
-                    onChanged: (_) {
-                      final value = controller.text;
-                      if (_errorMessage != null) {
-                        setState(() {
-                          _errorMessage = null;
-                        });
-                      } else {
-                        setState(() {});
-                      }
-
-                      // Auto-advance from "New PIN" to "Confirm PIN"
-                      // once 6 valid digits are entered.
-                      if (_step == 1 &&
-                          identical(controller, _newPINController) &&
-                          value.length == 6 &&
-                          RegExp(r'^[0-9]{6}$').hasMatch(value)) {
-                        setState(() {
-                          _step = 2;
-                          _errorMessage = null;
-                        });
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          if (mounted) {
-                            FocusScope.of(context)
-                                .requestFocus(_confirmPinFocusNode);
-                          }
-                        });
-                      }
-                    },
-                  ),
-                ),
               ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildBiometricPrompt() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(16),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.05)
-                : Colors.white.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.1)
-                  : Colors.white.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
-          child: Row(
-            children: [
-              Icon(Icons.fingerprint, color: context.accentColor, size: 28),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  'Tap Continue to verify with biometrics',
-                  style: TextStyle(
-                    fontFamily: 'ProductSans',
-                    fontSize: 15,
-                    color: context.textSecondary,
-                  ),
-                ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _isLoading ? null : _submit,
+                child: _isLoading
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(_isChange ? 'Change PIN' : 'Set PIN'),
               ),
             ],
           ),
@@ -1844,72 +789,123 @@ class _ChangePINScreenState extends State<ChangePINScreen> {
       ),
     );
   }
+}
 
-  Widget _buildError() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(12),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-        child: Container(
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: AppColors.error.withValues(alpha: 0.1),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: AppColors.error.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
-          child: Text(
-            _errorMessage!,
-            style: TextStyle(
-              color: AppColors.error,
-              fontSize: 14,
-              fontFamily: 'ProductSans',
-            ),
-          ),
-        ),
-      ),
-    );
+/// Six-digit PIN entry with dot boxes and a hidden text field
+class _PinField extends StatefulWidget {
+  final String label;
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool obscure;
+  final bool autofocus;
+  final ValueChanged<String> onChanged;
+  final VoidCallback? onFilled;
+
+  const _PinField({
+    required this.label,
+    required this.controller,
+    required this.focusNode,
+    required this.onChanged,
+    this.obscure = false,
+    this.autofocus = false,
+    this.onFilled,
+  });
+
+  @override
+  State<_PinField> createState() => _PinFieldState();
+}
+
+class _PinFieldState extends State<_PinField> {
+  void _listener() {
+    if (mounted) setState(() {});
+    widget.onChanged(widget.controller.text);
+    if (widget.controller.text.length == 6) {
+      widget.onFilled?.call();
+    }
   }
 
-  Widget _buildContinueButton() {
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
-        gradient: LinearGradient(
-          colors: [
-            context.accentColor,
-            context.accentColor.withValues(alpha: 0.8),
-          ],
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: context.accentColor.withValues(alpha: 0.4),
-            blurRadius: 12,
-            offset: const Offset(0, 4),
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_listener);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_listener);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final text = widget.controller.text;
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).requestFocus(widget.focusNode),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            widget.label,
+            style: TextStyle(fontSize: 13, color: context.textSecondary),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: List.generate(11, (index) {
+              if (index.isOdd) {
+                return const SizedBox(width: 8);
+              }
+              final boxIndex = index ~/ 2;
+              final filled = boxIndex < text.length;
+              return Expanded(
+                child: AspectRatio(
+                  aspectRatio: 0.85,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 150),
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: context.backgroundSecondary,
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(
+                        color: filled
+                            ? context.accentColor
+                            : context.borderColor,
+                        width: filled ? 1.5 : 1,
+                      ),
+                    ),
+                    child: filled
+                        ? Text(
+                            widget.obscure ? '•' : text[boxIndex],
+                            style: TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.w600,
+                              color: context.textPrimary,
+                            ),
+                          )
+                        : null,
+                  ),
+                ),
+              );
+            }),
+          ),
+          SizedBox(
+            width: 0,
+            height: 0,
+            child: TextField(
+              controller: widget.controller,
+              focusNode: widget.focusNode,
+              autofocus: widget.autofocus,
+              keyboardType: TextInputType.number,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+                LengthLimitingTextInputFormatter(6),
+              ],
+              decoration: const InputDecoration(
+                border: InputBorder.none,
+                counterText: '',
+              ),
+            ),
           ),
         ],
-      ),
-      child: ElevatedButton(
-        onPressed: _handleContinue,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.transparent,
-          shadowColor: Colors.transparent,
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-        ),
-        child: Text(
-          _step == 2 ? 'Change PIN' : 'Continue',
-          style: const TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-            fontFamily: 'ProductSans',
-            color: Colors.white,
-          ),
-        ),
       ),
     );
   }
@@ -1938,9 +934,7 @@ class _BiometricSetupScreenState extends State<BiometricSetupScreen> {
   Future<void> _checkBiometricAvailability() async {
     final available = await _authService.isBiometricAvailable();
     if (mounted) {
-      setState(() {
-        _isAvailable = available;
-      });
+      setState(() => _isAvailable = available);
     }
   }
 
@@ -1956,9 +950,7 @@ class _BiometricSetupScreenState extends State<BiometricSetupScreen> {
       if (success) {
         ToastUtils.showSuccess('Biometric enabled successfully');
         Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(
-            builder: (context) => const GalleryVaultScreen(),
-          ),
+          MaterialPageRoute(builder: (context) => const GalleryVaultScreen()),
           (route) => false,
         );
       } else {
@@ -1973,204 +965,59 @@ class _BiometricSetupScreenState extends State<BiometricSetupScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: context.backgroundColor,
       appBar: AppBar(
-        leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: context.textPrimary),
-          onPressed: () => Navigator.pop(context),
-        ),
-        title: Text(
-          'Enable Biometric',
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            color: context.textPrimary,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.transparent,
-        elevation: 0,
+        title: const Text('Biometric Unlock'),
+        automaticallyImplyLeading: !_isLoading,
       ),
-      body: Stack(
-        children: [
-          _isLoading
-              ? Center(
-                  child: CircularProgressIndicator(
-                    color: context.accentColor,
-                  ),
-                )
-              : SafeArea(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        const Spacer(),
-                        _buildIcon(),
-                        const SizedBox(height: 32),
-                        Text(
-                          'Quick & Secure Access',
-                          style: TextStyle(
-                            fontSize: 24,
-                            fontWeight: FontWeight.w700,
-                            color: context.textPrimary,
-                            fontFamily: 'ProductSans',
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          'Use your fingerprint or face to unlock the app quickly',
-                          style: TextStyle(
-                            fontSize: 16,
-                            color: context.textSecondary,
-                            fontFamily: 'ProductSans',
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 48),
-                        if (_errorMessage != null) _buildError(),
-                        const Spacer(),
-                        if (_isAvailable) _buildSetupButton(),
-                        if (!_isAvailable) _buildUnavailableMessage(),
-                        const SizedBox(height: 24),
-                      ],
-                    ),
-                  ),
+      body: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          children: [
+            const Spacer(),
+            Icon(Icons.fingerprint, size: 80, color: context.accentColor),
+            const SizedBox(height: 24),
+            const Text(
+              'Quick & secure access',
+              style: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Use your fingerprint or face to unlock the app without typing your credential.',
+              style: TextStyle(color: context.textSecondary, height: 1.4),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            if (_errorMessage != null)
+              Text(
+                _errorMessage!,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                  fontSize: 13,
                 ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildIcon() {
-    return Center(
-      child: Container(
-        width: 140,
-        height: 140,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(16),
-          color: context.isDarkMode
-              ? Colors.white.withValues(alpha: 0.08)
-              : Colors.white.withValues(alpha: 0.15),
-          border: Border.all(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.15)
-                : context.accentColor.withValues(alpha: 0.3),
-            width: 2,
-          ),
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(16),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-            child: Padding(
-              padding: const EdgeInsets.all(32),
-              child: const AdaptiveLogo(size: 76),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildError() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(14),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: AppColors.error.withValues(alpha: 0.1),
-            borderRadius: BorderRadius.circular(14),
-            border: Border.all(
-              color: AppColors.error.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
-          child: Text(
-            _errorMessage!,
-            style: TextStyle(
-              color: AppColors.error,
-              fontSize: 14,
-              fontFamily: 'ProductSans',
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildSetupButton() {
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
-        gradient: LinearGradient(
-          colors: [
-            context.accentColor,
-            context.accentColor.withValues(alpha: 0.8),
+                textAlign: TextAlign.center,
+              ),
+            const Spacer(),
+            if (_isAvailable)
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _isLoading ? null : _setupBiometric,
+                  child: _isLoading
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Enable Biometric'),
+                ),
+              )
+            else
+              Text(
+                'Biometric authentication is not available on this device',
+                style: TextStyle(color: context.textTertiary),
+                textAlign: TextAlign.center,
+              ),
           ],
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: context.accentColor.withValues(alpha: 0.4),
-            blurRadius: 12,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      child: ElevatedButton(
-        onPressed: _setupBiometric,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.transparent,
-          shadowColor: Colors.transparent,
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-        ),
-        child: const Text(
-          'Enable Biometric',
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-            fontFamily: 'ProductSans',
-            color: Colors.white,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildUnavailableMessage() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(14),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: context.isDarkMode
-                ? Colors.white.withValues(alpha: 0.05)
-                : Colors.white.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(14),
-            border: Border.all(
-              color: context.isDarkMode
-                  ? Colors.white.withValues(alpha: 0.1)
-                  : Colors.white.withValues(alpha: 0.2),
-              width: 1,
-            ),
-          ),
-          child: Text(
-            'Biometric authentication is not available on this device',
-            style: TextStyle(
-              color: context.textSecondary,
-              fontSize: 14,
-              fontFamily: 'ProductSans',
-            ),
-            textAlign: TextAlign.center,
-          ),
         ),
       ),
     );

--- a/lib/screens/document_picker_screen.dart
+++ b/lib/screens/document_picker_screen.dart
@@ -286,7 +286,7 @@ class _DocumentPickerScreenState extends State<DocumentPickerScreen> {
       debugPrint('Error scanning for documents: $e');
       setState(() {
         _isLoading = false;
-        _error = 'Failed to scan for documents: $e';
+        _error = 'Failed to scan for documents';
       });
     }
   }

--- a/lib/screens/document_viewer_screen.dart
+++ b/lib/screens/document_viewer_screen.dart
@@ -192,7 +192,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() {
-        _error = 'Failed to convert document: $e';
+        _error = 'Failed to convert document';
         _isLoading = false;
         _isConverting = false;
       });
@@ -259,7 +259,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
       setState(() => _isLoading = false);
     } catch (e) {
       setState(() {
-        _error = 'Failed to load document: $e';
+        _error = 'Failed to load document';
         _isLoading = false;
       });
     }
@@ -351,7 +351,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error exporting file: $e');
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 
@@ -392,7 +392,7 @@ class _DocumentViewerScreenState extends ConsumerState<DocumentViewerScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error opening file: $e');
-      ToastUtils.showError('Failed to open file: $e');
+      ToastUtils.showError('Failed to open file');
     }
   }
 

--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -715,7 +715,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error exporting file: $e');
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 
@@ -756,7 +756,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error opening file: $e');
-      ToastUtils.showError('Failed to open file: $e');
+      ToastUtils.showError('Failed to open file');
     }
   }
 

--- a/lib/screens/folder_detail_screen.dart
+++ b/lib/screens/folder_detail_screen.dart
@@ -744,7 +744,7 @@ class _FolderDetailScreenState extends ConsumerState<FolderDetailScreen> {
       }
     } catch (e) {
       if (mounted) {
-        ToastUtils.showError('Failed to export file: $e');
+        ToastUtils.showError('Failed to export file');
       }
     }
   }
@@ -754,7 +754,7 @@ class _FolderDetailScreenState extends ConsumerState<FolderDetailScreen> {
       await OpenFilex.open(file.vaultPath);
     } catch (e) {
       if (mounted) {
-        ToastUtils.showError('Failed to open file: $e');
+        ToastUtils.showError('Failed to open file');
       }
     }
   }
@@ -1666,7 +1666,8 @@ class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
     } catch (e) {
       setState(() {
         _isLoading = false;
-        _error = e.toString();
+        debugPrint('Folder browse error: $e');
+        _error = 'Couldn\'t open this folder — check permissions and try again';
       });
     }
   }
@@ -1722,7 +1723,8 @@ class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
     } catch (e) {
       setState(() {
         _isLoading = false;
-        _error = e.toString();
+        debugPrint('Folder browse error: $e');
+        _error = 'Couldn\'t open this folder — check permissions and try again';
       });
     }
   }
@@ -1938,11 +1940,12 @@ class _ImportProgressDialogState extends ConsumerState<_ImportProgressDialog> {
       ref.invalidate(foldersNotifierProvider);
       ref.invalidate(vaultNotifierProvider);
     } catch (e) {
+      debugPrint('Folder import error: $e');
       if (!mounted) return;
       setState(() {
         _isImporting = false;
-        _error = e.toString();
-        _status = 'Error: $e';
+        _error = 'Import failed — check the folder and try again';
+        _status = _error!;
       });
     }
   }

--- a/lib/screens/folder_picker_screen.dart
+++ b/lib/screens/folder_picker_screen.dart
@@ -84,7 +84,8 @@ class _FolderPickerScreenState extends State<FolderPickerScreen> {
     } catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.toString();
+          debugPrint('Folder browse error: $e');
+          _error = 'Couldn\'t open this folder — check permissions and try again';
           _loading = false;
         });
       }
@@ -121,7 +122,8 @@ class _FolderPickerScreenState extends State<FolderPickerScreen> {
     } catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.toString();
+          debugPrint('Folder browse error: $e');
+          _error = 'Couldn\'t open this folder — check permissions and try again';
           _loading = false;
         });
       }

--- a/lib/screens/folders_screen.dart
+++ b/lib/screens/folders_screen.dart
@@ -845,11 +845,12 @@ class _ImportProgressDialogState extends ConsumerState<_ImportProgressDialog> {
       ref.invalidate(foldersNotifierProvider);
       ref.invalidate(vaultNotifierProvider);
     } catch (e) {
+      debugPrint('Folder import error: $e');
       if (!mounted) return;
       setState(() {
         _isImporting = false;
-        _error = e.toString();
-        _status = 'Error: $e';
+        _error = 'Import failed — check the folder and try again';
+        _status = _error!;
       });
     }
   }
@@ -946,7 +947,8 @@ class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
     } catch (e) {
       setState(() {
         _isLoading = false;
-        _error = e.toString();
+        debugPrint('Folder browse error: $e');
+        _error = 'Couldn\'t open this folder — check permissions and try again';
       });
     }
   }
@@ -998,7 +1000,8 @@ class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
     } catch (e) {
       setState(() {
         _isLoading = false;
-        _error = e.toString();
+        debugPrint('Folder browse error: $e');
+        _error = 'Couldn\'t open this folder — check permissions and try again';
       });
     }
   }

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -630,8 +630,8 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
                 SwitchListTile(
                   value: _importSide == FeatureSide.left,
                   onChanged: (onLeft) {
-                    setState(() =>
-                        _importSide = onLeft ? FeatureSide.left : FeatureSide.right);
+                    setState(() => _importSide =
+                        onLeft ? FeatureSide.left : FeatureSide.right);
                     _persistImportSide();
                   },
                   activeThumbColor: context.accentColor,
@@ -758,7 +758,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
             await ref.read(vaultNotifierProvider.notifier).refresh();
           },
           color: context.accentColor,
-          child:           GridView.builder(
+          child: GridView.builder(
             padding: EdgeInsets.fromLTRB(
               8,
               8,
@@ -1938,143 +1938,115 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
 
   Widget _buildDrawer() {
     return Drawer(
-      backgroundColor: Colors.transparent,
-      child: ClipRRect(
-        borderRadius: const BorderRadius.only(
-          topRight: Radius.circular(0),
-          bottomRight: Radius.circular(0),
-        ),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
-          child: Container(
-            decoration: BoxDecoration(
-              color: context.isDarkMode
-                  ? Colors.black
-                  : Colors.white,
-              border: Border(
-                right: BorderSide(
-                  color: context.isDarkMode
-                      ? Colors.white.withValues(alpha: 0.1)
-                      : Colors.black.withValues(alpha: 0.1),
-                  width: 1,
-                ),
-              ),
-            ),
-            child: Column(
+      backgroundColor: context.isDarkMode ? Colors.black : Colors.white,
+      child: Column(
+        children: [
+          _buildDrawerHeader(),
+          Expanded(
+            child: ListView(
+              padding: EdgeInsets.zero,
               children: [
-                _buildDrawerHeader(),
-                Expanded(
-                  child: ListView(
-                    padding: EdgeInsets.zero,
-                    children: [
-                      _buildDrawerSection('Library'),
-                      _buildCountedDrawerItem(
-                        icon: Icons.folder_outlined,
-                        title: 'Albums',
-                        countOf: (ref) => ref
-                            .watch(albumsProvider)
-                            .maybeWhen(data: (l) => l.length, orElse: () => null),
-                        onTap: () {
-                          Navigator.pop(context);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => const AlbumsScreen()),
-                          );
-                        },
+                _buildDrawerSection('Library'),
+                _buildCountedDrawerItem(
+                  icon: Icons.folder_outlined,
+                  title: 'Albums',
+                  countOf: (ref) => ref
+                      .watch(albumsProvider)
+                      .maybeWhen(data: (l) => l.length, orElse: () => null),
+                  onTap: () {
+                    Navigator.pop(context);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const AlbumsScreen()),
+                    );
+                  },
+                ),
+                _buildCountedDrawerItem(
+                  icon: Icons.folder_copy_outlined,
+                  title: 'Folders',
+                  countOf: (ref) => ref
+                      .watch(foldersProvider)
+                      .maybeWhen(data: (l) => l.length, orElse: () => null),
+                  onTap: () {
+                    Navigator.pop(context);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const FoldersScreen()),
+                    );
+                  },
+                ),
+                _buildCountedDrawerItem(
+                  icon: Icons.explore_outlined,
+                  title: 'File Explorer',
+                  countOf: (ref) => ref.watch(fileCountsProvider).maybeWhen(
+                        data: (m) => m.values.fold<int>(0, (s, c) => s + c),
+                        orElse: () => null,
                       ),
-                      _buildCountedDrawerItem(
-                        icon: Icons.folder_copy_outlined,
-                        title: 'Folders',
-                        countOf: (ref) => ref
-                            .watch(foldersProvider)
-                            .maybeWhen(data: (l) => l.length, orElse: () => null),
-                        onTap: () {
-                          Navigator.pop(context);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => const FoldersScreen()),
-                          );
-                        },
-                      ),
-                      _buildCountedDrawerItem(
-                        icon: Icons.explore_outlined,
-                        title: 'File Explorer',
-                        countOf: (ref) => ref
-                            .watch(fileCountsProvider)
-                            .maybeWhen(
-                              data: (m) =>
-                                  m.values.fold<int>(0, (s, c) => s + c),
-                              orElse: () => null,
-                            ),
-                        onTap: () {
-                          Navigator.pop(context);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) =>
-                                    const VaultExplorerScreen()),
-                          );
-                        },
-                      ),
-                      _buildCountedDrawerItem(
-                        icon: Icons.favorite_outline,
-                        title: 'Favorites',
-                        countOf: (ref) => ref
-                            .watch(favoriteFilesProvider)
-                            .maybeWhen(data: (l) => l.length, orElse: () => null),
-                        onTap: () {
-                          Navigator.pop(context);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => const FavoritesScreen()),
-                          );
-                        },
-                      ),
-                      _buildCountedDrawerItem(
-                        icon: Icons.label_outline,
-                        title: 'Tags',
-                        countOf: (ref) => ref
-                            .watch(tagsProvider)
-                            .maybeWhen(data: (l) => l.length, orElse: () => null),
-                        onTap: () {
-                          Navigator.pop(context);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => const TagsScreen()),
-                          );
-                        },
-                      ),
-                      _buildDrawerSection('Security'),
-                      _buildDrawerItem(
-                        icon: Icons.security,
-                        title: 'Security Settings',
-                        showChevron: true,
-                        onTap: () {
-                          Navigator.pop(context);
-                          _openSettingsScreen();
-                        },
-                      ),
-                      _buildDrawerItem(
-                        icon: Icons.shield_outlined,
-                        title: 'Decoy Mode',
-                        subtitle: 'Set up fake vault',
-                        showChevron: true,
-                        onTap: () {
-                          Navigator.pop(context);
-                          _showDecoyModeSheet();
-                        },
-                      ),
-                    ],
-                  ),
+                  onTap: () {
+                    Navigator.pop(context);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const VaultExplorerScreen()),
+                    );
+                  },
+                ),
+                _buildCountedDrawerItem(
+                  icon: Icons.favorite_outline,
+                  title: 'Favorites',
+                  countOf: (ref) => ref
+                      .watch(favoriteFilesProvider)
+                      .maybeWhen(data: (l) => l.length, orElse: () => null),
+                  onTap: () {
+                    Navigator.pop(context);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const FavoritesScreen()),
+                    );
+                  },
+                ),
+                _buildCountedDrawerItem(
+                  icon: Icons.label_outline,
+                  title: 'Tags',
+                  countOf: (ref) => ref
+                      .watch(tagsProvider)
+                      .maybeWhen(data: (l) => l.length, orElse: () => null),
+                  onTap: () {
+                    Navigator.pop(context);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const TagsScreen()),
+                    );
+                  },
+                ),
+                _buildDrawerSection('Security'),
+                _buildDrawerItem(
+                  icon: Icons.security,
+                  title: 'Security Settings',
+                  showChevron: true,
+                  onTap: () {
+                    Navigator.pop(context);
+                    _openSettingsScreen();
+                  },
+                ),
+                _buildDrawerItem(
+                  icon: Icons.shield_outlined,
+                  title: 'Decoy Mode',
+                  subtitle: 'Set up fake vault',
+                  showChevron: true,
+                  onTap: () {
+                    Navigator.pop(context);
+                    _showDecoyModeSheet();
+                  },
                 ),
               ],
             ),
           ),
-        ),
+        ],
       ),
     );
   }
@@ -2111,18 +2083,12 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
                   width: 1.5,
                 ),
               ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(12),
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
-                  child: SvgPicture.asset(
-                    'assets/locker_logo_nobg.svg',
-                    fit: BoxFit.contain,
-                    colorFilter: const ColorFilter.mode(
-                      Colors.white,
-                      BlendMode.srcIn,
-                    ),
-                  ),
+              child: SvgPicture.asset(
+                'assets/locker_logo_nobg.svg',
+                fit: BoxFit.contain,
+                colorFilter: const ColorFilter.mode(
+                  Colors.white,
+                  BlendMode.srcIn,
                 ),
               ),
             ),
@@ -2166,10 +2132,10 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
         title.toUpperCase(),
         style: TextStyle(
           fontFamily: 'ProductSans',
-          fontSize: 11,
-          fontWeight: FontWeight.w700,
-          letterSpacing: 1.2,
-          color: context.textTertiary,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+          color: context.accentColor,
         ),
       ),
     );

--- a/lib/screens/gallery_vault_screen.dart
+++ b/lib/screens/gallery_vault_screen.dart
@@ -1681,7 +1681,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error exporting file: $e');
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 
@@ -1729,7 +1729,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error opening file: $e');
-      ToastUtils.showError('Failed to open file: $e');
+      ToastUtils.showError('Failed to open file');
     }
   }
 
@@ -3985,7 +3985,7 @@ class _GalleryVaultScreenState extends ConsumerState<GalleryVaultScreen> {
       }
     } catch (e) {
       if (mounted) setState(() => _isImporting = false);
-      ToastUtils.showError('Failed to import folder: $e');
+      ToastUtils.showError('Failed to import folder');
     }
   }
 }
@@ -4344,7 +4344,8 @@ class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
     } catch (e) {
       setState(() {
         _isLoading = false;
-        _error = e.toString();
+        debugPrint('Folder browse error: $e');
+        _error = 'Couldn\'t open this folder — check permissions and try again';
       });
     }
   }
@@ -4388,7 +4389,8 @@ class _FolderImportPickerScreenState extends State<_FolderImportPickerScreen> {
     } catch (e) {
       setState(() {
         _isLoading = false;
-        _error = e.toString();
+        debugPrint('Folder browse error: $e');
+        _error = 'Couldn\'t open this folder — check permissions and try again';
       });
     }
   }

--- a/lib/screens/media_picker_screen.dart
+++ b/lib/screens/media_picker_screen.dart
@@ -1,11 +1,10 @@
-import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
-import 'package:video_player/video_player.dart';
 import '../services/auto_kill_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/responsive_utils.dart';
+import '../widgets/hold_preview_card.dart';
 
 /// A custom media picker that uses PhotoManager to directly access gallery assets.
 /// This allows proper deletion of original files from the gallery.
@@ -47,6 +46,9 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
   OverlayEntry? _previewEntry;
   final ValueNotifier<Offset> _previewPosition = ValueNotifier(Offset.zero);
   final ValueNotifier<AssetEntity?> _previewAsset = ValueNotifier(null);
+  // ponytail: global tile rects captured once per hold; the grid cannot
+  // scroll mid-hold, so they stay valid. Recompute if that ever changes.
+  Map<String, Rect> _tileRects = const {};
 
   @override
   void initState() {
@@ -247,7 +249,7 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
   void _showPreview(AssetEntity asset, Offset globalPosition) {
     _hidePreview();
     _previewEntry = OverlayEntry(
-      builder: (_) => _HoldPreviewCard(
+      builder: (_) => HoldPreviewCard(
         asset: _previewAsset,
         position: _previewPosition,
       ),
@@ -283,20 +285,32 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
   }
 
   String? _assetIdAt(Offset globalPosition) {
+    for (final entry in _tileRects.entries) {
+      if (entry.value.contains(globalPosition)) return entry.key;
+    }
+    return null;
+  }
+
+  void _beginHold(AssetEntity asset, Offset globalPosition) {
+    final rects = <String, Rect>{};
     for (final entry in _tileKeys.entries) {
       final context = entry.value.currentContext;
       if (context == null) continue;
-
       final renderObject = context.findRenderObject();
       if (renderObject is! RenderBox || !renderObject.hasSize) continue;
-
-      final rect = renderObject.localToGlobal(Offset.zero) & renderObject.size;
-      if (rect.contains(globalPosition)) {
-        return entry.key;
-      }
+      rects[entry.key] =
+          renderObject.localToGlobal(Offset.zero) & renderObject.size;
     }
+    _tileRects = rects;
 
-    return null;
+    _startSlidingSelection(asset);
+    _showPreview(asset, globalPosition);
+  }
+
+  void _endHold() {
+    _tileRects = const {};
+    _stopSlidingSelection();
+    _hidePreview();
   }
 
   void _selectAll() {
@@ -478,22 +492,14 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
     final selectionIndex = _selectedAssets.toList().indexOf(asset);
 
     return GestureDetector(
-      onLongPressStart: (details) {
-        _startSlidingSelection(asset);
-        _showPreview(asset, details.globalPosition);
-      },
+      onLongPressStart: (details) =>
+          _beginHold(asset, details.globalPosition),
       onLongPressMoveUpdate: (details) {
         _updateSlidingSelection(details.globalPosition);
         _updatePreview(details.globalPosition);
       },
-      onLongPressEnd: (_) {
-        _stopSlidingSelection();
-        _hidePreview();
-      },
-      onLongPressCancel: () {
-        _stopSlidingSelection();
-        _hidePreview();
-      },
+      onLongPressEnd: (_) => _endHold(),
+      onLongPressCancel: _endHold,
       onTap: () => _toggleSelection(asset),
       child: Stack(
         key: _tileKeyFor(asset.id),
@@ -710,211 +716,4 @@ class MediaPickerResult {
   bool get isEmpty => selectedAssets.isEmpty;
   bool get isNotEmpty => selectedAssets.isNotEmpty;
   int get count => selectedAssets.length;
-}
-
-/// Computes a clamped on-screen rect for the hold-to-preview card so it stays
-/// fully visible, preferring a spot above the finger.
-Rect holdPreviewRect(Offset finger, Size screen, Size card) {
-  const margin = 12.0;
-
-  final left = (finger.dx - card.width / 2).clamp(
-    margin,
-    math.max(margin, screen.width - card.width - margin),
-  ).toDouble();
-  var top = finger.dy - card.height - 56;
-  if (top < margin) top = finger.dy + 56;
-  top = top.clamp(
-    margin,
-    math.max(margin, screen.height - card.height - margin),
-  );
-
-  return Rect.fromLTWH(left, top, card.width, card.height);
-}
-
-class _HoldPreviewCard extends StatelessWidget {
-  final ValueListenable<AssetEntity?> asset;
-  final ValueListenable<Offset> position;
-
-  const _HoldPreviewCard({required this.asset, required this.position});
-
-  @override
-  Widget build(BuildContext context) {
-    return ValueListenableBuilder<Offset>(
-      valueListenable: position,
-      builder: (context, finger, _) {
-        final screen = MediaQuery.of(context).size;
-        final side =
-            (screen.shortestSide * 0.65).clamp(200.0, 340.0).toDouble();
-        final rect = holdPreviewRect(finger, screen, Size(side, side));
-
-        return Positioned.fromRect(
-          rect: rect,
-          child: IgnorePointer(
-            child: ValueListenableBuilder<AssetEntity?>(
-              valueListenable: asset,
-              builder: (context, asset, _) {
-                if (asset == null) return const SizedBox.shrink();
-                return DecoratedBox(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(20),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.4),
-                        blurRadius: 24,
-                      ),
-                    ],
-                  ),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(20),
-                    // Keyed so a new hold starts fresh (no stale video frame).
-                    child: KeyedSubtree(
-                      key: ValueKey(asset.id),
-                      child: Container(
-                        color: Colors.black,
-                        child: _AssetPreviewContent(asset: asset),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-
-class _AssetPreviewContent extends StatelessWidget {
-  final AssetEntity asset;
-
-  const _AssetPreviewContent({required this.asset});
-
-  @override
-  Widget build(BuildContext context) {
-    if (asset.type == AssetType.video) return _VideoPreview(asset: asset);
-    return _ImagePreview(asset: asset);
-  }
-}
-
-class _ImagePreview extends StatefulWidget {
-  final AssetEntity asset;
-
-  const _ImagePreview({required this.asset});
-
-  @override
-  State<_ImagePreview> createState() => _ImagePreviewState();
-}
-
-class _ImagePreviewState extends State<_ImagePreview> {
-  late final Future<Uint8List?> _future = widget.asset.thumbnailDataWithSize(
-    const ThumbnailSize(1200, 1200),
-    quality: 90,
-  );
-
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<Uint8List?>(
-      future: _future,
-      builder: (context, snapshot) {
-        final bytes = snapshot.data;
-        if (bytes != null && bytes.isNotEmpty) {
-          return Image.memory(bytes, fit: BoxFit.contain);
-        }
-        if (snapshot.hasError) {
-          return const Center(
-            child: Icon(Icons.broken_image, color: Colors.white54),
-          );
-        }
-        return const Center(
-          child: CircularProgressIndicator(color: Colors.white70),
-        );
-      },
-    );
-  }
-}
-
-class _VideoPreview extends StatefulWidget {
-  final AssetEntity asset;
-
-  const _VideoPreview({required this.asset});
-
-  @override
-  State<_VideoPreview> createState() => _VideoPreviewState();
-}
-
-class _VideoPreviewState extends State<_VideoPreview> {
-  VideoPlayerController? _controller;
-  bool _failed = false;
-  late final Future<Uint8List?> _thumb = widget.asset.thumbnailDataWithSize(
-    const ThumbnailSize(1200, 1200),
-    quality: 90,
-  );
-
-  @override
-  void initState() {
-    super.initState();
-    _init();
-  }
-
-  Future<void> _init() async {
-    try {
-      final file = await widget.asset.file;
-      if (file == null || !mounted) return;
-      final controller = VideoPlayerController.file(file);
-      await controller.initialize();
-      if (!mounted) {
-        controller.dispose();
-        return;
-      }
-      setState(() => _controller = controller);
-      await controller.setLooping(true);
-      await controller.setVolume(0);
-      await controller.play();
-    } catch (_) {
-      if (mounted) setState(() => _failed = true);
-    }
-  }
-
-  @override
-  void dispose() {
-    _controller?.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final controller = _controller;
-    if (controller == null) {
-      return FutureBuilder<Uint8List?>(
-        future: _thumb,
-        builder: (context, snapshot) {
-          final bytes = snapshot.data;
-          if (bytes != null && bytes.isNotEmpty && !_failed) {
-            return Stack(
-              fit: StackFit.expand,
-              children: [
-                Image.memory(bytes, fit: BoxFit.contain),
-                const Center(
-                  child: Icon(Icons.play_arrow,
-                      size: 48, color: Colors.white70),
-                ),
-              ],
-            );
-          }
-          return const SizedBox.expand();
-        },
-      );
-    }
-
-    return Center(
-      child: AspectRatio(
-        aspectRatio:
-            controller.value.aspectRatio == 0
-                ? 1
-                : controller.value.aspectRatio,
-        child: VideoPlayer(controller),
-      ),
-    );
-  }
 }

--- a/lib/screens/media_picker_screen.dart
+++ b/lib/screens/media_picker_screen.dart
@@ -49,6 +49,9 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
   // ponytail: global tile rects captured once per hold; the grid cannot
   // scroll mid-hold, so they stay valid. Recompute if that ever changes.
   Map<String, Rect> _tileRects = const {};
+  bool _holdPreviewing = false;
+  Offset _holdOrigin = Offset.zero;
+  AssetEntity? _heldAsset;
 
   @override
   void initState() {
@@ -303,12 +306,35 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
     }
     _tileRects = rects;
 
-    _startSlidingSelection(asset);
+    _heldAsset = asset;
+    _holdOrigin = globalPosition;
+    _holdPreviewing = true;
     _showPreview(asset, globalPosition);
+  }
+
+  void _updateHold(Offset globalPosition) {
+    if (_holdPreviewing) {
+      // ponytail: 32px slop — hold still to peek, drag to slide-select.
+      if ((globalPosition - _holdOrigin).distance <= 32) {
+        _updatePreview(globalPosition);
+        return;
+      }
+      _holdPreviewing = false;
+      _hidePreview();
+      final held = _heldAsset;
+      if (held != null) _startSlidingSelection(held);
+    }
+    _updateSlidingSelection(globalPosition);
   }
 
   void _endHold() {
     _tileRects = const {};
+    if (_holdPreviewing) {
+      // Pure preview: no selection side effects.
+      _holdPreviewing = false;
+      _hidePreview();
+      return;
+    }
     _stopSlidingSelection();
     _hidePreview();
   }
@@ -494,10 +520,8 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
     return GestureDetector(
       onLongPressStart: (details) =>
           _beginHold(asset, details.globalPosition),
-      onLongPressMoveUpdate: (details) {
-        _updateSlidingSelection(details.globalPosition);
-        _updatePreview(details.globalPosition);
-      },
+      onLongPressMoveUpdate: (details) =>
+          _updateHold(details.globalPosition),
       onLongPressEnd: (_) => _endHold(),
       onLongPressCancel: _endHold,
       onTap: () => _toggleSelection(asset),

--- a/lib/screens/media_picker_screen.dart
+++ b/lib/screens/media_picker_screen.dart
@@ -1,6 +1,8 @@
-import 'dart:typed_data';
+import 'dart:math' as math;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
+import 'package:video_player/video_player.dart';
 import '../services/auto_kill_service.dart';
 import '../themes/app_colors.dart';
 import '../utils/responsive_utils.dart';
@@ -42,6 +44,9 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
   bool _isSlidingSelection = false;
   bool? _slidingSelectionValue;
   final Set<String> _slidingTouchedAssetIds = {};
+  OverlayEntry? _previewEntry;
+  final ValueNotifier<Offset> _previewPosition = ValueNotifier(Offset.zero);
+  final ValueNotifier<AssetEntity?> _previewAsset = ValueNotifier(null);
 
   @override
   void initState() {
@@ -52,6 +57,9 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
 
   @override
   void dispose() {
+    _hidePreview();
+    _previewPosition.dispose();
+    _previewAsset.dispose();
     _scrollController.dispose();
     super.dispose();
   }
@@ -234,6 +242,37 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
       _slidingSelectionValue = null;
       _slidingTouchedAssetIds.clear();
     });
+  }
+
+  void _showPreview(AssetEntity asset, Offset globalPosition) {
+    _hidePreview();
+    _previewEntry = OverlayEntry(
+      builder: (_) => _HoldPreviewCard(
+        asset: _previewAsset,
+        position: _previewPosition,
+      ),
+    );
+    Overlay.of(context).insert(_previewEntry!);
+    _previewAsset.value = asset;
+    _previewPosition.value = globalPosition;
+  }
+
+  void _updatePreview(Offset globalPosition) {
+    if (_previewEntry == null) return;
+    _previewPosition.value = globalPosition;
+
+    final assetId = _assetIdAt(globalPosition);
+    if (assetId == null) return;
+    final asset = _assetById(assetId);
+    if (asset != null && _previewAsset.value?.id != asset.id) {
+      _previewAsset.value = asset;
+    }
+  }
+
+  void _hidePreview() {
+    _previewEntry?.remove();
+    _previewEntry = null;
+    _previewAsset.value = null;
   }
 
   AssetEntity? _assetById(String assetId) {
@@ -439,11 +478,22 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
     final selectionIndex = _selectedAssets.toList().indexOf(asset);
 
     return GestureDetector(
-      onLongPressStart: (_) => _startSlidingSelection(asset),
-      onLongPressMoveUpdate: (details) =>
-          _updateSlidingSelection(details.globalPosition),
-      onLongPressEnd: (_) => _stopSlidingSelection(),
-      onLongPressCancel: _stopSlidingSelection,
+      onLongPressStart: (details) {
+        _startSlidingSelection(asset);
+        _showPreview(asset, details.globalPosition);
+      },
+      onLongPressMoveUpdate: (details) {
+        _updateSlidingSelection(details.globalPosition);
+        _updatePreview(details.globalPosition);
+      },
+      onLongPressEnd: (_) {
+        _stopSlidingSelection();
+        _hidePreview();
+      },
+      onLongPressCancel: () {
+        _stopSlidingSelection();
+        _hidePreview();
+      },
       onTap: () => _toggleSelection(asset),
       child: Stack(
         key: _tileKeyFor(asset.id),
@@ -660,4 +710,211 @@ class MediaPickerResult {
   bool get isEmpty => selectedAssets.isEmpty;
   bool get isNotEmpty => selectedAssets.isNotEmpty;
   int get count => selectedAssets.length;
+}
+
+/// Computes a clamped on-screen rect for the hold-to-preview card so it stays
+/// fully visible, preferring a spot above the finger.
+Rect holdPreviewRect(Offset finger, Size screen, Size card) {
+  const margin = 12.0;
+
+  final left = (finger.dx - card.width / 2).clamp(
+    margin,
+    math.max(margin, screen.width - card.width - margin),
+  ).toDouble();
+  var top = finger.dy - card.height - 56;
+  if (top < margin) top = finger.dy + 56;
+  top = top.clamp(
+    margin,
+    math.max(margin, screen.height - card.height - margin),
+  );
+
+  return Rect.fromLTWH(left, top, card.width, card.height);
+}
+
+class _HoldPreviewCard extends StatelessWidget {
+  final ValueListenable<AssetEntity?> asset;
+  final ValueListenable<Offset> position;
+
+  const _HoldPreviewCard({required this.asset, required this.position});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Offset>(
+      valueListenable: position,
+      builder: (context, finger, _) {
+        final screen = MediaQuery.of(context).size;
+        final side =
+            (screen.shortestSide * 0.65).clamp(200.0, 340.0).toDouble();
+        final rect = holdPreviewRect(finger, screen, Size(side, side));
+
+        return Positioned.fromRect(
+          rect: rect,
+          child: IgnorePointer(
+            child: ValueListenableBuilder<AssetEntity?>(
+              valueListenable: asset,
+              builder: (context, asset, _) {
+                if (asset == null) return const SizedBox.shrink();
+                return DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(20),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.4),
+                        blurRadius: 24,
+                      ),
+                    ],
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(20),
+                    // Keyed so a new hold starts fresh (no stale video frame).
+                    child: KeyedSubtree(
+                      key: ValueKey(asset.id),
+                      child: Container(
+                        color: Colors.black,
+                        child: _AssetPreviewContent(asset: asset),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _AssetPreviewContent extends StatelessWidget {
+  final AssetEntity asset;
+
+  const _AssetPreviewContent({required this.asset});
+
+  @override
+  Widget build(BuildContext context) {
+    if (asset.type == AssetType.video) return _VideoPreview(asset: asset);
+    return _ImagePreview(asset: asset);
+  }
+}
+
+class _ImagePreview extends StatefulWidget {
+  final AssetEntity asset;
+
+  const _ImagePreview({required this.asset});
+
+  @override
+  State<_ImagePreview> createState() => _ImagePreviewState();
+}
+
+class _ImagePreviewState extends State<_ImagePreview> {
+  late final Future<Uint8List?> _future = widget.asset.thumbnailDataWithSize(
+    const ThumbnailSize(1200, 1200),
+    quality: 90,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Uint8List?>(
+      future: _future,
+      builder: (context, snapshot) {
+        final bytes = snapshot.data;
+        if (bytes != null && bytes.isNotEmpty) {
+          return Image.memory(bytes, fit: BoxFit.contain);
+        }
+        if (snapshot.hasError) {
+          return const Center(
+            child: Icon(Icons.broken_image, color: Colors.white54),
+          );
+        }
+        return const Center(
+          child: CircularProgressIndicator(color: Colors.white70),
+        );
+      },
+    );
+  }
+}
+
+class _VideoPreview extends StatefulWidget {
+  final AssetEntity asset;
+
+  const _VideoPreview({required this.asset});
+
+  @override
+  State<_VideoPreview> createState() => _VideoPreviewState();
+}
+
+class _VideoPreviewState extends State<_VideoPreview> {
+  VideoPlayerController? _controller;
+  bool _failed = false;
+  late final Future<Uint8List?> _thumb = widget.asset.thumbnailDataWithSize(
+    const ThumbnailSize(1200, 1200),
+    quality: 90,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    try {
+      final file = await widget.asset.file;
+      if (file == null || !mounted) return;
+      final controller = VideoPlayerController.file(file);
+      await controller.initialize();
+      if (!mounted) {
+        controller.dispose();
+        return;
+      }
+      setState(() => _controller = controller);
+      await controller.setLooping(true);
+      await controller.setVolume(0);
+      await controller.play();
+    } catch (_) {
+      if (mounted) setState(() => _failed = true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = _controller;
+    if (controller == null) {
+      return FutureBuilder<Uint8List?>(
+        future: _thumb,
+        builder: (context, snapshot) {
+          final bytes = snapshot.data;
+          if (bytes != null && bytes.isNotEmpty && !_failed) {
+            return Stack(
+              fit: StackFit.expand,
+              children: [
+                Image.memory(bytes, fit: BoxFit.contain),
+                const Center(
+                  child: Icon(Icons.play_arrow,
+                      size: 48, color: Colors.white70),
+                ),
+              ],
+            );
+          }
+          return const SizedBox.expand();
+        },
+      );
+    }
+
+    return Center(
+      child: AspectRatio(
+        aspectRatio:
+            controller.value.aspectRatio == 0
+                ? 1
+                : controller.value.aspectRatio,
+        child: VideoPlayer(controller),
+      ),
+    );
+  }
 }

--- a/lib/screens/media_viewer_screen.dart
+++ b/lib/screens/media_viewer_screen.dart
@@ -679,7 +679,7 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error exporting file: $e');
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 
@@ -720,7 +720,7 @@ class _MediaViewerScreenState extends ConsumerState<MediaViewerScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error opening file: $e');
-      ToastUtils.showError('Failed to open file: $e');
+      ToastUtils.showError('Failed to open file');
     }
   }
 

--- a/lib/screens/note_editor_screen.dart
+++ b/lib/screens/note_editor_screen.dart
@@ -22,6 +22,7 @@ class _NoteEditorScreenState extends ConsumerState<NoteEditorScreen> {
   bool _showPreview = false;
   bool _isSaving = false;
   bool _isLoading = false;
+  bool _encrypt = false;
   String? _folderId;
 
   @override
@@ -111,13 +112,26 @@ class _NoteEditorScreenState extends ConsumerState<NoteEditorScreen> {
             },
             tooltip: _isMarkdown ? 'Plain text' : 'Markdown',
           ),
+          if (!isEditing)
+            IconButton(
+              icon: Icon(
+                _encrypt ? Icons.lock : Icons.lock_outline,
+                color: _encrypt ? context.accentColor : context.textSecondary,
+              ),
+              onPressed: () {
+                setState(() => _encrypt = !_encrypt);
+              },
+              tooltip: _encrypt ? 'Encrypted' : 'Encrypt note',
+            ),
           IconButton(
             icon: Icon(Icons.folder_outlined, color: context.textSecondary),
             onPressed: _showFolderPicker,
+            tooltip: 'Folder',
           ),
           IconButton(
             icon: Icon(Icons.check, color: context.accentColor),
             onPressed: _isSaving ? null : _saveNote,
+            tooltip: 'Save',
           ),
         ],
       ),
@@ -314,6 +328,7 @@ class _NoteEditorScreenState extends ConsumerState<NoteEditorScreen> {
           content: _contentController.text,
           folderId: _folderId,
           isMarkdown: _isMarkdown,
+          encrypt: _encrypt,
         );
         if (mounted) ToastUtils.showSuccess('Note created');
       }

--- a/lib/screens/note_folders_screen.dart
+++ b/lib/screens/note_folders_screen.dart
@@ -71,9 +71,15 @@ class _NoteFoldersScreenState extends ConsumerState<NoteFoldersScreen> {
             );
           }
 
-          return ListView.builder(
-            padding: const EdgeInsets.all(16),
+          return ListView.separated(
+            padding: const EdgeInsets.symmetric(vertical: 4),
             itemCount: folders.length,
+            separatorBuilder: (_, __) => Divider(
+              height: 1,
+              indent: 16,
+              endIndent: 16,
+              color: context.dividerColor,
+            ),
             itemBuilder: (context, index) {
               final folder = folders[index];
               final noteCount = notesAsync.whenOrNull(
@@ -82,82 +88,79 @@ class _NoteFoldersScreenState extends ConsumerState<NoteFoldersScreen> {
                   ) ??
                   0;
 
-              return Container(
-                margin: const EdgeInsets.only(bottom: 12),
-                decoration: BoxDecoration(
+              return ListTile(
+                leading: Icon(Icons.folder_outlined,
+                    color: context.textSecondary),
+                title: Text(
+                  folder.name,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: context.textPrimary,
+                  ),
+                ),
+                subtitle: Text(
+                  '$noteCount ${noteCount == 1 ? 'note' : 'notes'}',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.textTertiary,
+                  ),
+                ),
+                trailing: PopupMenuButton<String>(
+                  icon:
+                      Icon(Icons.more_vert, color: context.textSecondary),
                   color: context.surfaceColor,
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: context.borderColor),
-                ),
-                child: ListTile(
-                  leading: Icon(Icons.folder, color: context.accentColor),
-                  title: Text(
-                    folder.name,
-                    style: TextStyle(
-                      fontFamily: 'ProductSans',
-                      fontSize: 15,
-                      fontWeight: FontWeight.w600,
-                      color: context.textPrimary,
-                    ),
-                  ),
-                  subtitle: Text(
-                    '$noteCount note(s)',
-                    style: TextStyle(
-                      fontFamily: 'ProductSans',
-                      fontSize: 12,
-                      color: context.textTertiary,
-                    ),
-                  ),
-                  trailing: PopupMenuButton<String>(
-                    icon: Icon(Icons.more_vert, color: context.textSecondary),
-                    color: context.surfaceColor,
-                    onSelected: (value) {
-                      if (value == 'rename') {
-                        _showRenameDialog(folder);
-                      } else if (value == 'delete') {
-                        _showDeleteConfirmation(folder);
-                      }
-                    },
-                    itemBuilder: (context) => [
-                      PopupMenuItem(
-                        value: 'rename',
-                        child: Row(
-                          children: [
-                            Icon(Icons.edit, size: 18, color: context.textSecondary),
-                            const SizedBox(width: 12),
-                            Text(
-                              'Rename',
-                              style: TextStyle(
-                                fontFamily: 'ProductSans',
-                                color: context.textPrimary,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      PopupMenuItem(
-                        value: 'delete',
-                        child: Row(
-                          children: [
-                            Icon(Icons.delete_outline, size: 18, color: AppColors.error),
-                            const SizedBox(width: 12),
-                            Text(
-                              'Delete',
-                              style: TextStyle(
-                                fontFamily: 'ProductSans',
-                                color: AppColors.error,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                  onTap: () {
-                    ref.read(selectedNoteFolderProvider.notifier).state = folder.id;
-                    Navigator.pop(context);
+                  onSelected: (value) {
+                    if (value == 'rename') {
+                      _showRenameDialog(folder);
+                    } else if (value == 'delete') {
+                      _showDeleteConfirmation(folder);
+                    }
                   },
+                  itemBuilder: (context) => [
+                    PopupMenuItem(
+                      value: 'rename',
+                      child: Row(
+                        children: [
+                          Icon(Icons.edit_outlined,
+                              size: 18, color: context.textSecondary),
+                          const SizedBox(width: 12),
+                          Text(
+                            'Rename',
+                            style: TextStyle(
+                              fontFamily: 'ProductSans',
+                              color: context.textPrimary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    PopupMenuItem(
+                      value: 'delete',
+                      child: Row(
+                        children: [
+                          Icon(Icons.delete_outline,
+                              size: 18, color: AppColors.error),
+                          const SizedBox(width: 12),
+                          Text(
+                            'Delete',
+                            style: TextStyle(
+                              fontFamily: 'ProductSans',
+                              color: AppColors.error,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
+                onTap: () {
+                  ref.read(selectedNoteFolderProvider.notifier).state =
+                      folder.id;
+                  Navigator.pop(context);
+                },
               );
             },
           );

--- a/lib/screens/note_list_screen.dart
+++ b/lib/screens/note_list_screen.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/note.dart';
-import '../models/encryption_algorithm.dart';
 import '../providers/note_providers.dart';
 import '../themes/app_colors.dart';
 import '../utils/toast_utils.dart';
 import '../widgets/note_card.dart';
-import '../widgets/operation_progress_sheet.dart';
 import 'note_editor_screen.dart';
 import 'note_folders_screen.dart';
 
@@ -42,6 +40,7 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
           : AppBar(
               backgroundColor: context.backgroundColor,
               elevation: 0,
+              automaticallyImplyLeading: false,
               title: Text(
                 'Notes',
                 style: TextStyle(
@@ -53,7 +52,9 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
               ),
               actions: [
                 IconButton(
-                  icon: Icon(Icons.folder_outlined, color: context.textSecondary),
+                  icon: Icon(Icons.folder_outlined,
+                      color: context.textSecondary),
+                  tooltip: 'Folders',
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
@@ -66,7 +67,7 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
       body: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
             child: TextField(
               controller: _searchController,
               onChanged: (value) {
@@ -77,21 +78,23 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
                 color: context.textPrimary,
               ),
               decoration: InputDecoration(
-                hintText: 'Search notes...',
+                hintText: 'Search notes',
                 hintStyle: TextStyle(
                   fontFamily: 'ProductSans',
                   color: context.textTertiary,
                 ),
-                prefixIcon: Icon(Icons.search, color: context.textTertiary),
+                prefixIcon:
+                    Icon(Icons.search, size: 20, color: context.textTertiary),
+                isDense: true,
                 filled: true,
                 fillColor: context.surfaceColor,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide(color: context.borderColor),
+                  borderSide: BorderSide.none,
                 ),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide(color: context.borderColor),
+                  borderSide: BorderSide.none,
                 ),
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
@@ -102,25 +105,21 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
           ),
           if (selectedFolder != null)
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
               child: Row(
                 children: [
-                  Icon(Icons.folder, size: 16, color: context.accentColor),
+                  Icon(Icons.folder, size: 14, color: context.accentColor),
                   const SizedBox(width: 6),
                   Expanded(
                     child: Text(
-                      foldersAsync.when(
-                        data: (folders) {
-                          final folder = folders.firstWhere(
-                            (f) => f.id == selectedFolder,
-                            orElse: () =>
-                                NoteFolder(id: '', name: 'Unknown', createdAt: DateTime.now(), updatedAt: DateTime.now()),
-                          );
-                          return folder.name;
-                        },
-                        loading: () => 'Loading...',
-                        error: (_, __) => 'Error',
+                      foldersAsync.maybeWhen(
+                        data: (folders) => folders
+                            .where((f) => f.id == selectedFolder)
+                            .fold('', (prev, f) => f.name),
+                        orElse: () => '',
                       ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         fontFamily: 'ProductSans',
                         fontSize: 13,
@@ -128,18 +127,14 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
                       ),
                     ),
                   ),
-                  TextButton(
+                  IconButton(
+                    icon: Icon(Icons.close,
+                        size: 16, color: context.textTertiary),
+                    tooltip: 'Clear folder filter',
                     onPressed: () {
-                      ref.read(selectedNoteFolderProvider.notifier).state = null;
+                      ref.read(selectedNoteFolderProvider.notifier).state =
+                          null;
                     },
-                    child: Text(
-                      'Clear',
-                      style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        fontSize: 12,
-                        color: context.accentColor,
-                      ),
-                    ),
                   ),
                 ],
               ),
@@ -147,7 +142,8 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
           Expanded(
             child: notesAsync.when(
               data: (notes) {
-                final filtered = _filterNotes(notes, searchQuery, selectedFolder);
+                final filtered =
+                    _filterNotes(notes, searchQuery, selectedFolder);
                 if (filtered.isEmpty) {
                   return Center(
                     child: Column(
@@ -155,17 +151,17 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
                       children: [
                         Icon(
                           Icons.note_outlined,
-                          size: 64,
+                          size: 48,
                           color: context.textTertiary,
                         ),
-                        const SizedBox(height: 16),
+                        const SizedBox(height: 12),
                         Text(
                           searchQuery.isNotEmpty
                               ? 'No notes found'
                               : 'No notes yet',
                           style: TextStyle(
                             fontFamily: 'ProductSans',
-                            fontSize: 16,
+                            fontSize: 15,
                             color: context.textTertiary,
                           ),
                         ),
@@ -173,25 +169,25 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
                     ),
                   );
                 }
-                return GridView.builder(
-                  padding: const EdgeInsets.all(16),
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    crossAxisSpacing: 12,
-                    mainAxisSpacing: 12,
-                    childAspectRatio: 1.4,
-                  ),
+                return ListView.separated(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
                   itemCount: filtered.length,
+                  separatorBuilder: (_, __) => Divider(
+                    height: 1,
+                    indent: 16,
+                    endIndent: 16,
+                    color: context.dividerColor,
+                  ),
                   itemBuilder: (context, index) {
                     final note = filtered[index];
-                    final isSelected = _selectedNoteIds.contains(note.id);
                     return NoteCard(
                       note: note,
-                      isSelected: isSelected,
+                      isSelected: _selectedNoteIds.contains(note.id),
+                      isSelectionMode: _isSelectionMode,
                       onTap: () {
                         if (_isSelectionMode) {
                           setState(() {
-                            if (isSelected) {
+                            if (_selectedNoteIds.contains(note.id)) {
                               _selectedNoteIds.remove(note.id);
                               if (_selectedNoteIds.isEmpty) {
                                 _isSelectionMode = false;
@@ -238,7 +234,10 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
       floatingActionButton: _isSelectionMode
           ? null
           : FloatingActionButton(
-              onPressed: _showNewNoteSheet,
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const NoteEditorScreen()),
+              ),
               backgroundColor: context.accentColor,
               elevation: 0,
               child: const Icon(Icons.add, color: Colors.white),
@@ -271,7 +270,7 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
       actions: [
         IconButton(
           icon: Icon(Icons.delete_outline, color: AppColors.error),
-          onPressed: () => _showDeleteConfirmation(),
+          onPressed: _showDeleteConfirmation,
         ),
       ],
     );
@@ -300,424 +299,14 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
     return filtered;
   }
 
-  void _showNewNoteSheet() {
-    final titleController = TextEditingController();
-    final contentController = TextEditingController();
-    bool isSaving = false;
-    String selectedFormat = 'txt';
-    bool encrypt = false;
-    EncryptionAlgorithm selectedAlgorithm = EncryptionAlgorithm.aes256Gcm;
-    int selectedKdfIterations = 100000;
-    const kdfOptions = [100000, 200000, 500000];
-
-    showModalBottomSheet(
-      context: context,
-      backgroundColor: Colors.transparent,
-      isScrollControlled: true,
-      builder: (sheetContext) {
-        return StatefulBuilder(
-          builder: (context, setSheetState) {
-            return Padding(
-              padding: EdgeInsets.only(
-                bottom: MediaQuery.of(context).viewInsets.bottom,
-              ),
-              child: Container(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.of(context).size.height * 0.85,
-                ),
-                decoration: BoxDecoration(
-                  color: context.surfaceColor,
-                  borderRadius:
-                      const BorderRadius.vertical(top: Radius.circular(24)),
-                ),
-                child: SingleChildScrollView(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Container(
-                        margin: const EdgeInsets.only(top: 12),
-                        width: 40,
-                        height: 4,
-                        decoration: BoxDecoration(
-                          color: context.borderColor,
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(20),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    'New Note',
-                                    style: TextStyle(
-                                      fontFamily: 'ProductSans',
-                                      fontSize: 20,
-                                      fontWeight: FontWeight.w600,
-                                      color: context.textPrimary,
-                                    ),
-                                  ),
-                                ),
-                                TextButton(
-                                  onPressed: isSaving
-                                      ? null
-                                      : () async {
-                                          if (titleController.text
-                                              .trim()
-                                              .isEmpty) {
-                                            ToastUtils.showError(
-                                                'Title cannot be empty');
-                                            return;
-                                          }
-                                          setSheetState(
-                                              () => isSaving = true);
-
-                                          Navigator.pop(context);
-
-                                          final progressState =
-                                              ValueNotifier<OperationProgressState>(
-                                            OperationProgressState(
-                                              totalFiles: 1,
-                                              currentFile: 0,
-                                              currentFileName:
-                                                  titleController.text.trim(),
-                                              totalSizeBytes: contentController
-                                                  .text.length,
-                                              processedSizeBytes: 0,
-                                              statusMessage: 'Preparing...',
-                                              isProcessing: true,
-                                              isEncrypting: encrypt,
-                                              isComplete: false,
-                                            ),
-                                          );
-
-                                          if (!mounted) return;
-                                          showModalBottomSheet(
-                                            context: this.context,
-                                            backgroundColor: Colors.transparent,
-                                            isDismissible: false,
-                                            enableDrag: false,
-                                            builder: (ctx) =>
-                                                ValueListenableBuilder<
-                                                    OperationProgressState>(
-                                              valueListenable: progressState,
-                                              builder: (ctx, state, _) =>
-                                                  OperationProgressSheet(
-                                                operationType:
-                                                    OperationType.hide,
-                                                totalFiles: state.totalFiles,
-                                                currentFile: state.currentFile,
-                                                currentFileName:
-                                                    state.currentFileName,
-                                                totalSizeBytes:
-                                                    state.totalSizeBytes,
-                                                processedSizeBytes:
-                                                    state.processedSizeBytes,
-                                                statusMessage:
-                                                    state.statusMessage,
-                                                isProcessing: state.isProcessing,
-                                                isComplete: state.isComplete,
-                                                isEncrypting: state.isEncrypting,
-                                              ),
-                                            ),
-                                          );
-
-                                          try {
-                                            await ref
-                                                .read(notesNotifierProvider
-                                                    .notifier)
-                                                .createNote(
-                                              title: titleController.text.trim(),
-                                              content: contentController.text,
-                                              fileExtension: selectedFormat,
-                                              isMarkdown: selectedFormat == 'md',
-                                              encrypt: encrypt,
-                                              encryptionAlgorithm: encrypt
-                                                  ? selectedAlgorithm
-                                                  : EncryptionAlgorithm
-                                                      .aes256Gcm,
-                                              kdfIterations:
-                                                  selectedKdfIterations,
-                                              onProgress: (status,
-                                                  {isEncrypting = false}) {
-                                                progressState.value =
-                                                    progressState.value.copyWith(
-                                                  statusMessage: status,
-                                                  isEncrypting: isEncrypting,
-                                                  currentFile: 1,
-                                                  processedSizeBytes:
-                                                      isEncrypting
-                                                          ? (progressState
-                                                                  .value
-                                                                  .processedSizeBytes +
-                                                              (contentController
-                                                                      .text
-                                                                      .length ~/
-                                                                      3))
-                                                          : progressState.value
-                                                              .processedSizeBytes,
-                                                );
-                                              },
-                                            );
-                                            progressState.value =
-                                                progressState.value.copyWith(
-                                              isProcessing: false,
-                                              isComplete: true,
-                                              statusMessage: 'Completed',
-                                              processedSizeBytes: progressState
-                                                  .value.totalSizeBytes,
-                                            );
-                                          } catch (e) {
-                                            if (!mounted) return;
-                                            Navigator.pop(this.context);
-                                            ToastUtils.showError(
-                                                'Failed to create note');
-                                          }
-                                        },
-                                  child: Text(
-                                    'Save',
-                                    style: TextStyle(
-                                      fontFamily: 'ProductSans',
-                                      color: context.accentColor,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const SizedBox(height: 12),
-                            Row(
-                              children: [
-                                Text(
-                                  'Format: ',
-                                  style: TextStyle(
-                                    fontFamily: 'ProductSans',
-                                    fontSize: 13,
-                                    color: context.textSecondary,
-                                  ),
-                                ),
-                                ...['txt', 'md', 'html'].map((fmt) {
-                                  final isSelected = fmt == selectedFormat;
-                                  return Padding(
-                                    padding: const EdgeInsets.only(right: 8),
-                                    child: ChoiceChip(
-                                      label: Text(
-                                        '.$fmt',
-                                        style: TextStyle(
-                                          fontFamily: 'ProductSans',
-                                          fontSize: 12,
-                                          color: isSelected
-                                              ? Colors.white
-                                              : context.textSecondary,
-                                        ),
-                                      ),
-                                      selected: isSelected,
-                                      onSelected: (_) {
-                                        setSheetState(
-                                            () => selectedFormat = fmt);
-                                      },
-                                      selectedColor: context.accentColor,
-                                      backgroundColor:
-                                          context.backgroundColor,
-                                      side: BorderSide(
-                                        color: isSelected
-                                            ? context.accentColor
-                                            : context.borderColor,
-                                      ),
-                                      visualDensity: VisualDensity.compact,
-                                    ),
-                                  );
-                                }),
-                              ],
-                            ),
-                            const SizedBox(height: 8),
-                            Row(
-                              children: [
-                                Icon(Icons.lock_outline,
-                                    size: 16, color: context.textSecondary),
-                                const SizedBox(width: 6),
-                                Text(
-                                  'Encrypt',
-                                  style: TextStyle(
-                                    fontFamily: 'ProductSans',
-                                    fontSize: 13,
-                                    color: context.textSecondary,
-                                  ),
-                                ),
-                                const Spacer(),
-                                Switch(
-                                  value: encrypt,
-                                  activeTrackColor: context.accentColor,
-                                  onChanged: (v) =>
-                                      setSheetState(() => encrypt = v),
-                                ),
-                              ],
-                            ),
-                            if (encrypt) ...[
-                              const SizedBox(height: 8),
-                              Text(
-                                'Algorithm',
-                                style: TextStyle(
-                                  fontFamily: 'ProductSans',
-                                  fontSize: 13,
-                                  color: context.textSecondary,
-                                ),
-                              ),
-                              const SizedBox(height: 6),
-                              Row(
-                                children: EncryptionAlgorithm.values.map((algo) {
-                                  final isSelected = algo == selectedAlgorithm;
-                                  return Padding(
-                                    padding: const EdgeInsets.only(right: 8),
-                                    child: ChoiceChip(
-                                      label: Text(
-                                        algo.displayName,
-                                        style: TextStyle(
-                                          fontFamily: 'ProductSans',
-                                          fontSize: 12,
-                                          color: isSelected
-                                              ? Colors.white
-                                              : context.textSecondary,
-                                        ),
-                                      ),
-                                      selected: isSelected,
-                                      onSelected: (_) => setSheetState(
-                                          () => selectedAlgorithm = algo),
-                                      selectedColor: context.accentColor,
-                                      backgroundColor: context.backgroundColor,
-                                      side: BorderSide(
-                                        color: isSelected
-                                            ? context.accentColor
-                                            : context.borderColor,
-                                      ),
-                                      visualDensity: VisualDensity.compact,
-                                    ),
-                                  );
-                                }).toList(),
-                              ),
-                              const SizedBox(height: 8),
-                              Text(
-                                'KDF iterations',
-                                style: TextStyle(
-                                  fontFamily: 'ProductSans',
-                                  fontSize: 13,
-                                  color: context.textSecondary,
-                                ),
-                              ),
-                              const SizedBox(height: 6),
-                              Row(
-                                children: kdfOptions.map((kdf) {
-                                  final isSelected = kdf == selectedKdfIterations;
-                                  final label = kdf == 100000
-                                      ? '${(kdf / 1000).round()}K'
-                                      : '${(kdf / 1000).round()}K';
-                                  return Padding(
-                                    padding: const EdgeInsets.only(right: 8),
-                                    child: ChoiceChip(
-                                      label: Text(
-                                        label,
-                                        style: TextStyle(
-                                          fontFamily: 'ProductSans',
-                                          fontSize: 12,
-                                          color: isSelected
-                                              ? Colors.white
-                                              : context.textSecondary,
-                                        ),
-                                      ),
-                                      selected: isSelected,
-                                      onSelected: (_) => setSheetState(
-                                          () => selectedKdfIterations = kdf),
-                                      selectedColor: context.accentColor,
-                                      backgroundColor: context.backgroundColor,
-                                      side: BorderSide(
-                                        color: isSelected
-                                            ? context.accentColor
-                                            : context.borderColor,
-                                      ),
-                                      visualDensity: VisualDensity.compact,
-                                    ),
-                                  );
-                                }).toList(),
-                              ),
-                            ],
-                            const SizedBox(height: 8),
-                            TextField(
-                              controller: titleController,
-                              style: TextStyle(
-                                fontFamily: 'ProductSans',
-                                fontSize: 18,
-                                fontWeight: FontWeight.w600,
-                                color: context.textPrimary,
-                              ),
-                              decoration: InputDecoration(
-                                hintText: 'Title',
-                                hintStyle: TextStyle(
-                                  fontFamily: 'ProductSans',
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w600,
-                                  color: context.textTertiary,
-                                ),
-                                border: InputBorder.none,
-                                enabledBorder: InputBorder.none,
-                                focusedBorder: InputBorder.none,
-                                contentPadding: EdgeInsets.zero,
-                              ),
-                            ),
-                            Divider(color: context.dividerColor),
-                            SizedBox(
-                              height: 200,
-                              child: TextField(
-                                controller: contentController,
-                                maxLines: null,
-                                expands: true,
-                                textAlignVertical: TextAlignVertical.top,
-                                style: TextStyle(
-                                  fontFamily: 'ProductSans',
-                                  fontSize: 15,
-                                  color: context.textPrimary,
-                                  height: 1.5,
-                                ),
-                                decoration: InputDecoration(
-                                  hintText: 'Start writing...',
-                                  hintStyle: TextStyle(
-                                    fontFamily: 'ProductSans',
-                                    fontSize: 15,
-                                    color: context.textTertiary,
-                                  ),
-                                  border: InputBorder.none,
-                                  enabledBorder: InputBorder.none,
-                                  focusedBorder: InputBorder.none,
-                                  contentPadding: EdgeInsets.zero,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            );
-          },
-        );
-      },
-    ).whenComplete(() {
-      titleController.dispose();
-      contentController.dispose();
-    });
-  }
-
   Future<void> _showDeleteConfirmation() async {
+    final count = _selectedNoteIds.length;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
         backgroundColor: context.surfaceColor,
         title: Text(
-          'Delete Notes',
+          count == 1 ? 'Delete Note' : 'Delete Notes',
           style: TextStyle(
             fontFamily: 'ProductSans',
             fontWeight: FontWeight.w600,
@@ -725,7 +314,7 @@ class _NoteListScreenState extends ConsumerState<NoteListScreen> {
           ),
         ),
         content: Text(
-          'Delete ${_selectedNoteIds.length} note(s)? This cannot be undone.',
+          'Delete $count ${count == 1 ? 'note' : 'notes'}? This cannot be undone.',
           style: TextStyle(
             fontFamily: 'ProductSans',
             color: context.textSecondary,

--- a/lib/screens/password_list_screen.dart
+++ b/lib/screens/password_list_screen.dart
@@ -54,7 +54,6 @@ class _PasswordListScreenState extends ConsumerState<PasswordListScreen> {
   @override
   Widget build(BuildContext context) {
     final searchQuery = ref.watch(passwordSearchQueryProvider);
-    final selectedTag = ref.watch(selectedPasswordTagProvider);
     final entriesAsync = ref.watch(passwordsNotifierProvider);
 
     return Scaffold(
@@ -77,7 +76,7 @@ class _PasswordListScreenState extends ConsumerState<PasswordListScreen> {
       body: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
             child: TextField(
               controller: _searchController,
               onChanged: (value) {
@@ -88,21 +87,23 @@ class _PasswordListScreenState extends ConsumerState<PasswordListScreen> {
                 color: context.textPrimary,
               ),
               decoration: InputDecoration(
-                hintText: 'Search passwords...',
+                hintText: 'Search passwords',
                 hintStyle: TextStyle(
                   fontFamily: 'ProductSans',
                   color: context.textTertiary,
                 ),
-                prefixIcon: Icon(Icons.search, color: context.textTertiary),
+                prefixIcon:
+                    Icon(Icons.search, size: 20, color: context.textTertiary),
+                isDense: true,
                 filled: true,
                 fillColor: context.surfaceColor,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide(color: context.borderColor),
+                  borderSide: BorderSide.none,
                 ),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: BorderSide(color: context.borderColor),
+                  borderSide: BorderSide.none,
                 ),
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
@@ -115,81 +116,79 @@ class _PasswordListScreenState extends ConsumerState<PasswordListScreen> {
           Expanded(
             child: entriesAsync.when(
               data: (entries) {
-                final allTags = _collectTags(entries);
-                final filtered =
-                    _filterPasswords(entries, searchQuery, selectedTag);
-                return Column(
-                  children: [
-                    if (allTags.isNotEmpty)
-                      SizedBox(
-                        height: 40,
-                        child: ListView(
-                          scrollDirection: Axis.horizontal,
-                          padding: const EdgeInsets.symmetric(horizontal: 16),
-                          children: [
-                            _buildTagChip(
-                              null,
-                              selectedTag == null,
-                              'All',
-                            ),
-                            ...allTags.map((tag) =>
-                                _buildTagChip(tag, selectedTag == tag, tag)),
-                          ],
+                final filtered = _filterPasswords(entries, searchQuery);
+                if (filtered.isEmpty) {
+                  return Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.lock_outline,
+                          size: 48,
+                          color: context.textTertiary,
                         ),
-                      ),
-                    Expanded(
-                      child: filtered.isEmpty
-                          ? _buildEmptyState(searchQuery)
-                          : ListView.builder(
-                              padding: const EdgeInsets.all(16),
-                              itemCount: filtered.length,
-                              itemBuilder: (context, index) {
-                                final entry = filtered[index];
-                                final isSelected =
-                                    _selectedIds.contains(entry.id);
-                                return Padding(
-                                  padding:
-                                      const EdgeInsets.only(bottom: 10),
-                                  child: PasswordCard(
-                                    entry: entry,
-                                    isSelected: isSelected,
-                                    onTap: () {
-                                      if (_isSelectionMode) {
-                                        setState(() {
-                                          if (isSelected) {
-                                            _selectedIds.remove(entry.id);
-                                            if (_selectedIds.isEmpty) {
-                                              _isSelectionMode = false;
-                                            }
-                                          } else {
-                                            _selectedIds.add(entry.id);
-                                          }
-                                        });
-                                      } else {
-                                        Navigator.push(
-                                          context,
-                                          MaterialPageRoute(
-                                            builder: (_) =>
-                                                PasswordEditorScreen(
-                                                    entry: entry),
-                                          ),
-                                        );
-                                      }
-                                    },
-                                    onLongPress: () {
-                                      if (!_isSelectionMode) {
-                                        setState(() {
-                                          _isSelectionMode = true;
-                                          _selectedIds.add(entry.id);
-                                        });
-                                      }
-                                    },
-                                  ),
-                                );
-                              },
-                            ),
+                        const SizedBox(height: 12),
+                        Text(
+                          searchQuery.isNotEmpty
+                              ? 'No passwords found'
+                              : 'No passwords yet',
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 15,
+                            color: context.textTertiary,
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
+                  );
+                }
+                return ListView.separated(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  itemCount: filtered.length,
+                  separatorBuilder: (_, __) => Divider(
+                    height: 1,
+                    indent: 16,
+                    endIndent: 16,
+                    color: context.dividerColor,
+                  ),
+                  itemBuilder: (context, index) {
+                    final entry = filtered[index];
+                    return PasswordCard(
+                      entry: entry,
+                      isSelected: _selectedIds.contains(entry.id),
+                      isSelectionMode: _isSelectionMode,
+                      onTap: () {
+                        if (_isSelectionMode) {
+                          setState(() {
+                            if (_selectedIds.contains(entry.id)) {
+                              _selectedIds.remove(entry.id);
+                              if (_selectedIds.isEmpty) {
+                                _isSelectionMode = false;
+                              }
+                            } else {
+                              _selectedIds.add(entry.id);
+                            }
+                          });
+                        } else {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) =>
+                                  PasswordEditorScreen(entry: entry),
+                            ),
+                          );
+                        }
+                      },
+                      onLongPress: () {
+                        if (!_isSelectionMode) {
+                          setState(() {
+                            _isSelectionMode = true;
+                            _selectedIds.add(entry.id);
+                          });
+                        }
+                      },
+                    );
+                  },
                 );
               },
               loading: () =>
@@ -225,7 +224,7 @@ class _PasswordListScreenState extends ConsumerState<PasswordListScreen> {
 
   Widget _buildAutofillInfoCard() {
     return Container(
-      margin: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      margin: const EdgeInsets.fromLTRB(16, 12, 16, 12),
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
         color: context.accentColor.withValues(alpha: 0.08),
@@ -310,77 +309,11 @@ class _PasswordListScreenState extends ConsumerState<PasswordListScreen> {
     );
   }
 
-  Widget _buildTagChip(String? tag, bool isSelected, String label) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 8),
-      child: FilterChip(
-        label: Text(
-          label,
-          style: TextStyle(
-            fontFamily: 'ProductSans',
-            fontSize: 12,
-            color: isSelected
-                ? Colors.white
-                : context.textSecondary,
-          ),
-        ),
-        selected: isSelected,
-        onSelected: (_) {
-          ref.read(selectedPasswordTagProvider.notifier).state = tag;
-        },
-        selectedColor: context.accentColor,
-        backgroundColor: context.surfaceColor,
-        side: BorderSide(
-          color: isSelected ? context.accentColor : context.borderColor,
-        ),
-        visualDensity: VisualDensity.compact,
-      ),
-    );
-  }
-
-  Widget _buildEmptyState(String searchQuery) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.lock_outline,
-            size: 64,
-            color: context.textTertiary,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            searchQuery.isNotEmpty
-                ? 'No passwords found'
-                : 'No passwords yet',
-            style: TextStyle(
-              fontFamily: 'ProductSans',
-              fontSize: 16,
-              color: context.textTertiary,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  List<String> _collectTags(List<PasswordEntry> entries) {
-    final tags = <String>{};
-    for (final entry in entries) {
-      tags.addAll(entry.tags);
-    }
-    return tags.toList()..sort();
-  }
-
   List<PasswordEntry> _filterPasswords(
     List<PasswordEntry> entries,
     String searchQuery,
-    String? selectedTag,
   ) {
     var filtered = entries;
-    if (selectedTag != null) {
-      filtered = filtered.where((e) => e.hasTag(selectedTag)).toList();
-    }
     if (searchQuery.isNotEmpty) {
       final query = searchQuery.toLowerCase();
       filtered = filtered

--- a/lib/screens/song_player_screen.dart
+++ b/lib/screens/song_player_screen.dart
@@ -118,7 +118,7 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
     } catch (e) {
       if (!mounted) return;
       setState(() {
-        _error = 'Failed to load song: $e';
+        _error = 'Failed to load song';
         _isLoading = false;
       });
     }
@@ -132,7 +132,7 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
         await _player.play();
       }
     } catch (e) {
-      ToastUtils.showError('Playback failed: $e');
+      ToastUtils.showError('Playback failed');
     }
   }
 
@@ -200,7 +200,7 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
       }
     } catch (e) {
       if (mounted) Navigator.pop(context);
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 
@@ -244,7 +244,7 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
       }
     } catch (e) {
       if (mounted) Navigator.pop(context);
-      ToastUtils.showError('Failed to open file: $e');
+      ToastUtils.showError('Failed to open file');
     }
   }
 
@@ -277,7 +277,7 @@ class _SongPlayerScreenState extends ConsumerState<SongPlayerScreen>
     } catch (e) {
       _reenableAutoKillOnResume = false;
       await AutoKillService.setEnabled(true);
-      ToastUtils.showError('Failed to open Flick: $e');
+      ToastUtils.showError('Failed to open Flick');
     }
   }
 

--- a/lib/screens/sync_settings_screen.dart
+++ b/lib/screens/sync_settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:uuid/uuid.dart';
 import '../models/sync_profile.dart';
 import '../providers/sync_provider.dart';
 import '../providers/vault_providers.dart';
+import '../services/remote/server_errors.dart';
 import '../services/remote/webdav_store.dart';
 import '../services/sync_profile_service.dart';
 import '../services/sync_service.dart' show SyncPhase, SyncProgress;
@@ -13,6 +14,7 @@ import '../themes/app_colors.dart';
 /// Connection settings + sync status for the local-server sync feature
 /// (docs/local_server_sync.md). Supports multiple profiles; exactly one is
 /// "active" (the sync target), held in vault settings as [syncProfileId].
+/// Adding/editing a server happens in [_ServerSheet], a focused bottom sheet.
 class SyncSettingsScreen extends ConsumerStatefulWidget {
   const SyncSettingsScreen({super.key});
 
@@ -21,24 +23,10 @@ class SyncSettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
-  final _urlController = TextEditingController();
-  final _userController = TextEditingController();
-  final _passwordController = TextEditingController();
-  final _basePathController = TextEditingController(text: '/locker');
-
-  SyncDirection _direction = SyncDirection.pushOnly;
-  bool _wifiOnly = true;
-
-  /// Profile currently loaded into the editor form. Null = a fresh profile
-  /// being created.
-  String? _editingId;
-
   String? _activeId;
   bool _masterEnabled = false;
 
-  bool _isTesting = false;
   bool _loading = true;
-  bool _obscurePassword = true;
   final List<_SyncLogEntry> _log = [];
 
   @override
@@ -48,31 +36,13 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
     ref.listen<SyncState>(syncProvider, _onSyncStateChanged);
   }
 
-  /// One-shot load of settings + profiles; seeds the form with the active (or
-  /// first) profile. Reactive updates afterwards come from watching the
-  /// providers in [build], but form seeding only happens here and on explicit
-  // user actions — never on a provider re-emit.
+  /// One-shot load of settings + profiles. Reactive updates afterwards come
+  // from watching the providers in [build].
   Future<void> _bootstrap() async {
     final settings = await ref.read(vaultServiceProvider).getSettings();
-    final profiles = await SyncProfileService.instance.listProfiles();
     _activeId = settings.syncProfileId;
     _masterEnabled = settings.syncEnabled;
-    final target =
-        (profiles.where((p) => p.id == _activeId).toList()).firstOrNull ??
-            profiles.firstOrNull;
-    _seedForm(target);
     if (mounted) setState(() => _loading = false);
-  }
-
-  void _seedForm(SyncProfile? p) {
-    _editingId = p?.id;
-    _urlController.text = p?.serverUrl ?? '';
-    _userController.text = p?.username ?? '';
-    _basePathController.text =
-        p?.basePath.isEmpty == true ? '/locker' : (p?.basePath ?? '/locker');
-    _passwordController.clear();
-    _direction = p?.direction ?? SyncDirection.pushOnly;
-    _wifiOnly = p?.wifiOnly ?? true;
   }
 
   void _onSyncStateChanged(SyncState? prev, SyncState next) {
@@ -148,120 +118,49 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
     });
   }
 
-  @override
-  void dispose() {
-    _urlController.dispose();
-    _userController.dispose();
-    _passwordController.dispose();
-    _basePathController.dispose();
-    super.dispose();
+  void _openEditor({SyncProfile? profile}) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      backgroundColor: context.backgroundColor,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (ctx) => _ServerSheet(
+        profile: profile,
+        onSave: _saveFromSheet,
+      ),
+    );
   }
 
-  bool get _isPlainHttp =>
-      _urlController.text.trim().toLowerCase().startsWith('http://');
-
-  bool get _editingActive => _editingId != null && _editingId == _activeId;
-
-  SyncProfile _profileFromForm() => SyncProfile(
-        id: _editingId ?? const Uuid().v4(),
-        serverUrl: _urlController.text.trim(),
-        username: _userController.text.trim().isEmpty
-            ? null
-            : _userController.text.trim(),
-        basePath: _basePathController.text.trim().isEmpty
-            ? '/locker'
-            : _basePathController.text.trim(),
-        direction: _direction,
-        wifiOnly: _wifiOnly,
-        enabled: true,
-      );
-
-  Future<void> _testConnection() async {
-    final url = _urlController.text.trim();
-    if (url.isEmpty) {
-      _snack('Enter a server URL first');
-      return;
-    }
-    setState(() => _isTesting = true);
+  /// Persists the profile (and password when given). New profiles auto-activate
+  /// so sync works out of the box. Returns whether the sheet may close.
+  Future<bool> _saveFromSheet(
+      SyncProfile profile, String password, bool isNew) async {
     try {
-      final password = _passwordController.text.isNotEmpty
-          ? _passwordController.text
-          : (_editingId == null
-              ? ''
-              : await SyncProfileService.instance.getPassword(_editingId!) ??
-                  '');
-      final store = WebDAVStore(
-        baseUrl: url,
-        username: _userController.text.trim(),
-        password: password,
-        basePath: _basePathController.text.trim().isEmpty
-            ? '/locker'
-            : _basePathController.text.trim(),
-      );
-      await store.testConnection();
-      _snack('Connected ✓');
-      _addLog('Connection test succeeded', ok: true);
-    } catch (e) {
-      final msg = _describeConnError(e);
-      _snack(msg);
-      _addLog('Connection test failed: $msg', ok: false);
-    } finally {
-      if (mounted) setState(() => _isTesting = false);
+      await SyncProfileService.instance.saveProfile(profile);
+      if (password.isNotEmpty) {
+        await SyncProfileService.instance.savePassword(profile.id, password);
+      }
+      if (isNew || _activeId == null) {
+        _activeId = profile.id;
+        _masterEnabled = true;
+        await _persistActivation(profile.id, enabled: true);
+      }
+      ref.invalidate(vaultSettingsProvider);
+      ref.invalidate(syncProfilesProvider);
+      if (mounted) {
+        setState(() {});
+        _snack(isNew
+            ? 'Server added and activated'
+            : 'Saved');
+      }
+      return true;
+    } catch (_) {
+      if (mounted) _snack('Couldn\'t save — try again');
+      return false;
     }
-  }
-
-  /// Map a WebDAV/Dio failure to something actionable. A connect timeout on a
-  /// LAN IP is always "server unreachable", never "timeout too short".
-  // string-match on toString(); avoids importing transitive dio.
-  String _describeConnError(Object e) {
-    final s = e.toString().toLowerCase();
-    if (s.contains('connection timeout') || s.contains('connecttimeout')) {
-      return 'Couldn\'t reach the server (timed out). Check it\'s running on '
-          'the right port and bound to 0.0.0.0, not localhost.';
-    }
-    if (s.contains('connection refused') ||
-        s.contains('reset') ||
-        s.contains('broken pipe')) {
-      return 'Server refused the connection. Wrong port, or the WebDAV '
-          'service isn\'t running.';
-    }
-    if (s.contains('connection error') ||
-        s.contains('socket') ||
-        s.contains('network') ||
-        s.contains('host')) {
-      return 'Network error — wrong address, firewall, or device not on the '
-          'same LAN as the server.';
-    }
-    if (s.contains('401') || s.contains('unauthorized')) {
-      return 'Authentication failed — check username and password.';
-    }
-    return 'Connection failed: $e';
-  }
-
-  Future<void> _save() async {
-    if (_urlController.text.trim().isEmpty) {
-      _snack('Server URL is required');
-      return;
-    }
-    final isNew = _editingId == null;
-    final profile = _profileFromForm();
-    await SyncProfileService.instance.saveProfile(profile);
-    if (_passwordController.text.isNotEmpty) {
-      await SyncProfileService.instance
-          .savePassword(profile.id, _passwordController.text);
-      _passwordController.clear();
-    }
-    _editingId = profile.id;
-
-    // New profiles (or when none is active yet) auto-activate so sync works.
-    if (isNew || _activeId == null) {
-      _activeId = profile.id;
-      _masterEnabled = true;
-      await _persistActivation(profile.id, enabled: true);
-    }
-    ref.invalidate(vaultSettingsProvider);
-    ref.invalidate(syncProfilesProvider);
-    if (mounted) _snack('Saved');
   }
 
   Future<void> _activate(SyncProfile p) async {
@@ -320,18 +219,12 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
         false;
     if (!ok) return;
     await SyncProfileService.instance.deleteProfile(p.id);
-    final wasActive = _activeId == p.id;
-    final wasEditing = _editingId == p.id;
-    if (wasActive) {
+    if (_activeId == p.id) {
       _activeId = null;
       final s = await ref.read(vaultServiceProvider).getSettings();
       await ref
           .read(vaultServiceProvider)
           .updateSettings(s.copyWith(syncProfileId: null));
-    }
-    if (wasEditing) {
-      final remaining = await SyncProfileService.instance.listProfiles();
-      _seedForm(remaining.firstOrNull);
     }
     ref.invalidate(vaultSettingsProvider);
     ref.invalidate(syncProfilesProvider);
@@ -395,141 +288,25 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
                 ),
                 const SizedBox(height: 20),
 
-                // ---- Profiles ----
-                _SectionHeader(
-                  title: 'Servers',
-                  trailing: TextButton.icon(
-                    onPressed: () => setState(_seedFormNull),
-                    icon: const Icon(Icons.add, size: 18),
-                    label: const Text('Add',
-                        style: TextStyle(fontFamily: 'ProductSans')),
-                  ),
-                ),
+                // ---- Servers ----
                 if (profiles.isEmpty)
                   _emptyServersHint(context)
-                else
+                else ...[
+                  _SectionHeader(
+                    title: 'Servers',
+                    trailing: IconButton(
+                      tooltip: 'Add server',
+                      icon: Icon(Icons.add, size: 20, color: context.accentColor),
+                      onPressed: () => _openEditor(),
+                    ),
+                  ),
                   ...profiles.map((p) => Padding(
                         padding: const EdgeInsets.only(bottom: 8),
                         child: _profileCard(context, p,
                             isActive: p.id == _activeId),
                       )),
-                const SizedBox(height: 8),
-
-                // ---- Editor ----
-                _SectionHeader(
-                    title: _editingId == null ? 'New server' : 'Edit server'),
-                _card(context, [
-                  _field(
-                    controller: _urlController,
-                    label: 'Server URL',
-                    hint: 'https://nas.local/dav',
-                    keyboardType: TextInputType.url,
-                    onChanged: (_) => setState(() {}),
-                  ),
-                  if (_isPlainHttp) _plainHttpWarning(context),
-                  _field(
-                    controller: _userController,
-                    label: 'Username (optional)',
-                    hint: 'app-password user',
-                  ),
-                  _passwordField(context),
-                  _field(
-                    controller: _basePathController,
-                    label: 'Base path',
-                    hint: '/locker',
-                  ),
-                ]),
+                ],
                 const SizedBox(height: 12),
-                _SectionHeader(title: 'Options'),
-                _card(context, [
-                  _formLabel(context, 'Direction'),
-                  const SizedBox(height: 6),
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 16),
-                    child: InputDecorator(
-                      decoration: _fieldDecoration().copyWith(
-                        contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 4),
-                      ),
-                      child: DropdownButtonHideUnderline(
-                        child: DropdownButton<SyncDirection>(
-                          value: _direction,
-                          isExpanded: true,
-                          items: const [
-                            DropdownMenuItem(
-                              value: SyncDirection.pushOnly,
-                              child: Text('Push only (backup)',
-                                  style: TextStyle(fontFamily: 'ProductSans')),
-                            ),
-                            DropdownMenuItem(
-                              value: SyncDirection.twoWay,
-                              child: Text('Two-way',
-                                  style: TextStyle(fontFamily: 'ProductSans')),
-                            ),
-                          ],
-                          onChanged: (v) =>
-                              setState(() => _direction = v ?? _direction),
-                        ),
-                      ),
-                    ),
-                  ),
-                  SwitchListTile(
-                    title: const Text('Wi-Fi only',
-                        style: TextStyle(fontFamily: 'ProductSans')),
-                    subtitle: Text('Skip sync on mobile data',
-                        style: _subStyle(context)),
-                    value: _wifiOnly,
-                    onChanged: (v) => setState(() => _wifiOnly = v),
-                    activeThumbColor: context.accentColor,
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                ]),
-                const SizedBox(height: 8),
-                if (_editingActive)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 8),
-                    child: Row(
-                      children: [
-                        Icon(Icons.check_circle,
-                            size: 16, color: context.accentColor),
-                        const SizedBox(width: 6),
-                        Expanded(
-                          child: Text(
-                            'This is the active sync target.',
-                            style: _subStyle(context)
-                                .copyWith(color: context.accentColor),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                Row(
-                  children: [
-                    Expanded(
-                      child: OutlinedButton(
-                        onPressed: _isTesting ? null : _testConnection,
-                        child: _isTesting
-                            ? SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                    strokeWidth: 2, color: context.accentColor),
-                              )
-                            : const Text('Test',
-                                style: TextStyle(fontFamily: 'ProductSans')),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: FilledButton(
-                        onPressed: _save,
-                        child: Text(_editingId == null ? 'Create' : 'Save',
-                            style: const TextStyle(fontFamily: 'ProductSans')),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 24),
 
                 // ---- Sync ----
                 _SectionHeader(title: 'Sync'),
@@ -548,7 +325,7 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
                     child: Text(
-                      'Push-only backs the vault up as encrypted blobs to your '
+                      'Backup pushes the vault as encrypted blobs to your '
                       'server. Two-way also pulls remote changes and deletions '
                       'onto this device.',
                       style: _subStyle(context),
@@ -593,15 +370,13 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
     );
   }
 
-  void _seedFormNull() => _seedForm(null);
-
   Widget _profileCard(BuildContext context, SyncProfile p,
       {required bool isActive}) {
     return Material(
       color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        onTap: () => setState(() => _seedForm(p)),
+        onTap: () => _openEditor(profile: p),
         child: Container(
           padding: const EdgeInsets.fromLTRB(14, 12, 10, 12),
           decoration: BoxDecoration(
@@ -642,7 +417,7 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
                         Text(
                           p.direction == SyncDirection.twoWay
                               ? 'Two-way'
-                              : 'Push only',
+                              : 'Backup',
                           style: _subStyle(context),
                         ),
                       ],
@@ -696,7 +471,7 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
                       _activate(p);
                       break;
                     case 'edit':
-                      setState(() => _seedForm(p));
+                      _openEditor(profile: p);
                       break;
                     case 'delete':
                       _confirmDelete(p);
@@ -713,7 +488,7 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
 
   Widget _emptyServersHint(BuildContext context) => Container(
         width: double.infinity,
-        padding: const EdgeInsets.all(20),
+        padding: const EdgeInsets.all(24),
         decoration: BoxDecoration(
           color: context.textPrimary.withValues(alpha: 0.03),
           borderRadius: BorderRadius.circular(12),
@@ -722,9 +497,9 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
         ),
         child: Column(
           children: [
-            Icon(Icons.cloud_off_outlined,
+            Icon(Icons.cloud_outlined,
                 size: 32, color: context.textTertiary),
-            const SizedBox(height: 8),
+            const SizedBox(height: 10),
             Text('No servers yet',
                 style: TextStyle(
                     fontFamily: 'ProductSans',
@@ -732,9 +507,17 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
                     color: context.textSecondary)),
             const SizedBox(height: 4),
             Text(
-              'Tap Add to configure a WebDAV server (NAS or cloud).',
+              'Connect to any WebDAV server — a NAS at home '
+              'or a cloud provider.',
               textAlign: TextAlign.center,
               style: _subStyle(context),
+            ),
+            const SizedBox(height: 16),
+            FilledButton.tonalIcon(
+              onPressed: () => _openEditor(),
+              icon: const Icon(Icons.add, size: 18),
+              label: const Text('Add server',
+                  style: TextStyle(fontFamily: 'ProductSans')),
             ),
           ],
         ),
@@ -751,23 +534,6 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: children,
-        ),
-      );
-
-  Widget _plainHttpWarning(BuildContext context) => Container(
-        width: double.infinity,
-        margin: const EdgeInsets.only(top: 4, bottom: 8),
-        padding: const EdgeInsets.all(10),
-        decoration: BoxDecoration(
-          color: AppColors.error.withValues(alpha: 0.08),
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: AppColors.error.withValues(alpha: 0.18)),
-        ),
-        child: Text(
-          'This URL is unencrypted. Credentials and data travel in plain text '
-          'over the network. Only use on a trusted LAN.',
-          style: TextStyle(
-              fontFamily: 'ProductSans', fontSize: 12, color: AppColors.error),
         ),
       );
 
@@ -790,95 +556,6 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
         fontFamily: 'ProductSans',
         fontSize: 12,
         color: context.textTertiary,
-      );
-
-  Widget _formLabel(BuildContext context, String text) => Text(
-        text,
-        style: TextStyle(
-            fontFamily: 'ProductSans',
-            fontSize: 12,
-            fontWeight: FontWeight.w600,
-            color: context.textTertiary),
-      );
-
-  InputDecoration _fieldDecoration({String? hint, Widget? suffixIcon}) =>
-      InputDecoration(
-        hintText: hint,
-        hintStyle: TextStyle(
-            fontFamily: 'ProductSans', fontSize: 13, color: context.textSecondary),
-        suffixIcon: suffixIcon,
-        filled: true,
-        fillColor: context.textPrimary.withValues(alpha: 0.03),
-        contentPadding:
-            const EdgeInsets.symmetric(horizontal: 12, vertical: 13),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: BorderSide(color: context.borderColor),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: BorderSide(color: context.borderColor),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: BorderSide(color: context.accentColor),
-        ),
-      );
-
-  Widget _field({
-    required TextEditingController controller,
-    required String label,
-    String? hint,
-    bool obscure = false,
-    TextInputType? keyboardType,
-    void Function(String)? onChanged,
-  }) =>
-      Padding(
-        padding: const EdgeInsets.only(bottom: 18),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _formLabel(context, label),
-            const SizedBox(height: 6),
-            TextField(
-              controller: controller,
-              obscureText: obscure,
-              keyboardType: keyboardType,
-              decoration: _fieldDecoration(hint: hint),
-              onChanged: (v) => onChanged?.call(v),
-            ),
-          ],
-        ),
-      );
-
-  Widget _passwordField(BuildContext context) => Padding(
-        padding: const EdgeInsets.only(bottom: 18),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _formLabel(context, 'Password'),
-            const SizedBox(height: 6),
-            TextField(
-              controller: _passwordController,
-              obscureText: _obscurePassword,
-              decoration: _fieldDecoration(
-                hint: _editingId == null
-                    ? 'app password'
-                    : 'leave blank to keep current',
-                suffixIcon: IconButton(
-                  icon: Icon(
-                    _obscurePassword
-                        ? Icons.visibility_off_outlined
-                        : Icons.visibility_outlined,
-                  ),
-                  onPressed: () =>
-                      setState(() => _obscurePassword = !_obscurePassword),
-                  tooltip: _obscurePassword ? 'Show password' : 'Hide password',
-                ),
-              ),
-            ),
-          ],
-        ),
       );
 
   String _formatDate(DateTime d) {
@@ -921,6 +598,389 @@ class _SyncSettingsScreenState extends ConsumerState<SyncSettingsScreen> {
   }
 }
 
+/// Focused add/edit form shown as a bottom sheet. Owns all field state;
+/// persistence goes through [onSave].
+class _ServerSheet extends StatefulWidget {
+  const _ServerSheet({required this.profile, required this.onSave});
+
+  final SyncProfile? profile;
+  final Future<bool> Function(
+      SyncProfile profile, String password, bool isNew) onSave;
+
+  @override
+  State<_ServerSheet> createState() => _ServerSheetState();
+}
+
+class _ServerSheetState extends State<_ServerSheet> {
+  late final TextEditingController _urlController =
+      TextEditingController(text: widget.profile?.serverUrl ?? '');
+  late final TextEditingController _userController =
+      TextEditingController(text: widget.profile?.username ?? '');
+  final _passwordController = TextEditingController();
+  late final TextEditingController _basePathController = TextEditingController(
+      text: widget.profile?.basePath.isEmpty == true
+          ? '/locker'
+          : (widget.profile?.basePath ?? '/locker'));
+
+  late SyncDirection _direction =
+      widget.profile?.direction ?? SyncDirection.pushOnly;
+  late bool _wifiOnly = widget.profile?.wifiOnly ?? true;
+
+  bool _obscurePassword = true;
+  bool _isTesting = false;
+  bool _isSaving = false;
+  String? _urlError;
+
+  bool get _isPlainHttp =>
+      _urlController.text.trim().toLowerCase().startsWith('http://');
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _userController.dispose();
+    _passwordController.dispose();
+    _basePathController.dispose();
+    super.dispose();
+  }
+
+  bool _validateUrl() {
+    final url = _urlController.text.trim();
+    if (url.isEmpty) {
+      setState(() => _urlError = 'Server URL is required');
+      return false;
+    }
+    if (Uri.tryParse(url)?.host.isEmpty != false) {
+      setState(() => _urlError = 'Enter a full URL, e.g. https://nas.local/dav');
+      return false;
+    }
+    if (_urlError != null) setState(() => _urlError = null);
+    return true;
+  }
+
+  Future<void> _testConnection() async {
+    if (!_validateUrl()) return;
+    setState(() => _isTesting = true);
+    try {
+      final password = _passwordController.text.isNotEmpty
+          ? _passwordController.text
+          : (widget.profile == null
+              ? ''
+              : await SyncProfileService.instance
+                      .getPassword(widget.profile!.id) ??
+                  '');
+      final store = WebDAVStore(
+        baseUrl: _urlController.text.trim(),
+        username: _userController.text.trim(),
+        password: password,
+        basePath: _basePathController.text.trim().isEmpty
+            ? '/locker'
+            : _basePathController.text.trim(),
+      );
+      await store.testConnection();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Connected ✓')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(describeServerError(e))),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isTesting = false);
+    }
+  }
+
+  Future<void> _save() async {
+    if (!_validateUrl()) return;
+    setState(() => _isSaving = true);
+    final profile = SyncProfile(
+      id: widget.profile?.id ?? const Uuid().v4(),
+      serverUrl: _urlController.text.trim(),
+      username: _userController.text.trim().isEmpty
+          ? null
+          : _userController.text.trim(),
+      basePath: _basePathController.text.trim().isEmpty
+          ? '/locker'
+          : _basePathController.text.trim(),
+      direction: _direction,
+      wifiOnly: _wifiOnly,
+      enabled: true,
+    );
+    final ok = await widget.onSave(
+        profile, _passwordController.text, widget.profile == null);
+    if (!mounted) return;
+    if (ok) {
+      Navigator.pop(context);
+    } else {
+      setState(() => _isSaving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isNew = widget.profile == null;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 20,
+        right: 20,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              isNew ? 'Add server' : 'Edit server',
+              style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  color: context.textPrimary),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              isNew
+                  ? 'WebDAV — works with most NAS boxes and cloud providers.'
+                  : _hostOf(widget.profile!.serverUrl),
+              style: _subStyle(context),
+            ),
+            const SizedBox(height: 16),
+            _field(
+              controller: _urlController,
+              label: 'Server URL',
+              hint: 'https://nas.local/dav',
+              keyboardType: TextInputType.url,
+              errorText: _urlError,
+              onChanged: (_) {
+                if (_urlError != null) setState(() => _urlError = null);
+                setState(() {});
+              },
+            ),
+            if (_isPlainHttp) ...[
+              _plainHttpWarning(context),
+              const SizedBox(height: 12),
+            ],
+            _field(
+              controller: _userController,
+              label: 'Username (optional)',
+              hint: 'app-password user',
+            ),
+            _passwordField(context),
+            _field(
+              controller: _basePathController,
+              label: 'Base path',
+              hint: '/locker',
+            ),
+            _formLabel(context, 'Direction'),
+            const SizedBox(height: 6),
+            SegmentedButton<SyncDirection>(
+              segments: [
+                ButtonSegment(
+                  value: SyncDirection.pushOnly,
+                  label: Text('Backup',
+                      style: TextStyle(
+                          fontFamily: 'ProductSans',
+                          color: _direction == SyncDirection.pushOnly
+                              ? context.accentColor
+                              : context.textSecondary)),
+                ),
+                ButtonSegment(
+                  value: SyncDirection.twoWay,
+                  label: Text('Two-way',
+                      style: TextStyle(
+                          fontFamily: 'ProductSans',
+                          color: _direction == SyncDirection.twoWay
+                              ? context.accentColor
+                              : context.textSecondary)),
+                ),
+              ],
+              selected: {_direction},
+              showSelectedIcon: false,
+              onSelectionChanged: (s) =>
+                  setState(() => _direction = s.first),
+            ),
+            const SizedBox(height: 8),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Wi-Fi only',
+                  style: TextStyle(fontFamily: 'ProductSans')),
+              subtitle:
+                  Text('Skip sync on mobile data', style: _subStyle(context)),
+              value: _wifiOnly,
+              onChanged: (v) => setState(() => _wifiOnly = v),
+              activeThumbColor: context.accentColor,
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _isTesting || _isSaving ? null : _testConnection,
+                    icon: _isTesting
+                        ? SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: context.accentColor),
+                          )
+                        : const Icon(Icons.network_check, size: 18),
+                    label: const Text('Test',
+                        style: TextStyle(fontFamily: 'ProductSans')),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  flex: 2,
+                  child: FilledButton(
+                    onPressed: _isSaving ? null : _save,
+                    child: _isSaving
+                        ? SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: context.backgroundColor),
+                          )
+                        : Text(isNew ? 'Add server' : 'Save',
+                            style:
+                                const TextStyle(fontFamily: 'ProductSans')),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _hostOf(String url) {
+    final u = Uri.tryParse(url);
+    return u?.host.isNotEmpty == true ? u!.host : url;
+  }
+
+  Widget _plainHttpWarning(BuildContext context) => Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: AppColors.error.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: AppColors.error.withValues(alpha: 0.18)),
+        ),
+        child: Text(
+          'This URL is unencrypted. Credentials and data travel in plain text '
+          'over the network. Only use on a trusted LAN.',
+          style: TextStyle(
+              fontFamily: 'ProductSans', fontSize: 12, color: AppColors.error),
+        ),
+      );
+
+  TextStyle _subStyle(BuildContext context) => TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 12,
+        color: context.textTertiary,
+      );
+
+  Widget _formLabel(BuildContext context, String text) => Text(
+        text,
+        style: TextStyle(
+            fontFamily: 'ProductSans',
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: context.textTertiary),
+      );
+
+  InputDecoration _fieldDecoration({String? hint, Widget? suffixIcon}) =>
+      InputDecoration(
+        hintText: hint,
+        hintStyle: TextStyle(
+            fontFamily: 'ProductSans',
+            fontSize: 13,
+            color: context.textSecondary),
+        suffixIcon: suffixIcon,
+        filled: true,
+        fillColor: context.textPrimary.withValues(alpha: 0.03),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 13),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(color: context.borderColor),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(color: context.borderColor),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide(color: context.accentColor),
+        ),
+      );
+
+  Widget _field({
+    required TextEditingController controller,
+    required String label,
+    String? hint,
+    bool obscure = false,
+    TextInputType? keyboardType,
+    String? errorText,
+    void Function(String)? onChanged,
+  }) =>
+      Padding(
+        padding: const EdgeInsets.only(bottom: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _formLabel(context, label),
+            const SizedBox(height: 6),
+            TextField(
+              controller: controller,
+              obscureText: obscure,
+              keyboardType: keyboardType,
+              decoration:
+                  _fieldDecoration(hint: hint).copyWith(errorText: errorText),
+              onChanged: (v) => onChanged?.call(v),
+            ),
+          ],
+        ),
+      );
+
+  Widget _passwordField(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _formLabel(context, 'Password'),
+            const SizedBox(height: 6),
+            TextField(
+              controller: _passwordController,
+              obscureText: _obscurePassword,
+              decoration: _fieldDecoration(
+                hint: widget.profile == null
+                    ? 'app password'
+                    : 'leave blank to keep current',
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscurePassword
+                        ? Icons.visibility_off_outlined
+                        : Icons.visibility_outlined,
+                  ),
+                  onPressed: () =>
+                      setState(() => _obscurePassword = !_obscurePassword),
+                  tooltip: _obscurePassword ? 'Show password' : 'Hide password',
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+}
+
 /// Big status banner for the active profile's current run state.
 class _HeroStatus extends StatelessWidget {
   const _HeroStatus({
@@ -947,7 +1007,8 @@ class _HeroStatus extends StatelessWidget {
                   fontFamily: 'ProductSans',
                   fontWeight: FontWeight.w600,
                   color: context.textPrimary)),
-          Text('Add a server below, then set it active.', style: _sub(context)),
+          Text('Add a server to get started — it becomes the sync target.',
+              style: _sub(context)),
         ],
       );
     }

--- a/lib/screens/tags_screen.dart
+++ b/lib/screens/tags_screen.dart
@@ -806,7 +806,7 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error exporting file: $e');
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 
@@ -847,7 +847,7 @@ class _TagsScreenState extends ConsumerState<TagsScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       debugPrint('Error opening file: $e');
-      ToastUtils.showError('Failed to open file: $e');
+      ToastUtils.showError('Failed to open file');
     }
   }
 

--- a/lib/screens/unlock_screen.dart
+++ b/lib/screens/unlock_screen.dart
@@ -146,7 +146,8 @@ class _UnlockScreenState extends State<UnlockScreen> {
     if (!result.isDecoy) return false;
 
     try {
-      await EncryptionService.instance.unlockMasterKey(credential, isDecoy: true);
+      await EncryptionService.instance
+          .unlockMasterKey(credential, isDecoy: true);
     } catch (e) {
       debugPrint('Decoy key unlock failed: $e');
       return false;
@@ -279,7 +280,8 @@ class _UnlockScreenState extends State<UnlockScreen> {
       } catch (e) {
         debugPrint('Biometric key unlock failed: $e');
         setState(() {
-          _errorMessage = 'Unable to unlock vault. Please use your backup credential.';
+          _errorMessage =
+              'Unable to unlock vault. Please use your backup credential.';
           _isAuthenticating = false;
         });
       }
@@ -462,9 +464,8 @@ class _UnlockScreenState extends State<UnlockScreen> {
           autofocus: true,
           enabled: _inputEnabled,
           obscureText: _obscurePassword,
-          autofillHints: _autofillEnabled
-              ? const [AutofillHints.password]
-              : null,
+          autofillHints:
+              _autofillEnabled ? const [AutofillHints.password] : null,
           style: TextStyle(
             fontFamily: 'ProductSans',
             fontSize: 16,
@@ -561,8 +562,8 @@ class _UnlockScreenState extends State<UnlockScreen> {
       button: true,
       label: 'Unlock with biometrics',
       child: Material(
-        color: context.accentColor
-            .withValues(alpha: _inputEnabled ? 0.12 : 0.06),
+        color:
+            context.accentColor.withValues(alpha: _inputEnabled ? 0.12 : 0.06),
         shape: const CircleBorder(),
         clipBehavior: Clip.antiAlias,
         child: InkWell(
@@ -633,8 +634,7 @@ class _UnlockScreenState extends State<UnlockScreen> {
       style: FilledButton.styleFrom(
         backgroundColor: context.accentColor,
         foregroundColor: onColor,
-        disabledBackgroundColor:
-            context.accentColor.withValues(alpha: 0.35),
+        disabledBackgroundColor: context.accentColor.withValues(alpha: 0.35),
         minimumSize: const Size.fromHeight(52),
         textStyle: const TextStyle(
           fontFamily: 'ProductSans',

--- a/lib/screens/unlock_screen.dart
+++ b/lib/screens/unlock_screen.dart
@@ -452,6 +452,7 @@ class _UnlockScreenState extends State<UnlockScreen> {
       controller: _pinController,
       enabled: _inputEnabled,
       autofillEnabled: _autofillEnabled,
+      isLoading: _isAuthenticating,
     );
   }
 

--- a/lib/screens/vault_explorer_screen.dart
+++ b/lib/screens/vault_explorer_screen.dart
@@ -239,7 +239,7 @@ class _VaultExplorerScreenState extends ConsumerState<VaultExplorerScreen> {
       }
     } catch (e) {
       debugPrint('Error exporting file: $e');
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 

--- a/lib/screens/vault_settings_screen.dart
+++ b/lib/screens/vault_settings_screen.dart
@@ -692,6 +692,26 @@ class _VaultSettingsScreenState extends ConsumerState<VaultSettingsScreen> {
                         contentPadding: EdgeInsets.zero,
                       ),
                       ListTile(
+                        leading: Icon(Icons.code_outlined,
+                            color: context.accentColor),
+                        title: const Text('Open Source Libraries',
+                            style: TextStyle(fontFamily: 'ProductSans')),
+                        subtitle: Text(
+                          'Licenses of packages used',
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 12,
+                            color: context.textTertiary,
+                          ),
+                        ),
+                        onTap: () => showLicensePage(
+                          context: context,
+                          applicationName: 'Latch',
+                          applicationVersion: version,
+                        ),
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                      ListTile(
                         leading: Icon(Icons.description_outlined,
                             color: context.accentColor),
                         title: const Text('License',

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -139,7 +139,12 @@ class BackupService {
       }
     } catch (e, st) {
       debugPrint('BackupService createBackup error: $e $st');
-      return BackupResult(success: false, error: e.toString());
+      return BackupResult(
+        success: false,
+        error: e.toString().toLowerCase().contains('no space')
+            ? 'Not enough free space to create the backup'
+            : 'Backup failed — check the destination and try again',
+      );
     }
   }
 }

--- a/lib/services/encryption_service.dart
+++ b/lib/services/encryption_service.dart
@@ -932,7 +932,7 @@ class EncryptionService {
           (header[3] == 0x47 || header[3] == 0x32)) {
         // GCM-encrypted streamed file (v1 legacy or v2 authenticated)
         debugPrint('[Encryption] Detected GCM format (byte3=0x${header[3].toRadixString(16)})');
-        return decryptStreamedFileToMemoryGcm(
+        return await decryptStreamedFileToMemoryGcm(
           encryptedPath,
           ivBase64,
           isDecoy: isDecoy,

--- a/lib/services/note_service.dart
+++ b/lib/services/note_service.dart
@@ -21,11 +21,13 @@ class NoteService {
 
   static const String _notesIndexKey = 'locker_notes_index';
   static const String _noteFoldersKey = 'locker_note_folders';
+  static const String _notesIndexDecoyKey = 'locker_notes_index_decoy';
+  static const String _noteFoldersDecoyKey = 'locker_note_folders_decoy';
   static const String _notesDirName = 'notes';
   static const int _defaultKdfIterations = 100000;
 
-  List<Note>? _cachedNotes;
-  List<NoteFolder>? _cachedFolders;
+  final Map<bool, List<Note>> _notesCache = {};
+  final Map<bool, List<NoteFolder>> _foldersCache = {};
 
   Future<String> _getNotesDir({bool isDecoy = false}) async {
     final appDir = await getApplicationDocumentsDirectory();
@@ -41,51 +43,104 @@ class NoteService {
   }
 
   Future<List<Note>> loadNotes({bool isDecoy = false}) async {
-    if (_cachedNotes != null) return _cachedNotes!;
+    final cached = _notesCache[isDecoy];
+    if (cached != null) return cached;
+    if (!isDecoy) await _migrateLegacyNotes();
+    final json = await _secureStorage.read(
+      key: isDecoy ? _notesIndexDecoyKey : _notesIndexKey,
+    );
+    final notes = <Note>[];
+    if (json != null && json.isNotEmpty) {
+      try {
+        final List<dynamic> decoded = jsonDecode(json) as List<dynamic>;
+        for (final e in decoded) {
+          try {
+            notes.add(Note.fromJson(e as Map<String, dynamic>));
+          } catch (_) {
+            // skip malformed entry, keep the rest
+          }
+        }
+      } catch (_) {
+        // index unreadable; keep loaded list empty
+      }
+    }
+    _notesCache[isDecoy] = notes;
+    return notes;
+  }
+
+  // ponytail: one-time split of the pre-decoy-fix shared index; remove later
+  Future<void> _migrateLegacyNotes() async {
+    if (await _secureStorage.read(key: _notesIndexDecoyKey) != null) return;
     final json = await _secureStorage.read(key: _notesIndexKey);
-    if (json == null || json.isEmpty) {
-      _cachedNotes = [];
-      return _cachedNotes!;
-    }
+    if (json == null || json.isEmpty) return;
+    List<dynamic> decoded;
     try {
-      final List<dynamic> decoded = jsonDecode(json) as List<dynamic>;
-      _cachedNotes = decoded
-          .map((e) => Note.fromJson(e as Map<String, dynamic>))
-          .toList();
+      decoded = jsonDecode(json) as List<dynamic>;
     } catch (_) {
-      _cachedNotes = [];
+      return;
     }
-    return _cachedNotes!;
+    final real = <Map<String, dynamic>>[];
+    final decoy = <Map<String, dynamic>>[];
+    for (final e in decoded) {
+      if (e is! Map<String, dynamic>) continue;
+      final path = e['encryptedContentPath'] as String?;
+      if (path != null && path.contains('/.locker_decoy/')) {
+        decoy.add(e);
+      } else {
+        real.add(e);
+      }
+    }
+    if (decoy.isEmpty) return;
+    await _secureStorage.write(key: _notesIndexKey, value: jsonEncode(real));
+    await _secureStorage.write(
+      key: _notesIndexDecoyKey,
+      value: jsonEncode(decoy),
+    );
   }
 
   Future<void> _saveNotes({bool isDecoy = false}) async {
-    if (_cachedNotes == null) return;
-    final json = jsonEncode(_cachedNotes!.map((n) => n.toJson()).toList());
-    await _secureStorage.write(key: _notesIndexKey, value: json);
+    final notes = _notesCache[isDecoy];
+    if (notes == null) return;
+    final json = jsonEncode(notes.map((n) => n.toJson()).toList());
+    await _secureStorage.write(
+      key: isDecoy ? _notesIndexDecoyKey : _notesIndexKey,
+      value: json,
+    );
   }
 
   Future<List<NoteFolder>> loadFolders({bool isDecoy = false}) async {
-    if (_cachedFolders != null) return _cachedFolders!;
-    final json = await _secureStorage.read(key: _noteFoldersKey);
-    if (json == null || json.isEmpty) {
-      _cachedFolders = [];
-      return _cachedFolders!;
+    final cached = _foldersCache[isDecoy];
+    if (cached != null) return cached;
+    final json = await _secureStorage.read(
+      key: isDecoy ? _noteFoldersDecoyKey : _noteFoldersKey,
+    );
+    final folders = <NoteFolder>[];
+    if (json != null && json.isNotEmpty) {
+      try {
+        final List<dynamic> decoded = jsonDecode(json) as List<dynamic>;
+        for (final e in decoded) {
+          try {
+            folders.add(NoteFolder.fromJson(e as Map<String, dynamic>));
+          } catch (_) {
+            // skip malformed entry, keep the rest
+          }
+        }
+      } catch (_) {
+        // index unreadable; keep loaded list empty
+      }
     }
-    try {
-      final List<dynamic> decoded = jsonDecode(json) as List<dynamic>;
-      _cachedFolders = decoded
-          .map((e) => NoteFolder.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (_) {
-      _cachedFolders = [];
-    }
-    return _cachedFolders!;
+    _foldersCache[isDecoy] = folders;
+    return folders;
   }
 
-  Future<void> _saveFolders() async {
-    if (_cachedFolders == null) return;
-    final json = jsonEncode(_cachedFolders!.map((f) => f.toJson()).toList());
-    await _secureStorage.write(key: _noteFoldersKey, value: json);
+  Future<void> _saveFolders({bool isDecoy = false}) async {
+    final folders = _foldersCache[isDecoy];
+    if (folders == null) return;
+    final json = jsonEncode(folders.map((f) => f.toJson()).toList());
+    await _secureStorage.write(
+      key: isDecoy ? _noteFoldersDecoyKey : _noteFoldersKey,
+      value: json,
+    );
   }
 
   Future<Uint8List> _deriveKey(Note note, {bool isDecoy = false}) async {
@@ -108,7 +163,7 @@ class NoteService {
   }) async {
     onProgress?.call('Preparing...', isEncrypting: false);
     await _ensureNotesDir(isDecoy: isDecoy);
-    await loadNotes(isDecoy: isDecoy);
+    final notes = await loadNotes(isDecoy: isDecoy);
 
     final id = const Uuid().v4();
     final now = DateTime.now();
@@ -180,7 +235,7 @@ class NoteService {
       updatedAt: now,
     );
 
-    _cachedNotes!.insert(0, note);
+    notes.insert(0, note);
     await _saveNotes(isDecoy: isDecoy);
 
     await VaultService.instance.registerNoteEntry(
@@ -239,11 +294,13 @@ class NoteService {
     bool? isMarkdown,
     String fileExtension = 'txt',
     bool encrypt = false,
-    EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
-    int kdfIterations = _defaultKdfIterations,
+    EncryptionAlgorithm? encryptionAlgorithm,
+    int? kdfIterations,
     bool isDecoy = false,
   }) async {
-    await loadNotes(isDecoy: isDecoy);
+    final notes = await loadNotes(isDecoy: isDecoy);
+    final algorithm = encryptionAlgorithm ?? note.encryptionAlgorithm;
+    final kdf = kdfIterations ?? note.kdfIterations;
 
     var updated = note.copyWith(
       title: title,
@@ -251,7 +308,7 @@ class NoteService {
       clearFolder: clearFolder,
       isMarkdown: isMarkdown,
       isEncrypted: encrypt || note.isEncrypted,
-      encryptionAlgorithm: encryptionAlgorithm,
+      encryptionAlgorithm: algorithm,
       updatedAt: DateTime.now(),
     );
 
@@ -262,33 +319,37 @@ class NoteService {
         final derivedKey = await _encryptionService.deriveFileKeyAsync(
           masterKey,
           salt,
-          kdfIterations,
+          kdf,
         );
 
         final data = Uint8List.fromList(utf8.encode(content));
-        final result = updated.encryptionAlgorithm == EncryptionAlgorithm.aes256Gcm
+        // write to temp then rename so a failed re-encrypt can't destroy the only copy
+        final tmpPath = '${note.encryptedContentPath}.tmp';
+        final result = algorithm == EncryptionAlgorithm.aes256Gcm
             ? await _encryptionService.encryptBytesStreamedGcm(
                 data,
-                note.encryptedContentPath,
+                tmpPath,
                 isDecoy: isDecoy,
                 derivedKey: derivedKey,
               )
             : await _encryptionService.encryptBytesStreamed(
                 data,
-                note.encryptedContentPath,
+                tmpPath,
                 isDecoy: isDecoy,
                 derivedKey: derivedKey,
               );
 
         if (!result.success) {
+          final tmp = File(tmpPath);
+          if (await tmp.exists()) await tmp.delete();
           throw Exception('Failed to re-encrypt note content');
         }
 
+        await File(tmpPath).rename(note.encryptedContentPath);
         updated = updated.copyWith(
-          encryptedContentPath: result.encryptedPath,
           iv: result.iv,
           keyDerivationSalt: base64Encode(salt),
-          kdfIterations: kdfIterations,
+          kdfIterations: kdf,
         );
       } else {
         final file = File(note.encryptedContentPath);
@@ -296,9 +357,9 @@ class NoteService {
       }
     }
 
-    final index = _cachedNotes!.indexWhere((n) => n.id == note.id);
+    final index = notes.indexWhere((n) => n.id == note.id);
     if (index != -1) {
-      _cachedNotes![index] = updated;
+      notes[index] = updated;
       await _saveNotes(isDecoy: isDecoy);
 
       await VaultService.instance.registerNoteEntry(
@@ -318,21 +379,21 @@ class NoteService {
   }
 
   Future<void> deleteNote(Note note, {bool isDecoy = false}) async {
-    await loadNotes(isDecoy: isDecoy);
+    final notes = await loadNotes(isDecoy: isDecoy);
     if (note.isEncrypted) {
       await _encryptionService.secureDelete(note.encryptedContentPath);
     } else {
       final file = File(note.encryptedContentPath);
       if (await file.exists()) await file.delete();
     }
-    _cachedNotes!.removeWhere((n) => n.id == note.id);
+    notes.removeWhere((n) => n.id == note.id);
     await _saveNotes(isDecoy: isDecoy);
 
     await VaultService.instance.removeNoteEntry(note.id, isDecoy: isDecoy);
   }
 
   Future<void> deleteNotes(List<Note> notes, {bool isDecoy = false}) async {
-    await loadNotes(isDecoy: isDecoy);
+    final cached = await loadNotes(isDecoy: isDecoy);
     for (final note in notes) {
       if (note.isEncrypted) {
         await _encryptionService.secureDelete(note.encryptedContentPath);
@@ -342,7 +403,7 @@ class NoteService {
       }
     }
     final ids = notes.map((n) => n.id).toSet();
-    _cachedNotes!.removeWhere((n) => ids.contains(n.id));
+    cached.removeWhere((n) => ids.contains(n.id));
     await _saveNotes(isDecoy: isDecoy);
 
     for (final note in notes) {
@@ -351,18 +412,18 @@ class NoteService {
   }
 
   Future<Note> togglePin(Note note, {bool isDecoy = false}) async {
-    await loadNotes(isDecoy: isDecoy);
+    final notes = await loadNotes(isDecoy: isDecoy);
     final toggled = note.togglePin();
-    final index = _cachedNotes!.indexWhere((n) => n.id == note.id);
+    final index = notes.indexWhere((n) => n.id == note.id);
     if (index != -1) {
-      _cachedNotes![index] = toggled;
+      notes[index] = toggled;
       await _saveNotes(isDecoy: isDecoy);
     }
     return toggled;
   }
 
   Future<NoteFolder> createFolder(String name, {bool isDecoy = false}) async {
-    await loadFolders(isDecoy: isDecoy);
+    final folders = await loadFolders(isDecoy: isDecoy);
     final now = DateTime.now();
     final folder = NoteFolder(
       id: const Uuid().v4(),
@@ -370,8 +431,8 @@ class NoteService {
       createdAt: now,
       updatedAt: now,
     );
-    _cachedFolders!.add(folder);
-    await _saveFolders();
+    folders.add(folder);
+    await _saveFolders(isDecoy: isDecoy);
     return folder;
   }
 
@@ -380,23 +441,23 @@ class NoteService {
     String newName, {
     bool isDecoy = false,
   }) async {
-    await loadFolders(isDecoy: isDecoy);
+    final folders = await loadFolders(isDecoy: isDecoy);
     final renamed = folder.copyWith(name: newName, updatedAt: DateTime.now());
-    final index = _cachedFolders!.indexWhere((f) => f.id == folder.id);
+    final index = folders.indexWhere((f) => f.id == folder.id);
     if (index != -1) {
-      _cachedFolders![index] = renamed;
-      await _saveFolders();
+      folders[index] = renamed;
+      await _saveFolders(isDecoy: isDecoy);
     }
     return renamed;
   }
 
   Future<void> deleteFolder(NoteFolder folder, {bool isDecoy = false}) async {
-    await loadFolders(isDecoy: isDecoy);
-    await loadNotes(isDecoy: isDecoy);
+    final folders = await loadFolders(isDecoy: isDecoy);
+    final notes = await loadNotes(isDecoy: isDecoy);
 
-    for (var i = 0; i < _cachedNotes!.length; i++) {
-      if (_cachedNotes![i].folderId == folder.id) {
-        _cachedNotes![i] = _cachedNotes![i].copyWith(
+    for (var i = 0; i < notes.length; i++) {
+      if (notes[i].folderId == folder.id) {
+        notes[i] = notes[i].copyWith(
           clearFolder: true,
           updatedAt: DateTime.now(),
         );
@@ -404,25 +465,28 @@ class NoteService {
     }
     await _saveNotes(isDecoy: isDecoy);
 
-    _cachedFolders!.removeWhere((f) => f.id == folder.id);
-    await _saveFolders();
+    folders.removeWhere((f) => f.id == folder.id);
+    await _saveFolders(isDecoy: isDecoy);
   }
 
   List<Note> getNotesInFolder(String? folderId) {
-    if (_cachedNotes == null) return [];
-    return _cachedNotes!.where((n) => n.folderId == folderId).toList();
+    return _notesCache[false]
+            ?.where((n) => n.folderId == folderId)
+            .toList() ??
+        [];
   }
 
   List<Note> searchNotes(String query) {
-    if (_cachedNotes == null) return [];
+    final notes = _notesCache[false];
+    if (notes == null) return [];
     final lower = query.toLowerCase();
-    return _cachedNotes!
+    return notes
         .where((n) => n.title.toLowerCase().contains(lower))
         .toList();
   }
 
   void clearCache() {
-    _cachedNotes = null;
-    _cachedFolders = null;
+    _notesCache.clear();
+    _foldersCache.clear();
   }
 }

--- a/lib/services/office_converter_service.dart
+++ b/lib/services/office_converter_service.dart
@@ -193,7 +193,7 @@ class OfficeConverterService {
       debugPrint('Error converting document: $e');
       return ConversionResult(
         success: false,
-        error: 'Failed to convert document: $e',
+        error: 'Failed to convert document',
       );
     }
   }
@@ -223,7 +223,7 @@ class OfficeConverterService {
       debugPrint('Error converting DOCX: $e');
       return ConversionResult(
         success: false,
-        error: 'Failed to convert DOCX: $e',
+        error: 'Failed to convert DOCX',
       );
     }
   }
@@ -253,7 +253,7 @@ class OfficeConverterService {
       debugPrint('Error converting ODT: $e');
       return ConversionResult(
         success: false,
-        error: 'Failed to convert ODT: $e',
+        error: 'Failed to convert ODT',
       );
     }
   }
@@ -283,7 +283,7 @@ class OfficeConverterService {
       debugPrint('Error converting RTF: $e');
       return ConversionResult(
         success: false,
-        error: 'Failed to convert RTF: $e',
+        error: 'Failed to convert RTF',
       );
     }
   }

--- a/lib/services/password_service.dart
+++ b/lib/services/password_service.dart
@@ -19,10 +19,17 @@ class PasswordService {
   final EncryptionService _encryptionService = EncryptionService.instance;
 
   static const String _indexKey = 'locker_passwords_index';
+  static const String _decoyIndexKey = 'locker_passwords_index_decoy';
   static const String _dirName = 'passwords';
   static const int _defaultKdfIterations = 100000;
 
-  List<PasswordEntry>? _cachedEntries;
+  final Map<bool, List<PasswordEntry>> _caches = {};
+
+  List<String> _normalizedTags(List<String> tags) => tags
+      .map((t) => t.toLowerCase().trim())
+      .where((t) => t.isNotEmpty)
+      .toSet()
+      .toList();
 
   Future<String> _getDir({bool isDecoy = false}) async {
     final appDir = await getApplicationDocumentsDirectory();
@@ -38,28 +45,34 @@ class PasswordService {
   }
 
   Future<List<PasswordEntry>> loadPasswords({bool isDecoy = false}) async {
-    if (_cachedEntries != null) return _cachedEntries!;
-    final json = await _secureStorage.read(key: _indexKey);
+    final cached = _caches[isDecoy];
+    if (cached != null) return cached;
+    final json = await _secureStorage.read(
+      key: isDecoy ? _decoyIndexKey : _indexKey,
+    );
     if (json == null || json.isEmpty) {
-      _cachedEntries = [];
-      return _cachedEntries!;
+      return _caches[isDecoy] = [];
     }
     try {
       final List<dynamic> decoded = jsonDecode(json) as List<dynamic>;
-      _cachedEntries = decoded
+      return _caches[isDecoy] = decoded
           .map((e) => PasswordEntry.fromJson(e as Map<String, dynamic>))
           .toList();
-    } catch (_) {
-      _cachedEntries = [];
+    } catch (e) {
+      // ponytail: a corrupt index must throw, an empty list here would
+      // silently overwrite every entry on the next _save
+      throw Exception('Password index is corrupt: $e');
     }
-    return _cachedEntries!;
   }
 
-  Future<void> _save() async {
-    if (_cachedEntries == null) return;
-    final json =
-        jsonEncode(_cachedEntries!.map((e) => e.toJson()).toList());
-    await _secureStorage.write(key: _indexKey, value: json);
+  Future<void> _save({bool isDecoy = false}) async {
+    final entries = _caches[isDecoy];
+    if (entries == null) return;
+    final json = jsonEncode(entries.map((e) => e.toJson()).toList());
+    await _secureStorage.write(
+      key: isDecoy ? _decoyIndexKey : _indexKey,
+      value: json,
+    );
   }
 
   Future<Uint8List> _deriveKey(
@@ -101,8 +114,7 @@ class PasswordService {
       kdfIterations,
     );
 
-    final data =
-        Uint8List.fromList(utf8.encode(content.toJsonString()));
+    final data = utf8.encode(content.toJsonString());
     final result = encryptionAlgorithm == EncryptionAlgorithm.aes256Gcm
         ? await _encryptionService.encryptBytesStreamedGcm(
             data,
@@ -129,15 +141,15 @@ class PasswordService {
       iv: result.iv!,
       keyDerivationSalt: base64Encode(saltBytes),
       kdfIterations: kdfIterations,
-      tags: tags,
+      tags: _normalizedTags(tags),
       isEncrypted: true,
       encryptionAlgorithm: encryptionAlgorithm,
       createdAt: now,
       updatedAt: now,
     );
 
-    _cachedEntries!.insert(0, entry);
-    await _save();
+    _caches[isDecoy]!.insert(0, entry);
+    await _save(isDecoy: isDecoy);
 
     await VaultService.instance.registerPasswordEntry(
       passwordId: entry.id,
@@ -185,16 +197,18 @@ class PasswordService {
     String? title,
     PasswordContent? content,
     List<String>? tags,
-    EncryptionAlgorithm encryptionAlgorithm = EncryptionAlgorithm.aes256Gcm,
-    int kdfIterations = _defaultKdfIterations,
+    EncryptionAlgorithm? encryptionAlgorithm,
+    int? kdfIterations,
     bool isDecoy = false,
   }) async {
-    await loadPasswords(isDecoy: isDecoy);
+    final entries = await loadPasswords(isDecoy: isDecoy);
+    final algorithm = encryptionAlgorithm ?? entry.encryptionAlgorithm;
+    final iterations = kdfIterations ?? entry.kdfIterations;
 
     var updated = entry.copyWith(
       title: title,
-      tags: tags,
-      encryptionAlgorithm: encryptionAlgorithm,
+      tags: tags == null ? null : _normalizedTags(tags),
+      encryptionAlgorithm: algorithm,
       updatedAt: DateTime.now(),
     );
 
@@ -205,21 +219,23 @@ class PasswordService {
       final derivedKey = await _encryptionService.deriveFileKeyAsync(
         masterKey,
         salt,
-        kdfIterations,
+        iterations,
       );
 
-      final data =
-          Uint8List.fromList(utf8.encode(content.toJsonString()));
-      final result = updated.encryptionAlgorithm == EncryptionAlgorithm.aes256Gcm
+      final data = utf8.encode(content.toJsonString());
+      // ponytail: encrypt beside the original then swap, so a failed
+      // re-encrypt can't destroy the only copy
+      final tmpPath = '${entry.encryptedContentPath}.tmp';
+      final result = algorithm == EncryptionAlgorithm.aes256Gcm
           ? await _encryptionService.encryptBytesStreamedGcm(
               data,
-              entry.encryptedContentPath,
+              tmpPath,
               isDecoy: isDecoy,
               derivedKey: derivedKey,
             )
           : await _encryptionService.encryptBytesStreamed(
               data,
-              entry.encryptedContentPath,
+              tmpPath,
               isDecoy: isDecoy,
               derivedKey: derivedKey,
             );
@@ -228,18 +244,21 @@ class PasswordService {
         throw Exception('Failed to re-encrypt password entry');
       }
 
+      await _encryptionService.secureDelete(entry.encryptedContentPath);
+      await File(result.encryptedPath!).rename(entry.encryptedContentPath);
+
       updated = updated.copyWith(
-        encryptedContentPath: result.encryptedPath,
+        encryptedContentPath: entry.encryptedContentPath,
         iv: result.iv,
         keyDerivationSalt: base64Encode(salt),
-        kdfIterations: kdfIterations,
+        kdfIterations: iterations,
       );
     }
 
-    final index = _cachedEntries!.indexWhere((e) => e.id == entry.id);
+    final index = entries.indexWhere((e) => e.id == entry.id);
     if (index != -1) {
-      _cachedEntries![index] = updated;
-      await _save();
+      entries[index] = updated;
+      await _save(isDecoy: isDecoy);
 
       await VaultService.instance.registerPasswordEntry(
         passwordId: updated.id,
@@ -260,8 +279,8 @@ class PasswordService {
       {bool isDecoy = false}) async {
     await loadPasswords(isDecoy: isDecoy);
     await _encryptionService.secureDelete(entry.encryptedContentPath);
-    _cachedEntries!.removeWhere((e) => e.id == entry.id);
-    await _save();
+    _caches[isDecoy]!.removeWhere((e) => e.id == entry.id);
+    await _save(isDecoy: isDecoy);
     await VaultService.instance.removePasswordEntry(entry.id, isDecoy: isDecoy);
   }
 
@@ -272,8 +291,8 @@ class PasswordService {
       await _encryptionService.secureDelete(entry.encryptedContentPath);
     }
     final ids = entries.map((e) => e.id).toSet();
-    _cachedEntries!.removeWhere((e) => ids.contains(e.id));
-    await _save();
+    _caches[isDecoy]!.removeWhere((e) => ids.contains(e.id));
+    await _save(isDecoy: isDecoy);
     for (final entry in entries) {
       await VaultService.instance.removePasswordEntry(entry.id, isDecoy: isDecoy);
     }
@@ -281,27 +300,17 @@ class PasswordService {
 
   Future<PasswordEntry> toggleFavorite(PasswordEntry entry,
       {bool isDecoy = false}) async {
-    await loadPasswords(isDecoy: isDecoy);
+    final entries = await loadPasswords(isDecoy: isDecoy);
     final toggled = entry.toggleFavorite();
-    final index = _cachedEntries!.indexWhere((e) => e.id == entry.id);
+    final index = entries.indexWhere((e) => e.id == entry.id);
     if (index != -1) {
-      _cachedEntries![index] = toggled;
-      await _save();
+      entries[index] = toggled;
+      await _save(isDecoy: isDecoy);
     }
     return toggled;
   }
 
-  List<PasswordEntry> searchPasswords(String query) {
-    if (_cachedEntries == null) return [];
-    final lower = query.toLowerCase();
-    return _cachedEntries!
-        .where((e) =>
-            e.title.toLowerCase().contains(lower) ||
-            e.tags.any((t) => t.contains(lower)))
-        .toList();
-  }
-
   void clearCache() {
-    _cachedEntries = null;
+    _caches.clear();
   }
 }

--- a/lib/services/remote/server_errors.dart
+++ b/lib/services/remote/server_errors.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+
+/// Map any server/sync failure to a plain-language, actionable message.
+/// String-matches on toString() so callers don't import transitive dio/webdav.
+String describeServerError(Object e) {
+  final s = e.toString().toLowerCase();
+
+  if (s.contains('connection timeout') || s.contains('connecttimeout')) {
+    return "Couldn't reach the server (timed out). Check it's running on "
+        'the right port and bound to 0.0.0.0, not localhost.';
+  }
+  if (s.contains('connection refused') ||
+      s.contains('reset') ||
+      s.contains('broken pipe')) {
+    return "Server refused the connection. Wrong port, or the WebDAV "
+        "service isn't running.";
+  }
+  if (s.contains('401') ||
+      s.contains('unauthorized') ||
+      s.contains('403') ||
+      s.contains('forbidden')) {
+    return 'Sign-in failed — check your username and password.';
+  }
+  if (s.contains('certificate') ||
+      s.contains('handshake') ||
+      s.contains('tls')) {
+    return "Secure connection failed — the server's certificate was "
+        'rejected. If you trust it, add the exception in your server '
+        'settings.';
+  }
+  if (s.contains('404') || s.contains('not found')) {
+    return "The server couldn't find that path — check the base path and "
+        'URL in your server settings.';
+  }
+  if (s.contains('receive timeout') ||
+      s.contains('send timeout') ||
+      s.contains('connection closed')) {
+    return 'The connection dropped mid-transfer. Check your network and '
+        'try again.';
+  }
+  if (s.contains('connection error') ||
+      s.contains('socket') ||
+      s.contains('network') ||
+      s.contains('host')) {
+    return 'Network error — wrong address, firewall, or device not on the '
+        'same LAN as the server.';
+  }
+  if (e is FormatException || s.contains('invalid ciphertext')) {
+    return "The data on the server couldn't be read — it may be corrupt or "
+        'belong to a different vault.';
+  }
+  if (s.startsWith('bad state:')) {
+    // SyncService StateErrors are already plain sentences; strip the prefix.
+    return e.toString().replaceFirst(RegExp(r'^Bad state:\s*'), '');
+  }
+
+  debugPrint('[sync] unrecognized error: $e');
+  return 'Something went wrong while talking to the server. Check your '
+      'connection and try again.';
+}

--- a/lib/widgets/explorer_file_grid.dart
+++ b/lib/widgets/explorer_file_grid.dart
@@ -1041,7 +1041,7 @@ class ExplorerFileGrid extends ConsumerWidget {
     } catch (e) {
       if (ctx.mounted) Navigator.pop(ctx);
       debugPrint('Error exporting file: $e');
-      ToastUtils.showError('Failed to export file: $e');
+      ToastUtils.showError('Failed to export file');
     }
   }
 
@@ -1090,7 +1090,7 @@ class ExplorerFileGrid extends ConsumerWidget {
     } catch (e) {
       if (ctx.mounted) Navigator.pop(ctx);
       debugPrint('Error opening file: $e');
-      ToastUtils.showError('Failed to open file: $e');
+      ToastUtils.showError('Failed to open file');
     }
   }
 

--- a/lib/widgets/hold_preview_card.dart
+++ b/lib/widgets/hold_preview_card.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:photo_manager/photo_manager.dart';
+import 'package:video_player/video_player.dart';
+
+/// Computes a clamped on-screen rect for the hold-to-preview card so it stays
+/// fully visible, preferring a spot above the finger.
+Rect holdPreviewRect(Offset finger, Size screen, Size card) {
+  const margin = 12.0;
+
+  final left = (finger.dx - card.width / 2).clamp(
+    margin,
+    (screen.width - card.width - margin).clamp(margin, double.infinity),
+  ).toDouble();
+  var top = finger.dy - card.height - 56;
+  if (top < margin) top = finger.dy + 56;
+  top = top.clamp(
+    margin,
+    (screen.height - card.height - margin).clamp(margin, double.infinity),
+  );
+
+  return Rect.fromLTWH(left, top, card.width, card.height);
+}
+
+/// Floating card shown while the user holds a grid tile in the media picker.
+/// Follows [position]; swaps content when [asset] changes (peek & select).
+class HoldPreviewCard extends StatelessWidget {
+  final ValueListenable<AssetEntity?> asset;
+  final ValueListenable<Offset> position;
+
+  const HoldPreviewCard({super.key, required this.asset, required this.position});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Offset>(
+      valueListenable: position,
+      builder: (context, finger, _) {
+        final screen = MediaQuery.of(context).size;
+        final side =
+            (screen.shortestSide * 0.65).clamp(200.0, 340.0).toDouble();
+        final rect = holdPreviewRect(finger, screen, Size(side, side));
+
+        return Positioned.fromRect(
+          rect: rect,
+          child: IgnorePointer(
+            child: ValueListenableBuilder<AssetEntity?>(
+              valueListenable: asset,
+              builder: (context, asset, _) {
+                if (asset == null) return const SizedBox.shrink();
+                return TweenAnimationBuilder<double>(
+                  tween: Tween(begin: 0, end: 1),
+                  duration: const Duration(milliseconds: 150),
+                  curve: Curves.easeOut,
+                  builder: (context, t, child) => Opacity(
+                    opacity: t,
+                    child: Transform.scale(scale: 0.9 + 0.1 * t, child: child),
+                  ),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(20),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.4),
+                          blurRadius: 24,
+                        ),
+                      ],
+                    ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(20),
+                      // Keyed so a new hold starts fresh (no stale video frame).
+                      child: KeyedSubtree(
+                        key: ValueKey(asset.id),
+                        child: Container(
+                          color: Colors.black,
+                          child: _AssetPreviewContent(asset: asset),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _AssetPreviewContent extends StatelessWidget {
+  final AssetEntity asset;
+
+  const _AssetPreviewContent({required this.asset});
+
+  @override
+  Widget build(BuildContext context) {
+    if (asset.type == AssetType.video) return _VideoPreview(asset: asset);
+    return _ImagePreview(asset: asset);
+  }
+}
+
+class _ImagePreview extends StatefulWidget {
+  final AssetEntity asset;
+
+  const _ImagePreview({required this.asset});
+
+  @override
+  State<_ImagePreview> createState() => _ImagePreviewState();
+}
+
+class _ImagePreviewState extends State<_ImagePreview> {
+  late final Future<Uint8List?> _future = widget.asset.thumbnailDataWithSize(
+    const ThumbnailSize(1200, 1200),
+    quality: 90,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Uint8List?>(
+      future: _future,
+      builder: (context, snapshot) {
+        final bytes = snapshot.data;
+        if (bytes != null && bytes.isNotEmpty) {
+          return Image.memory(bytes, fit: BoxFit.contain);
+        }
+        if (snapshot.hasError) {
+          return const Center(
+            child: Icon(Icons.broken_image, color: Colors.white54),
+          );
+        }
+        return const Center(
+          child: CircularProgressIndicator(color: Colors.white70),
+        );
+      },
+    );
+  }
+}
+
+class _VideoPreview extends StatefulWidget {
+  final AssetEntity asset;
+
+  const _VideoPreview({required this.asset});
+
+  @override
+  State<_VideoPreview> createState() => _VideoPreviewState();
+}
+
+class _VideoPreviewState extends State<_VideoPreview> {
+  VideoPlayerController? _controller;
+  Timer? _initTimer;
+  late final Future<Uint8List?> _thumb = widget.asset.thumbnailDataWithSize(
+    const ThumbnailSize(1200, 1200),
+    quality: 90,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    // ponytail: 150ms delay so quick accidental holds never touch disk.
+    _initTimer = Timer(const Duration(milliseconds: 150), _init);
+  }
+
+  Future<void> _init() async {
+    try {
+      final file = await widget.asset.file;
+      if (file == null || !mounted) return;
+      final controller = VideoPlayerController.file(file);
+      await controller.initialize();
+      if (!mounted) {
+        controller.dispose();
+        return;
+      }
+      setState(() => _controller = controller);
+      await controller.setLooping(true);
+      await controller.setVolume(0);
+      await controller.play();
+    } catch (_) {
+      if (mounted) setState(() => _controller = null);
+    }
+  }
+
+  @override
+  void dispose() {
+    _initTimer?.cancel();
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = _controller;
+    if (controller == null) {
+      return FutureBuilder<Uint8List?>(
+        future: _thumb,
+        builder: (context, snapshot) {
+          final bytes = snapshot.data;
+          if (bytes != null && bytes.isNotEmpty) {
+            return Stack(
+              fit: StackFit.expand,
+              children: [
+                Image.memory(bytes, fit: BoxFit.contain),
+                const Center(
+                  child: Icon(Icons.play_arrow,
+                      size: 48, color: Colors.white70),
+                ),
+              ],
+            );
+          }
+          return const SizedBox.expand();
+        },
+      );
+    }
+
+    return Center(
+      child: AspectRatio(
+        aspectRatio:
+            controller.value.aspectRatio == 0
+                ? 1
+                : controller.value.aspectRatio,
+        child: VideoPlayer(controller),
+      ),
+    );
+  }
+}

--- a/lib/widgets/note_card.dart
+++ b/lib/widgets/note_card.dart
@@ -7,6 +7,7 @@ class NoteCard extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
   final bool isSelected;
+  final bool isSelectionMode;
 
   const NoteCard({
     super.key,
@@ -14,77 +15,64 @@ class NoteCard extends StatelessWidget {
     this.onTap,
     this.onLongPress,
     this.isSelected = false,
+    this.isSelectionMode = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return ListTile(
       onTap: onTap,
       onLongPress: onLongPress,
-      child: Container(
-        decoration: BoxDecoration(
-          color: isSelected
-              ? context.accentColor.withValues(alpha: 0.15)
-              : context.surfaceColor,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: isSelected ? context.accentColor : context.borderColor,
-            width: isSelected ? 2 : 1,
-          ),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  if (note.isPinned)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 6),
-                      child: Icon(
-                        Icons.push_pin,
-                        size: 14,
-                        color: context.accentColor,
-                      ),
-                    ),
-                  if (note.isMarkdown)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 6),
-                      child: Icon(
-                        Icons.text_snippet,
-                        size: 14,
-                        color: context.textTertiary,
-                      ),
-                    ),
-                  Expanded(
-                    child: Text(
-                      note.title,
-                      style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: context.textPrimary,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
+      selected: isSelected,
+      selectedTileColor: context.accentColor.withValues(alpha: 0.10),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+      title: Row(
+        children: [
+          if (note.isPinned)
+            Padding(
+              padding: const EdgeInsets.only(right: 6),
+              child: Icon(
+                Icons.push_pin,
+                size: 14,
+                color: context.accentColor,
               ),
-              const SizedBox(height: 8),
-              Text(
-                _formatDate(note.updatedAt),
-                style: TextStyle(
-                  fontFamily: 'ProductSans',
-                  fontSize: 12,
-                  color: context.textTertiary,
-                ),
+            ),
+          Expanded(
+            child: Text(
+              note.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: context.textPrimary,
               ),
-            ],
+            ),
           ),
+        ],
+      ),
+      subtitle: Text(
+        _formatDate(note.updatedAt),
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: 12,
+          color: context.textTertiary,
         ),
       ),
+      trailing: isSelectionMode
+          ? Icon(
+              isSelected ? Icons.check_circle : Icons.circle_outlined,
+              size: 20,
+              color: isSelected ? context.accentColor : context.textTertiary,
+            )
+          : note.isEncrypted
+              ? Icon(Icons.lock_outline,
+                  size: 15, color: context.textTertiary)
+              : note.isMarkdown
+                  ? Icon(Icons.text_snippet,
+                      size: 15, color: context.textTertiary)
+                  : null,
     );
   }
 

--- a/lib/widgets/password_card.dart
+++ b/lib/widgets/password_card.dart
@@ -8,6 +8,7 @@ class PasswordCard extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
   final bool isSelected;
+  final bool isSelectionMode;
 
   const PasswordCard({
     super.key,
@@ -15,101 +16,64 @@ class PasswordCard extends StatelessWidget {
     this.onTap,
     this.onLongPress,
     this.isSelected = false,
+    this.isSelectionMode = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    final meta = entry.tags.isEmpty
+        ? _formatDate(entry.updatedAt)
+        : '${entry.tags.join(' · ')} · ${_formatDate(entry.updatedAt)}';
+
+    return ListTile(
       onTap: onTap,
       onLongPress: onLongPress,
-      child: Container(
-        decoration: BoxDecoration(
-          color: isSelected
-              ? context.accentColor.withValues(alpha: 0.15)
-              : context.surfaceColor,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: isSelected ? context.accentColor : context.borderColor,
-            width: isSelected ? 2 : 1,
-          ),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    Icons.lock_outline,
-                    size: 16,
-                    color: context.textTertiary,
-                  ),
-                  const SizedBox(width: 6),
-                  if (entry.isFavorite)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 6),
-                      child: Icon(
-                        Icons.star,
-                        size: 14,
-                        color: context.accentColor,
-                      ),
-                    ),
-                  Expanded(
-                    child: Text(
-                      entry.title,
-                      style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: context.textPrimary,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
+      selected: isSelected,
+      selectedTileColor: context.accentColor.withValues(alpha: 0.10),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+      title: Row(
+        children: [
+          if (entry.isFavorite)
+            Padding(
+              padding: const EdgeInsets.only(right: 6),
+              child: Icon(
+                Icons.star,
+                size: 14,
+                color: context.accentColor,
               ),
-              if (entry.tags.isNotEmpty) ...[
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 4,
-                  runSpacing: 4,
-                  children: entry.tags.take(3).map((t) {
-                    return Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 2,
-                      ),
-                      decoration: BoxDecoration(
-                        color: context.accentColor.withValues(alpha: 0.12),
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: Text(
-                        t,
-                        style: TextStyle(
-                          fontFamily: 'ProductSans',
-                          fontSize: 10,
-                          color: context.accentColor,
-                        ),
-                      ),
-                    );
-                  }).toList(),
-                ),
-              ],
-              const SizedBox(height: 8),
-              Text(
-                _formatDate(entry.updatedAt),
-                style: TextStyle(
-                  fontFamily: 'ProductSans',
-                  fontSize: 12,
-                  color: context.textTertiary,
-                ),
+            ),
+          Expanded(
+            child: Text(
+              entry.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: context.textPrimary,
               ),
-            ],
+            ),
           ),
+        ],
+      ),
+      subtitle: Text(
+        meta,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: 12,
+          color: context.textTertiary,
         ),
       ),
+      trailing: isSelectionMode
+          ? Icon(
+              isSelected ? Icons.check_circle : Icons.circle_outlined,
+              size: 20,
+              color: isSelected ? context.accentColor : context.textTertiary,
+            )
+          : null,
     );
   }
 

--- a/lib/widgets/pin_input_widget.dart
+++ b/lib/widgets/pin_input_widget.dart
@@ -26,6 +26,7 @@ class PinInputWidget extends StatefulWidget {
   final PinInputController? controller;
   final bool enabled;
   final bool autofillEnabled;
+  final bool isLoading;
 
   const PinInputWidget({
     super.key,
@@ -35,6 +36,7 @@ class PinInputWidget extends StatefulWidget {
     this.controller,
     this.enabled = true,
     this.autofillEnabled = false,
+    this.isLoading = false,
   });
 
   @override
@@ -125,45 +127,58 @@ class _PinInputWidgetState extends State<PinInputWidget> {
               ),
             ),
             const SizedBox(height: 16),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: List.generate(_pinLength, (index) {
-                final isFilled = index < _pin.length;
-                return AnimatedContainer(
-                  duration: const Duration(milliseconds: 150),
-                  curve: Curves.easeOut,
-                  width: 40,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    color: isFilled
-                        ? context.accentColor.withValues(alpha: 0.12)
-                        : context.backgroundSecondary,
-                    borderRadius: BorderRadius.circular(10),
-                    border: Border.all(
-                      color: isFilled
-                          ? context.accentColor
-                          : context.dividerColor,
-                      width: isFilled ? 1.4 : 1,
-                    ),
+            if (widget.isLoading)
+              const SizedBox(
+                height: 48,
+                width: double.infinity,
+                child: Center(
+                  child: SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2.4),
                   ),
-                  child: Center(
-                    child: AnimatedScale(
-                      scale: isFilled ? 1 : 0,
-                      duration: const Duration(milliseconds: 120),
-                      curve: Curves.easeOut,
-                      child: Container(
-                        width: 12,
-                        height: 12,
-                        decoration: BoxDecoration(
-                          color: context.accentColor,
-                          shape: BoxShape.circle,
+                ),
+              )
+            else
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: List.generate(_pinLength, (index) {
+                  final isFilled = index < _pin.length;
+                  return AnimatedContainer(
+                    duration: const Duration(milliseconds: 150),
+                    curve: Curves.easeOut,
+                    width: 40,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      color: isFilled
+                          ? context.accentColor.withValues(alpha: 0.12)
+                          : context.backgroundSecondary,
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(
+                        color: isFilled
+                            ? context.accentColor
+                            : context.dividerColor,
+                        width: isFilled ? 1.4 : 1,
+                      ),
+                    ),
+                    child: Center(
+                      child: AnimatedScale(
+                        scale: isFilled ? 1 : 0,
+                        duration: const Duration(milliseconds: 120),
+                        curve: Curves.easeOut,
+                        child: Container(
+                          width: 12,
+                          height: 12,
+                          decoration: BoxDecoration(
+                            color: context.accentColor,
+                            shape: BoxShape.circle,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                );
-              }),
-            ),
+                  );
+                }),
+              ),
             SizedBox(
               width: 0,
               height: 0,

--- a/test/media_preview_position_test.dart
+++ b/test/media_preview_position_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/widgets/hold_preview_card.dart';
+
+void main() {
+  const screen = Size(400, 800);
+  const card = Size(260, 260);
+
+  test('centers on finger when there is room above', () {
+    final rect = holdPreviewRect(const Offset(200, 600), screen, card);
+    expect(rect.left, 70);
+    expect(rect.bottom, closeTo(600 - 56, 0.01));
+  });
+
+  test('flips below finger when too close to top', () {
+    final rect = holdPreviewRect(const Offset(200, 30), screen, card);
+    expect(rect.top, closeTo(30 + 56, 0.01));
+  });
+
+  test('clamps to screen edges', () {
+    final leftEdge = holdPreviewRect(const Offset(5, 600), screen, card);
+    expect(leftEdge.left, 12);
+
+    final rightEdge = holdPreviewRect(
+        const Offset(395, 600), screen, card);
+    expect(rightEdge.right, 388);
+
+    // Finger at very bottom: card sits above the finger, still fully visible.
+    final bottom = holdPreviewRect(const Offset(200, 799), screen, card);
+    expect(bottom.bottom, closeTo(799 - 56, 0.01));
+    expect(bottom.bottom <= 788, isTrue);
+  });
+
+  test('tiny screen never produces negative offsets', () {
+    final rect = holdPreviewRect(
+        const Offset(10, 10), const Size(100, 100), card);
+    expect(rect.left, greaterThanOrEqualTo(12));
+    expect(rect.top, greaterThanOrEqualTo(12));
+  });
+}

--- a/test/note_service_test.dart
+++ b/test/note_service_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/services/note_service.dart';
+
+const _secureStorageChannel = 'plugins.it_nomads.com/flutter_secure_storage';
+const _pathProviderChannel = 'plugins.flutter.io/path_provider';
+
+Map<String, dynamic> _noteJson(String id, {String? path}) {
+  return {
+    'id': id,
+    'title': 'note $id',
+    'encryptedContentPath': path ?? '/tmp/real/.locker_vault/notes/$id.enc',
+    'iv': '',
+    'keyDerivationSalt': '',
+    'kdfIterations': 100000,
+    'folderId': null,
+    'isPinned': false,
+    'isMarkdown': false,
+    'isEncrypted': false,
+    'encryptionAlgorithm': 'aes256Gcm',
+    'createdAt': '2024-01-01T00:00:00.000',
+    'updatedAt': '2024-01-01T00:00:00.000',
+  };
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Map<String, String> storage;
+  late Directory tmpDir;
+
+  setUp(() async {
+    storage = {};
+    tmpDir = await Directory.systemTemp.createTemp('locker_notes_test');
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel(_secureStorageChannel),
+      (call) async {
+        final args = (call.arguments ?? {}) as Map;
+        final key = args['key'] as String?;
+        switch (call.method) {
+          case 'read':
+            return storage[key];
+          case 'write':
+            storage[key!] = args['value'] as String;
+            return null;
+          case 'delete':
+            storage.remove(key);
+            return null;
+          case 'deleteAll':
+            storage.clear();
+            return null;
+          case 'containsKey':
+            return storage.containsKey(key);
+          case 'readAll':
+            return storage;
+          default:
+            return null;
+        }
+      },
+    );
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel(_pathProviderChannel),
+      (call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return tmpDir.path;
+        }
+        return null;
+      },
+    );
+
+    NoteService.instance.clearCache();
+  });
+
+  test('legacy shared index splits into real and decoy indexes', () async {
+    storage['locker_notes_index'] = jsonEncode([
+      _noteJson('real1'),
+      _noteJson('decoy1',
+          path: '/tmp/x/.locker_decoy/notes/decoy1.enc'),
+    ]);
+
+    final real = await NoteService.instance.loadNotes(isDecoy: false);
+    expect(real.map((n) => n.id), ['real1']);
+
+    NoteService.instance.clearCache();
+    final decoy = await NoteService.instance.loadNotes(isDecoy: true);
+    expect(decoy.map((n) => n.id), ['decoy1']);
+  });
+
+  test('malformed entry is skipped, index not wiped by next save', () async {
+    storage['locker_notes_index'] = jsonEncode([
+      _noteJson('good1'),
+      'garbage-entry',
+    ]);
+
+    final notes = await NoteService.instance.loadNotes(isDecoy: false);
+    expect(notes.map((n) => n.id), ['good1']);
+
+    await NoteService.instance.togglePin(notes.first);
+    NoteService.instance.clearCache();
+
+    final reloaded = await NoteService.instance.loadNotes(isDecoy: false);
+    expect(reloaded.map((n) => n.id), ['good1']);
+    expect(reloaded.first.isPinned, isTrue);
+  });
+
+  test('decoy folders stored separately from real folders', () async {
+    await NoteService.instance.createFolder('real', isDecoy: false);
+    await NoteService.instance.createFolder('decoy', isDecoy: true);
+    NoteService.instance.clearCache();
+
+    final real = await NoteService.instance.loadFolders(isDecoy: false);
+    final decoy = await NoteService.instance.loadFolders(isDecoy: true);
+    expect(real.map((f) => f.name), ['real']);
+    expect(decoy.map((f) => f.name), ['decoy']);
+  });
+}

--- a/test/server_errors_test.dart
+++ b/test/server_errors_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:locker/services/remote/server_errors.dart';
+
+void main() {
+  test('maps raw exceptions to human messages, never leaks them', () {
+    expect(describeServerError(Exception('DioException [connection timeout]')),
+        contains("Couldn't reach the server"));
+    expect(describeServerError(Exception('Connection refused')),
+        contains('refused the connection'));
+    expect(describeServerError(Exception('401 Unauthorized')),
+        contains('username and password'));
+    expect(describeServerError(Exception('CERTIFICATE_VERIFY_FAILED')),
+        contains('certificate'));
+    expect(describeServerError(Exception('Connection closed before status')),
+        contains('dropped'));
+    expect(describeServerError(Exception('SocketException: failed host lookup')),
+        contains('Network error'));
+    expect(
+        describeServerError(const FormatException('Manifest blob too short')),
+        contains("couldn't be read"));
+    expect(describeServerError(StateError('Missing blob for remote entry x')),
+        'Missing blob for remote entry x');
+    expect(describeServerError(Exception('weird unknown failure')),
+        isNot(contains('Exception')));
+  });
+}


### PR DESCRIPTION
# Summary

Adds a floating hold-preview card to the media picker, decoy password and note support with separate indexing/caching, an encryption toggle for note editing, and strips raw exception details from all user-facing errors.

# Changes

## Media Picker Preview

- Add slide preview on long-press with floating preview card (image/video support)
- Add hold preview state tracking to prevent accidental selection during drag
- Refactor media picker to use tile rectangle cache
- Add media preview position tests

## Decoy Support

- Support decoy passwords in password service with separate indexing and improved caching
- Add decoy cache and migration to `NoteService`

## Notes

- Add encryption toggle to note editor
- Update note list screen and note folders screen UI
- Add selection mode toggle to `NoteCard` (`ListTile`-based)
- Add note service test suite (legacy index splitting, malformed entry skipping, decoy folder separation)

## Passwords

- Refactor `PasswordCard` to `ListTile` with selection mode
- Remove tag filtering and simplify password list

## Error Handling

- Remove exception details from user-facing errors across screens (toasts, error states)
- Map disk-full errors to clear messages with generic fallbacks for backup failures
- Use `describeServerError` helper for sync errors
- Add server error mapping tests ensuring no exception detail leakage
- Extract server editor to bottom sheet (`_ServerSheet`)

## UI

- Add authentication loading state with spinner
- Add Open Source Libraries tile to vault settings
- Refactor `GalleryVault` drawer layout, title font, and logo styling
- Standardize unlock screen key unlock calls and autofill hints